### PR TITLE
feat: phase 2, hexagonal site domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build
 
 # Claude Code local state
 .claude/
+.agents/
+skills-lock.json

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -7,5 +7,14 @@
     "MD024": { "siblings_only": true },
   },
   "globs": ["**/*.md"],
-  "ignores": ["node_modules", "coverage", "build", "dist", "out", ".next"],
+  "ignores": [
+    "node_modules",
+    "coverage",
+    "build",
+    "dist",
+    "out",
+    ".next",
+    ".agents",
+    ".claude",
+  ],
 }

--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -4,10 +4,10 @@
 
 | Phase | Description                                     | State              |
 | ----- | ----------------------------------------------- | ------------------ |
-| 1     | Tooling baseline                                | In review (PR #22) |
-| 2     | Hexagonal skeleton inside current Vite app      | Pending            |
+| 1     | Tooling baseline                                | Done (PR #22)      |
+| 2     | Hexagonal skeleton inside current Vite app      | In progress        |
 | 3     | Info panel on Chakra (pre-Next/Panda)           | Pending            |
-| 4     | Migrate to Next.js 15 App Router (still Chakra) | Pending            |
+| 4     | Migrate to Next.js 16 App Router (still Chakra) | Pending            |
 | 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Pending            |
 | 6     | Layout & content polish                         | Pending            |
 | 7     | Docs & memory files                             | Pending            |
@@ -24,7 +24,7 @@ Goal of this change: bring the site to a modern, maintainable baseline
 without changing what makes it valuable (the geographic data, the
 Netlify deploy, the OpenLayers map). Specifically:
 
-- Move from Vite SPA to **Next.js 15 (App Router)** with static export so
+- Move from Vite SPA to **Next.js 16 (App Router)** with static export so
   it keeps deploying to Netlify with the same build artifact shape.
 - Replace **Chakra UI 2** (Emotion runtime CSS-in-JS) with **PandaCSS**
   (build-time atomic CSS) + **Ark UI** (headless primitives) + **Park UI**
@@ -57,7 +57,7 @@ be merged incrementally without leaving the tree broken.
 
 | Concern               | Choice                                                                                                                       | Why                                                                                                                                                                                                                                         |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Framework             | Next.js 15, App Router, `output: 'export'`                                                                                   | Keeps the Netlify static deploy model; gives App Router conventions, server components for build-time data, and a clean Vite-replacement story.                                                                                             |
+| Framework             | Next.js 16, App Router, `output: 'export'`                                                                                   | Keeps the Netlify static deploy model; gives App Router conventions, server components for build-time data, and a clean Vite-replacement story.                                                                                             |
 | Styling               | PandaCSS                                                                                                                     | Build-time atomic CSS, zero runtime, type-safe tokens. Same authors as Chakra. Explicitly NOT Tailwind.                                                                                                                                     |
 | Headless primitives   | Ark UI (`@ark-ui/react`)                                                                                                     | Accessible, framework-agnostic primitives (Dialog, Popover, Tooltip). Powers the Drawer used by the info panel.                                                                                                                             |
 | Styled preset         | Park UI                                                                                                                      | Pre-styled component recipes on top of Panda + Ark — gives us Chakra-level ergonomics without Emotion's runtime.                                                                                                                            |
@@ -256,7 +256,7 @@ real diff that has to make sense in the context of this codebase.
 - Verify in browser: click each marker, panel opens with correct
   data, ESC and backdrop close it, mobile layout works.
 
-### Phase 4 — Migrate to Next.js 15 App Router (still Chakra)
+### Phase 4 — Migrate to Next.js 16 App Router (still Chakra)
 
 - `next.config.mjs` with `output: 'export'`, `images.unoptimized: true`.
 - Move `src/App.tsx` content into `app/page.tsx`; create `app/layout.tsx`.

--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -2,15 +2,15 @@
 
 ## Status
 
-| Phase | Description                                     | State              |
-| ----- | ----------------------------------------------- | ------------------ |
-| 1     | Tooling baseline                                | Done (PR #22)      |
-| 2     | Hexagonal skeleton inside current Vite app      | In progress        |
-| 3     | Info panel on Chakra (pre-Next/Panda)           | Pending            |
-| 4     | Migrate to Next.js 16 App Router (still Chakra) | Pending            |
-| 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Pending            |
-| 6     | Layout & content polish                         | Pending            |
-| 7     | Docs & memory files                             | Pending            |
+| Phase | Description                                     | State         |
+| ----- | ----------------------------------------------- | ------------- |
+| 1     | Tooling baseline                                | Done (PR #22) |
+| 2     | Hexagonal skeleton inside current Vite app      | In progress   |
+| 3     | Info panel on Chakra (pre-Next/Panda)           | Pending       |
+| 4     | Migrate to Next.js 16 App Router (still Chakra) | Pending       |
+| 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Pending       |
+| 6     | Layout & content polish                         | Pending       |
+| 7     | Docs & memory files                             | Pending       |
 
 ## Context
 

--- a/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
@@ -20,12 +20,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+const okResponse = (): Response => new Response(geojsonText, { status: 200 });
+
+const stubFetchOk = (): ReturnType<typeof vi.fn> => {
+  const mock = vi.fn().mockResolvedValue(okResponse());
+  vi.stubGlobal('fetch', mock);
+  return mock;
+};
+
 describe('GeoJsonSiteRepository.list()', () => {
   it('parses every feature in the real dataset', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(geojsonText, { status: 200 }))
-    );
+    stubFetchOk();
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
     const sites = await repo.list();
 
@@ -43,24 +48,16 @@ describe('GeoJsonSiteRepository.list()', () => {
   });
 
   it('caches the result so repeated list() calls do not refetch', async () => {
-    const fetchMock = vi.fn(
-      async () => new Response(geojsonText, { status: 200 })
-    );
-    vi.stubGlobal('fetch', fetchMock);
-
+    const fetchMock = stubFetchOk();
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
     await repo.list();
     await repo.list();
     await repo.list();
-
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('findById returns the site when present and null otherwise', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(geojsonText, { status: 200 }))
-    );
+    stubFetchOk();
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
     const all = await repo.list();
     const first = all[0];
@@ -76,7 +73,7 @@ describe('GeoJsonSiteRepository.list()', () => {
   it('throws on non-OK fetch response', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('nope', { status: 500 }))
+      vi.fn().mockResolvedValue(new Response('nope', { status: 500 }))
     );
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
     await expect(repo.list()).rejects.toThrow(/500/);
@@ -86,7 +83,7 @@ describe('GeoJsonSiteRepository.list()', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(new Response('boom', { status: 503 }))
-      .mockResolvedValueOnce(new Response(geojsonText, { status: 200 }));
+      .mockResolvedValueOnce(okResponse());
     vi.stubGlobal('fetch', fetchMock);
 
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');

--- a/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
@@ -1,0 +1,125 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { __test, GeoJsonSiteRepository } from '../geojson-site-repository';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+let geojsonText: string;
+
+beforeAll(async () => {
+  geojsonText = await readFile(
+    resolve(here, '../../../../public/data/ndwt.geojson'),
+    'utf-8'
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GeoJsonSiteRepository.list()', () => {
+  it('parses every feature in the real dataset', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(geojsonText, { status: 200 }))
+    );
+    const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
+    const sites = await repo.list();
+
+    expect(sites.length).toBeGreaterThan(100);
+    expect(sites.length).toBeLessThan(300);
+
+    for (const site of sites) {
+      expect(typeof site.id).toBe('string');
+      expect(site.id.length).toBeGreaterThan(0);
+      expect(site.coordinates.longitude).toBeGreaterThan(-180);
+      expect(site.coordinates.longitude).toBeLessThan(180);
+      expect(site.coordinates.latitude).toBeGreaterThan(-90);
+      expect(site.coordinates.latitude).toBeLessThan(90);
+    }
+  });
+
+  it('caches the result so repeated list() calls do not refetch', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(geojsonText, { status: 200 })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
+    await repo.list();
+    await repo.list();
+    await repo.list();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('findById returns the site when present and null otherwise', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(geojsonText, { status: 200 }))
+    );
+    const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
+    const all = await repo.list();
+    const first = all[0];
+    if (!first) throw new Error('expected at least one site');
+
+    const found = await repo.findById(first.id);
+    expect(found?.id).toBe(first.id);
+
+    const missing = await repo.findById('does-not-exist' as typeof first.id);
+    expect(missing).toBeNull();
+  });
+
+  it('throws on non-OK fetch response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 }))
+    );
+    const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
+    await expect(repo.list()).rejects.toThrow(/500/);
+  });
+});
+
+describe('toSite mapper', () => {
+  it('handles missing optional fields without throwing', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {
+        riverName: 'Columbia',
+        riverSegment: 'Lake Umatilla',
+        riverMile: '234',
+        bank: 'OR',
+        'restrooms-src': '0',
+        'boatRamp-src': '1',
+      },
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [-120.37, 45.695] as [number, number],
+      },
+    };
+    const site = __test.toSite(feature, 0);
+    expect(site.coordinates).toEqual({ longitude: -120.37, latitude: 45.695 });
+    expect(site.facilities.has('restrooms')).toBe(false);
+    expect(site.facilities.has('boatRamp')).toBe(true);
+    expect(site.season).toBeUndefined();
+    expect(site.contact).toBeUndefined();
+    expect(site.riverMile).toBe(234);
+  });
+
+  it('falls back to a generated id when web-scraper-order is missing', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [0, 0] as [number, number],
+      },
+    };
+    const site = __test.toSite(feature, 42);
+    expect(site.id).toBe('site-42');
+    expect(site.riverMile).toBe(0);
+  });
+});

--- a/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
@@ -81,6 +81,20 @@ describe('GeoJsonSiteRepository.list()', () => {
     const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
     await expect(repo.list()).rejects.toThrow(/500/);
   });
+
+  it('retries after a failed fetch (does not pin a rejected inflight promise)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('boom', { status: 503 }))
+      .mockResolvedValueOnce(new Response(geojsonText, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const repo = new GeoJsonSiteRepository('/data/ndwt.geojson');
+    await expect(repo.list()).rejects.toThrow(/503/);
+    const sites = await repo.list();
+    expect(sites.length).toBeGreaterThan(100);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('toSite mapper', () => {

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -34,41 +34,41 @@ const readProp = (
   props: RawProps,
   ...keys: readonly string[]
 ): string | undefined => {
-  for (const k of keys) {
-    const v = props[k];
-    if (v !== undefined && v !== '') return v;
+  for (const key of keys) {
+    const value = props[key];
+    if (value !== undefined && value !== '') return value;
   }
   return undefined;
 };
 
 const facilityFlags = (props: RawProps): Partial<Record<Facility, boolean>> => {
   const flags: Partial<Record<Facility, boolean>> = {};
-  for (const f of FACILITIES) {
-    flags[f] = props[`${f}-src`] === '1';
+  for (const facility of FACILITIES) {
+    flags[facility] = props[`${facility}-src`] === '1';
   }
   return flags;
 };
 
 const toSite = (feature: RawFeature, index: number): Site => {
-  const p = feature.properties;
+  const props = feature.properties;
   const [lng, lat] = feature.geometry.coordinates;
-  const idRaw = readProp(p, ...ID_KEY_CANDIDATES) ?? `site-${index}`;
-  const mile = Number(readProp(p, 'riverMile') ?? '');
+  const idRaw = readProp(props, ...ID_KEY_CANDIDATES) ?? `site-${index}`;
+  const mile = Number(readProp(props, 'riverMile') ?? '');
 
   return {
     id: siteId(idRaw),
-    riverSegment: readProp(p, 'riverSegment') ?? '',
-    riverName: readProp(p, 'riverName') ?? '',
+    riverSegment: readProp(props, 'riverSegment') ?? '',
+    riverName: readProp(props, 'riverName') ?? '',
     riverMile: Number.isFinite(mile) ? mile : 0,
-    bank: readProp(p, 'bank') ?? '',
+    bank: readProp(props, 'bank') ?? '',
     coordinates: coordinates(lng, lat),
-    season: readProp(p, 'season'),
-    camping: readProp(p, 'camping'),
-    contact: readProp(p, 'contact'),
-    phone: readProp(p, 'phone'),
-    website: readProp(p, 'website'),
-    facilities: FacilitySet.fromFlags(facilityFlags(p)),
-    sourceUrl: readProp(p, ...SOURCE_URL_KEYS),
+    season: readProp(props, 'season'),
+    camping: readProp(props, 'camping'),
+    contact: readProp(props, 'contact'),
+    phone: readProp(props, 'phone'),
+    website: readProp(props, 'website'),
+    facilities: FacilitySet.fromFlags(facilityFlags(props)),
+    sourceUrl: readProp(props, ...SOURCE_URL_KEYS),
   };
 };
 
@@ -78,35 +78,36 @@ export class GeoJsonSiteRepository implements SiteRepository {
 
   constructor(private readonly url: string) {}
 
-  async list(): Promise<readonly Site[]> {
-    if (this.cache !== null) return this.cache;
+  list(): Promise<readonly Site[]> {
+    if (this.cache !== null) return Promise.resolve(this.cache);
     if (this.inflight !== null) return this.inflight;
 
-    this.inflight = (async () => {
-      try {
-        const res = await fetch(this.url);
-        if (!res.ok) {
-          throw new Error(
-            `Failed to fetch ${this.url}: ${res.status} ${res.statusText}`
-          );
-        }
-        const body = (await res.json()) as RawFeatureCollection;
-        const sites = body.features.map((feature, index) =>
-          toSite(feature, index)
-        );
-        this.cache = sites;
-        return sites;
-      } finally {
-        this.inflight = null;
-      }
-    })();
-
+    this.inflight = this.fetchAndParse();
     return this.inflight;
   }
 
   async findById(id: SiteId): Promise<Site | null> {
     const all = await this.list();
-    return all.find((s) => s.id === id) ?? null;
+    return all.find((site) => site.id === id) ?? null;
+  }
+
+  private async fetchAndParse(): Promise<readonly Site[]> {
+    try {
+      const res = await fetch(this.url);
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch ${this.url}: ${res.status} ${res.statusText}`
+        );
+      }
+      const body = (await res.json()) as RawFeatureCollection;
+      const sites = body.features.map((feature, index) =>
+        toSite(feature, index)
+      );
+      this.cache = sites;
+      return sites;
+    } finally {
+      this.inflight = null;
+    }
   }
 }
 

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -79,10 +79,10 @@ export class GeoJsonSiteRepository implements SiteRepository {
   constructor(private readonly url: string) {}
 
   async list(): Promise<readonly Site[]> {
-    if (this.cache) return this.cache;
-    if (this.inflight) return this.inflight;
+    if (this.cache !== null) return this.cache;
+    if (this.inflight !== null) return this.inflight;
 
-    this.inflight = (async () => {
+    const request = (async () => {
       const res = await fetch(this.url);
       if (!res.ok) {
         throw new Error(
@@ -90,13 +90,19 @@ export class GeoJsonSiteRepository implements SiteRepository {
         );
       }
       const body = (await res.json()) as RawFeatureCollection;
-      const sites = body.features.map(toSite);
+      const sites = body.features.map((feature, index) =>
+        toSite(feature, index)
+      );
       this.cache = sites;
-      this.inflight = null;
       return sites;
     })();
 
-    return this.inflight;
+    this.inflight = request;
+    request.finally(() => {
+      if (this.inflight === request) this.inflight = null;
+    });
+
+    return request;
   }
 
   async findById(id: SiteId): Promise<Site | null> {

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -82,27 +82,26 @@ export class GeoJsonSiteRepository implements SiteRepository {
     if (this.cache !== null) return this.cache;
     if (this.inflight !== null) return this.inflight;
 
-    const request = (async () => {
-      const res = await fetch(this.url);
-      if (!res.ok) {
-        throw new Error(
-          `Failed to fetch ${this.url}: ${res.status} ${res.statusText}`
+    this.inflight = (async () => {
+      try {
+        const res = await fetch(this.url);
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch ${this.url}: ${res.status} ${res.statusText}`
+          );
+        }
+        const body = (await res.json()) as RawFeatureCollection;
+        const sites = body.features.map((feature, index) =>
+          toSite(feature, index)
         );
+        this.cache = sites;
+        return sites;
+      } finally {
+        this.inflight = null;
       }
-      const body = (await res.json()) as RawFeatureCollection;
-      const sites = body.features.map((feature, index) =>
-        toSite(feature, index)
-      );
-      this.cache = sites;
-      return sites;
     })();
 
-    this.inflight = request;
-    request.finally(() => {
-      if (this.inflight === request) this.inflight = null;
-    });
-
-    return request;
+    return this.inflight;
   }
 
   async findById(id: SiteId): Promise<Site | null> {

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -1,0 +1,108 @@
+import type { SiteRepository } from '../../application/ports/site-repository';
+import {
+  coordinates,
+  FACILITIES,
+  type Facility,
+  FacilitySet,
+  type Site,
+  type SiteId,
+  siteId,
+} from '../../domain';
+
+interface RawProps {
+  readonly [key: string]: string | undefined;
+}
+
+interface RawFeature {
+  readonly type: 'Feature';
+  readonly properties: RawProps;
+  readonly geometry: {
+    readonly type: 'Point';
+    readonly coordinates: readonly [number, number];
+  };
+}
+
+interface RawFeatureCollection {
+  readonly type: 'FeatureCollection';
+  readonly features: readonly RawFeature[];
+}
+
+const ID_KEY_CANDIDATES = ['web-scraper-order', '﻿web-scraper-order'] as const;
+const SOURCE_URL_KEYS = ['web-scraper-start-url'] as const;
+
+const readProp = (
+  props: RawProps,
+  ...keys: readonly string[]
+): string | undefined => {
+  for (const k of keys) {
+    const v = props[k];
+    if (v !== undefined && v !== '') return v;
+  }
+  return undefined;
+};
+
+const facilityFlags = (props: RawProps): Partial<Record<Facility, boolean>> => {
+  const flags: Partial<Record<Facility, boolean>> = {};
+  for (const f of FACILITIES) {
+    flags[f] = props[`${f}-src`] === '1';
+  }
+  return flags;
+};
+
+const toSite = (feature: RawFeature, index: number): Site => {
+  const p = feature.properties;
+  const [lng, lat] = feature.geometry.coordinates;
+  const idRaw = readProp(p, ...ID_KEY_CANDIDATES) ?? `site-${index}`;
+  const mile = Number(readProp(p, 'riverMile') ?? '');
+
+  return {
+    id: siteId(idRaw),
+    riverSegment: readProp(p, 'riverSegment') ?? '',
+    riverName: readProp(p, 'riverName') ?? '',
+    riverMile: Number.isFinite(mile) ? mile : 0,
+    bank: readProp(p, 'bank') ?? '',
+    coordinates: coordinates(lng, lat),
+    season: readProp(p, 'season'),
+    camping: readProp(p, 'camping'),
+    contact: readProp(p, 'contact'),
+    phone: readProp(p, 'phone'),
+    website: readProp(p, 'website'),
+    facilities: FacilitySet.fromFlags(facilityFlags(p)),
+    sourceUrl: readProp(p, ...SOURCE_URL_KEYS),
+  };
+};
+
+export class GeoJsonSiteRepository implements SiteRepository {
+  private cache: readonly Site[] | null = null;
+  private inflight: Promise<readonly Site[]> | null = null;
+
+  constructor(private readonly url: string) {}
+
+  async list(): Promise<readonly Site[]> {
+    if (this.cache) return this.cache;
+    if (this.inflight) return this.inflight;
+
+    this.inflight = (async () => {
+      const res = await fetch(this.url);
+      if (!res.ok) {
+        throw new Error(
+          `Failed to fetch ${this.url}: ${res.status} ${res.statusText}`
+        );
+      }
+      const body = (await res.json()) as RawFeatureCollection;
+      const sites = body.features.map(toSite);
+      this.cache = sites;
+      this.inflight = null;
+      return sites;
+    })();
+
+    return this.inflight;
+  }
+
+  async findById(id: SiteId): Promise<Site | null> {
+    const all = await this.list();
+    return all.find((s) => s.id === id) ?? null;
+  }
+}
+
+export const __test = { toSite };

--- a/src/application/ports/site-repository.ts
+++ b/src/application/ports/site-repository.ts
@@ -1,0 +1,6 @@
+import type { Site, SiteId } from '../../domain';
+
+export interface SiteRepository {
+  list(): Promise<readonly Site[]>;
+  findById(id: SiteId): Promise<Site | null>;
+}

--- a/src/application/use-cases/list-sites.ts
+++ b/src/application/use-cases/list-sites.ts
@@ -1,0 +1,9 @@
+import type { Site } from '../../domain';
+import type { SiteRepository } from '../ports/site-repository';
+
+export type ListSites = () => Promise<readonly Site[]>;
+
+export const makeListSites =
+  (repo: SiteRepository): ListSites =>
+  () =>
+    repo.list();

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,5 +1,5 @@
-import { Map, View } from 'ol';
-import { GeoJSON } from 'ol/format';
+import { Feature, Map, View } from 'ol';
+import Point from 'ol/geom/Point';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
 import { fromLonLat } from 'ol/proj';
@@ -7,7 +7,20 @@ import OSM from 'ol/source/OSM';
 import VectorSource from 'ol/source/Vector';
 import { useEffect, useRef } from 'react';
 
+import { listSites } from '../composition-root';
+import type { Site } from '../domain';
+
 import '../style.css';
+
+const siteToFeature = (site: Site): Feature<Point> => {
+  const feature = new Feature({
+    geometry: new Point(
+      fromLonLat([site.coordinates.longitude, site.coordinates.latitude])
+    ),
+  });
+  feature.setId(site.id);
+  return feature;
+};
 
 export default function MapComponent() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -17,26 +30,35 @@ export default function MapComponent() {
     const container = containerRef.current;
     if (!container) return undefined;
 
+    let cancelled = false;
+
     const map = new Map({
       target: container,
-      layers: [
-        new TileLayer({ source: new OSM() }),
-        new VectorLayer({
-          source: new VectorSource({
-            url: 'data/ndwt.geojson',
-            format: new GeoJSON(),
-          }),
-        }),
-      ],
+      layers: [new TileLayer({ source: new OSM() })],
       view: new View({
         center: fromLonLat([-121.5281, 45.7068]),
         zoom: 7,
       }),
     });
-
     mapRef.current = map;
 
+    listSites()
+      .then((sites) => {
+        if (cancelled) return;
+        const features = sites.map(siteToFeature);
+        map.addLayer(
+          new VectorLayer({ source: new VectorSource({ features }) })
+        );
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          // eslint-disable-next-line no-console
+          console.error('Failed to load sites', err);
+        }
+      });
+
     return () => {
+      cancelled = true;
       map.setTarget();
       mapRef.current = null;
     };

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -1,0 +1,11 @@
+import { GeoJsonSiteRepository } from './adapters/outbound/geojson-site-repository';
+import {
+  type ListSites,
+  makeListSites,
+} from './application/use-cases/list-sites';
+
+const SITES_GEOJSON_URL = 'data/ndwt.geojson';
+
+const siteRepository = new GeoJsonSiteRepository(SITES_GEOJSON_URL);
+
+export const listSites: ListSites = makeListSites(siteRepository);

--- a/src/domain/__tests__/facility.test.ts
+++ b/src/domain/__tests__/facility.test.ts
@@ -4,33 +4,33 @@ import { FACILITIES, FacilitySet } from '../facility';
 
 describe('FacilitySet', () => {
   it('empty() has size 0 and reports no facilities', () => {
-    const s = FacilitySet.empty();
-    expect(s.size).toBe(0);
-    for (const f of FACILITIES) {
-      expect(s.has(f)).toBe(false);
+    const set = FacilitySet.empty();
+    expect(set.size).toBe(0);
+    for (const facility of FACILITIES) {
+      expect(set.has(facility)).toBe(false);
     }
   });
 
   it('fromFlags() includes only truthy flags', () => {
-    const s = FacilitySet.fromFlags({
+    const set = FacilitySet.fromFlags({
       restrooms: true,
       boatRamp: true,
       marina: false,
     });
-    expect(s.has('restrooms')).toBe(true);
-    expect(s.has('boatRamp')).toBe(true);
-    expect(s.has('marina')).toBe(false);
-    expect(s.has('adaAccess')).toBe(false);
-    expect(s.size).toBe(2);
+    expect(set.has('restrooms')).toBe(true);
+    expect(set.has('boatRamp')).toBe(true);
+    expect(set.has('marina')).toBe(false);
+    expect(set.has('adaAccess')).toBe(false);
+    expect(set.size).toBe(2);
   });
 
   it('toArray() preserves canonical FACILITIES order', () => {
-    const s = FacilitySet.fromFlags({
+    const set = FacilitySet.fromFlags({
       adaAccess: true,
       restrooms: true,
       marina: true,
     });
-    expect(s.toArray()).toEqual(['restrooms', 'marina', 'adaAccess']);
+    expect(set.toArray()).toEqual(['restrooms', 'marina', 'adaAccess']);
   });
 
   it('fromFlags() with empty input is empty', () => {

--- a/src/domain/__tests__/facility.test.ts
+++ b/src/domain/__tests__/facility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { FACILITIES, FacilitySet } from '../facility';
+
+describe('FacilitySet', () => {
+  it('empty() has size 0 and reports no facilities', () => {
+    const s = FacilitySet.empty();
+    expect(s.size).toBe(0);
+    for (const f of FACILITIES) {
+      expect(s.has(f)).toBe(false);
+    }
+  });
+
+  it('fromFlags() includes only truthy flags', () => {
+    const s = FacilitySet.fromFlags({
+      restrooms: true,
+      boatRamp: true,
+      marina: false,
+    });
+    expect(s.has('restrooms')).toBe(true);
+    expect(s.has('boatRamp')).toBe(true);
+    expect(s.has('marina')).toBe(false);
+    expect(s.has('adaAccess')).toBe(false);
+    expect(s.size).toBe(2);
+  });
+
+  it('toArray() preserves canonical FACILITIES order', () => {
+    const s = FacilitySet.fromFlags({
+      adaAccess: true,
+      restrooms: true,
+      marina: true,
+    });
+    expect(s.toArray()).toEqual(['restrooms', 'marina', 'adaAccess']);
+  });
+
+  it('fromFlags() with empty input is empty', () => {
+    expect(FacilitySet.fromFlags({}).size).toBe(0);
+  });
+});

--- a/src/domain/coordinates.ts
+++ b/src/domain/coordinates.ts
@@ -1,0 +1,12 @@
+export interface Coordinates {
+  readonly longitude: number;
+  readonly latitude: number;
+}
+
+export const coordinates = (
+  longitude: number,
+  latitude: number
+): Coordinates => ({
+  longitude,
+  latitude,
+});

--- a/src/domain/facility.ts
+++ b/src/domain/facility.ts
@@ -1,0 +1,45 @@
+export const FACILITIES = [
+  'restrooms',
+  'potableWater',
+  'marineDumpStation',
+  'dayUseOnly',
+  'picnicShelters',
+  'boatRamp',
+  'handCarried',
+  'marina',
+  'adaAccess',
+] as const;
+
+export type Facility = (typeof FACILITIES)[number];
+
+export class FacilitySet {
+  private readonly set: ReadonlySet<Facility>;
+
+  private constructor(set: ReadonlySet<Facility>) {
+    this.set = set;
+  }
+
+  static empty(): FacilitySet {
+    return new FacilitySet(new Set());
+  }
+
+  static fromFlags(flags: Partial<Record<Facility, boolean>>): FacilitySet {
+    const present = new Set<Facility>();
+    for (const f of FACILITIES) {
+      if (flags[f]) present.add(f);
+    }
+    return new FacilitySet(present);
+  }
+
+  has(f: Facility): boolean {
+    return this.set.has(f);
+  }
+
+  toArray(): readonly Facility[] {
+    return FACILITIES.filter((f) => this.set.has(f));
+  }
+
+  get size(): number {
+    return this.set.size;
+  }
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,6 @@
+export type { Coordinates } from './coordinates';
+export { coordinates } from './coordinates';
+export type { Facility } from './facility';
+export { FACILITIES, FacilitySet } from './facility';
+export type { Site, SiteId } from './site';
+export { siteId } from './site';

--- a/src/domain/site.ts
+++ b/src/domain/site.ts
@@ -1,0 +1,22 @@
+import type { Coordinates } from './coordinates';
+import type { FacilitySet } from './facility';
+
+export type SiteId = string & { readonly __brand: 'SiteId' };
+
+export const siteId = (raw: string): SiteId => raw as SiteId;
+
+export interface Site {
+  readonly id: SiteId;
+  readonly riverSegment: string;
+  readonly riverName: string;
+  readonly riverMile: number;
+  readonly bank: string;
+  readonly coordinates: Coordinates;
+  readonly season?: string;
+  readonly camping?: string;
+  readonly contact?: string;
+  readonly phone?: string;
+  readonly website?: string;
+  readonly facilities: FacilitySet;
+  readonly sourceUrl?: string;
+}


### PR DESCRIPTION
## Summary

Phase 2 of [the modernization plan](docs/plans/modernization.md):
introduce a hexagonal (ports & adapters) architecture for site data
without changing what the user sees.

- **`src/domain/`** — pure types: `Site`, `SiteId` (branded), `Coordinates`, `Facility` enum + `FacilitySet`. No framework deps.
- **`src/application/`** — `SiteRepository` port + `makeListSites` use-case factory.
- **`src/adapters/outbound/geojson-site-repository.ts`** — implements the port. Fetches `/data/ndwt.geojson` once, caches, de-dupes concurrent calls, tolerates the dirty source data (BOM-prefixed `web-scraper-order` keys, missing optional fields, `\"0\"`/`\"1\"` facility flags as strings).
- **`src/composition-root.ts`** — single repository instance wired to the use-case. UI imports only from here.
- **`src/components/map.tsx`** — refactored to consume `listSites()` and build OL `Feature`s from `Site[]`. Single source of truth; OL no longer fetches the GeoJSON URL itself. Cancellation guard on unmount during inflight load.

Dependency rule: `domain` → nothing. `application` → `domain`. `adapters` → `application` + `domain`. `ui` → `application` + `domain` (via composition root, never directly into adapters).

Also bumped the plan's tech-stack choice from Next.js 15 → 16 per the call we made today, and gitignored two more Claude harness runtime artifacts (`.agents/`, `skills-lock.json`).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run lint:md\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` — 11 passing (3 new test files: \`FacilitySet\`, \`GeoJsonSiteRepository\` against the real GeoJSON, \`toSite\` mapper edge cases)
- [x] \`npm run build\`
- [x] Dev server starts and serves \`/data/ndwt.geojson\`
- [ ] **Browser smoke check (yours):** open \`localhost:5173\`, confirm all ~150 markers render exactly as before — I can't visually verify a rendered map from here, only that the data path types and unit tests pass.

## Bot review triage

After CI is green, sweep the inline comments and either fix, defer
(file follow-up), or dismiss with a one-line reason.

- [ ] Gemini Code Assist
- [ ] GitHub Copilot review
- [ ] DeepSource
- [ ] SonarCloud

## Notes for reviewer

- \`Bank\` and \`River\` value objects are **not** introduced this PR — the source data has irregular bank values like \`\"S- OR\"\` and \`\"South\"\` that don't fit a clean enum. Kept as raw strings on \`Site\`; will normalize in a later phase if the info panel needs it.
- The composition root is intentionally tiny and synchronous. When Phase 4 moves to Next.js, it'll grow a server-side variant (file-system loader for build time) alongside this one.