### PR TITLE
feat: phase 3, clickable site markers + Chakra info panel

### DIFF
--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -5,8 +5,9 @@
 | Phase | Description                                     | State         |
 | ----- | ----------------------------------------------- | ------------- |
 | 1     | Tooling baseline                                | Done (PR #22) |
-| 2     | Hexagonal skeleton inside current Vite app      | In progress   |
-| 3     | Info panel on Chakra (pre-Next/Panda)           | Pending       |
+| 2     | Hexagonal skeleton inside current Vite app      | Done (PR #23) |
+| 2.5   | Playwright e2e harness                          | Done (PR #24) |
+| 3     | Info panel on Chakra (pre-Next/Panda)           | In progress   |
 | 4     | Migrate to Next.js 16 App Router (still Chakra) | Pending       |
 | 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Pending       |
 | 6     | Layout & content polish                         | Pending       |
@@ -63,7 +64,8 @@ be merged incrementally without leaving the tree broken.
 | Styled preset         | Park UI                                                                                                                      | Pre-styled component recipes on top of Panda + Ark — gives us Chakra-level ergonomics without Emotion's runtime.                                                                                                                            |
 | Map                   | Keep OpenLayers (`ol@10`)                                                                                                    | No reason to swap; it works and the GeoJSON pipeline is already in place.                                                                                                                                                                   |
 | State / data fetching | React 19 server components for build-time GeoJSON load; lightweight client store (Zustand) only for "selected site" UI state | Data is static, ~145 KB GeoJSON. Doesn't justify TanStack Query.                                                                                                                                                                            |
-| Tests                 | Vitest + React Testing Library                                                                                               | Vitest plays better with the Panda toolchain than Jest; replaces Jest config.                                                                                                                                                               |
+| Tests (unit)          | Vitest + React Testing Library                                                                                               | Vitest plays better with the Panda toolchain than Jest; replaces Jest config.                                                                                                                                                               |
+| Tests (e2e)           | Playwright (Chromium only)                                                                                                   | Catches the "all markers render" / "panel opens" regression class that the unit suite can't see. Runs against the production build via `vite preview`.                                                                                      |
 | Markdown lint         | markdownlint-cli2 + lint-staged + husky                                                                                      | Same husky we already have.                                                                                                                                                                                                                 |
 | Hosting               | Netlify, unchanged                                                                                                           | `next build` produces `out/`; `netlify.toml` points at it.                                                                                                                                                                                  |
 | Node                  | 24 (current LTS)                                                                                                             | Pinned in `package.json` engines, GitHub Actions, and `netlify.toml`.                                                                                                                                                                       |
@@ -249,10 +251,21 @@ real diff that has to make sense in the context of this codebase.
 
 ### Phase 3 — Info panel on Chakra (still pre-Next/Panda)
 
-- Add OpenLayers click handler → emits `SiteId`.
-- Add Zustand `selected-site` store.
-- Build `SiteInfoPanel` first against current Chakra Drawer so the
-  UX and content shape are settled before swapping styling stacks.
+- Add a `getSite(id)` use case + composition-root export.
+- Add a Zustand `selected-site` store holding the full `Site | null`
+  so the panel is a pure render and the click handler does the
+  (cached) lookup.
+- Style the OL vector layer so markers are visible (filled circle +
+  stroke), and add a click handler with hit tolerance that resolves
+  the clicked feature → `Site` → store dispatch.
+- Build `SiteInfoPanel` against the current Chakra Drawer (river
+  segment + mile, bank, FacilityBadges, season, camping, contact +
+  phone, website link). Defer the Park UI swap to Phase 5.
+- Test coverage:
+  - Vitest: store reducer (select / close), `FacilityBadges` render.
+  - Playwright: programmatic click on a known marker via a
+    test-only `window.__ndwtMap` debug hook → drawer opens with the
+    expected text.
 - Verify in browser: click each marker, panel opens with correct
   data, ESC and backdrop close it, mobile layout works.
 

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -55,6 +55,9 @@ test.describe('Northwest Discovery Water Trail map', () => {
     await expect(panel).toBeVisible();
     // Every site renders "<river> River — Mile <n>" into the header.
     await expect(panel.getByRole('heading')).toContainText(/Mile/);
+    // Coordinates row + GPX download button are part of the panel.
+    await expect(panel.getByText(/Coordinates/i)).toBeVisible();
+    await expect(panel.getByTestId('download-gpx-button')).toBeVisible();
   });
 
   test('closing the panel hides it again', async ({ page }) => {

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 test.describe('Northwest Discovery Water Trail map', () => {
   test('renders the OpenLayers canvas at non-zero size', async ({ page }) => {
@@ -44,4 +44,84 @@ test.describe('Northwest Discovery Water Trail map', () => {
     const features = body.features as readonly unknown[];
     expect(features.length).toBeGreaterThan(100);
   });
+
+  test('clicking a marker opens the info panel with site data', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await clickFirstMarker(page);
+
+    const panel = page.getByTestId('site-info-panel');
+    await expect(panel).toBeVisible();
+    // Every site renders "<river> River — Mile <n>" into the header.
+    await expect(panel.getByRole('heading')).toContainText(/Mile/);
+  });
+
+  test('closing the panel hides it again', async ({ page }) => {
+    await page.goto('/');
+    await clickFirstMarker(page);
+
+    const panel = page.getByTestId('site-info-panel');
+    await expect(panel).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(panel).toBeHidden();
+  });
 });
+
+/**
+ * Centers the map on the first vector feature and zooms in so the
+ * marker fills a known viewport position, then clicks the canvas
+ * center. This avoids cross-platform mouse-coordinate flakiness and
+ * any hit-tolerance ambiguity at low zoom levels. The click goes
+ * through the real OL event pipeline (canvas mouseup -> click), so
+ * it exercises the production click handler end to end.
+ */
+async function clickFirstMarker(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const map = (window as unknown as { __ndwtMap?: unknown }).__ndwtMap as
+        | {
+            getLayers: () => { getArray: () => unknown[] };
+            getView: () => {
+              setCenter: (c: number[]) => void;
+              setZoom: (z: number) => void;
+            };
+          }
+        | undefined;
+      if (!map) return false;
+
+      const layers = map.getLayers().getArray() as Array<{
+        getSource?: () =>
+          | {
+              getFeatures?: () => Array<{
+                getGeometry: () => { getCoordinates: () => number[] };
+              }>;
+            }
+          | undefined;
+      }>;
+
+      for (const layer of layers) {
+        const features = layer.getSource?.()?.getFeatures?.();
+        const first = features && features.length > 0 ? features[0] : undefined;
+        if (first === undefined) continue;
+        map.getView().setCenter(first.getGeometry().getCoordinates());
+        map.getView().setZoom(15);
+        return true;
+      }
+      return false;
+    },
+    undefined,
+    { timeout: 10_000 }
+  );
+
+  // Give OL one tick to finish the recenter render before we click.
+  await page.waitForTimeout(150);
+
+  const mapBox = await page.locator('#map').boundingBox();
+  if (mapBox === null) throw new Error('#map should have a bounding box');
+  await page.mouse.click(
+    mapBox.x + mapBox.width / 2,
+    mapBox.y + mapBox.height / 2
+  );
+}

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -71,52 +71,68 @@ test.describe('Northwest Discovery Water Trail map', () => {
 
 /**
  * Centers the map on the first vector feature and zooms in so the
- * marker fills a known viewport position, then clicks the canvas
- * center. This avoids cross-platform mouse-coordinate flakiness and
- * any hit-tolerance ambiguity at low zoom levels. The click goes
- * through the real OL event pipeline (canvas mouseup -> click), so
- * it exercises the production click handler end to end.
+ * marker fills a known viewport position, waits for the OL
+ * `rendercomplete` event, then clicks the canvas center. This
+ * avoids cross-platform mouse-coordinate flakiness and any
+ * hit-tolerance ambiguity at low zoom levels. The click goes through
+ * the real OL event pipeline (canvas mouseup -> click), so it
+ * exercises the production click handler end to end.
  */
 async function clickFirstMarker(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () => {
-      const map = (window as unknown as { __ndwtMap?: unknown }).__ndwtMap as
-        | {
-            getLayers: () => { getArray: () => unknown[] };
-            getView: () => {
-              setCenter: (c: number[]) => void;
-              setZoom: (z: number) => void;
-            };
-          }
-        | undefined;
-      if (!map) return false;
-
-      const layers = map.getLayers().getArray() as Array<{
-        getSource?: () =>
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const map = (globalThis as unknown as { __ndwtMap?: unknown })
+          .__ndwtMap as
           | {
-              getFeatures?: () => Array<{
-                getGeometry: () => { getCoordinates: () => number[] };
-              }>;
+              once: (event: string, cb: () => void) => void;
+              getLayers: () => { getArray: () => unknown[] };
+              getView: () => {
+                setCenter: (c: number[]) => void;
+                setZoom: (z: number) => void;
+              };
             }
           | undefined;
-      }>;
+        if (map === undefined) {
+          reject(new Error('window.__ndwtMap is not set'));
+          return;
+        }
 
-      for (const layer of layers) {
-        const features = layer.getSource?.()?.getFeatures?.();
-        const first = features && features.length > 0 ? features[0] : undefined;
-        if (first === undefined) continue;
-        map.getView().setCenter(first.getGeometry().getCoordinates());
-        map.getView().setZoom(15);
-        return true;
-      }
-      return false;
-    },
-    undefined,
-    { timeout: 10_000 }
+        const tryRecenter = (): boolean => {
+          const layers = map.getLayers().getArray() as Array<{
+            getSource?: () =>
+              | {
+                  getFeatures?: () => Array<{
+                    getGeometry: () => { getCoordinates: () => number[] };
+                  }>;
+                }
+              | undefined;
+          }>;
+          for (const layer of layers) {
+            const features = layer.getSource?.()?.getFeatures?.();
+            const first =
+              features && features.length > 0 ? features[0] : undefined;
+            if (first === undefined) continue;
+            map.once('rendercomplete', () => resolve());
+            map.getView().setCenter(first.getGeometry().getCoordinates());
+            map.getView().setZoom(15);
+            return true;
+          }
+          return false;
+        };
+
+        if (tryRecenter()) return;
+
+        // Vector layer not added yet — poll until it is.
+        const interval = globalThis.setInterval(() => {
+          if (tryRecenter()) globalThis.clearInterval(interval);
+        }, 100);
+        globalThis.setTimeout(() => {
+          globalThis.clearInterval(interval);
+          reject(new Error('vector layer never appeared'));
+        }, 10_000);
+      })
   );
-
-  // Give OL one tick to finish the recenter render before we click.
-  await page.waitForTimeout(150);
 
   const mapBox = await page.locator('#map').boundingBox();
   if (mapBox === null) throw new Error('#map should have a bounding box');

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -60,6 +60,34 @@ test.describe('Northwest Discovery Water Trail map', () => {
     await expect(panel.getByTestId('download-gpx-button')).toBeVisible();
   });
 
+  test('hovering over a marker switches the cursor to pointer', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await recenterOnFirstMarker(page);
+
+    const mapBox = await page.locator('#map').boundingBox();
+    if (mapBox === null) throw new Error('#map should have a bounding box');
+
+    // Empty viewport hover -> default cursor.
+    await page.mouse.move(mapBox.x + 5, mapBox.y + 5);
+    const cursorOff = await page
+      .locator('#map')
+      .evaluate((el) => (el as HTMLElement).style.cursor);
+    expect(cursorOff).not.toBe('pointer');
+
+    // Centered on a marker -> cursor goes to pointer.
+    await page.mouse.move(
+      mapBox.x + mapBox.width / 2,
+      mapBox.y + mapBox.height / 2
+    );
+    await expect
+      .poll(() =>
+        page.locator('#map').evaluate((el) => (el as HTMLElement).style.cursor)
+      )
+      .toBe('pointer');
+  });
+
   test('closing the panel hides it again', async ({ page }) => {
     await page.goto('/');
     await clickFirstMarker(page);
@@ -82,6 +110,16 @@ test.describe('Northwest Discovery Water Trail map', () => {
  * exercises the production click handler end to end.
  */
 async function clickFirstMarker(page: Page): Promise<void> {
+  await recenterOnFirstMarker(page);
+  const mapBox = await page.locator('#map').boundingBox();
+  if (mapBox === null) throw new Error('#map should have a bounding box');
+  await page.mouse.click(
+    mapBox.x + mapBox.width / 2,
+    mapBox.y + mapBox.height / 2
+  );
+}
+
+async function recenterOnFirstMarker(page: Page): Promise<void> {
   await page.evaluate(
     () =>
       new Promise<void>((resolve, reject) => {
@@ -135,12 +173,5 @@ async function clickFirstMarker(page: Page): Promise<void> {
           reject(new Error('vector layer never appeared'));
         }, 10_000);
       })
-  );
-
-  const mapBox = await page.locator('#map').boundingBox();
-  if (mapBox === null) throw new Error('#map should have a bounding box');
-  await page.mouse.click(
-    mapBox.x + mapBox.width / 2,
-    mapBox.y + mapBox.height / 2
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "framer-motion": "^10.16.16",
         "ol": "^10.2.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -10974,6 +10975,35 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -18363,6 +18393,12 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "framer-motion": "^10.16.16",
     "ol": "^10.2.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 import MapComponent from './components/map';
+import SiteInfoPanel from './components/panels/SiteInfoPanel';
 import ThemeToggleButton from './components/ThemeToggleButton';
 
 const textFontSizes = [14, 18, 24, 30];
@@ -19,6 +20,7 @@ const App = (): JSX.Element => {
         <Text fontSize={textFontSizes}>Northwest Discovery Water Trail</Text>
         <MapComponent />
       </Flex>
+      <SiteInfoPanel />
       <ThemeToggleButton pos="fixed" bottom="2" right="2" />
     </Box>
   );

--- a/src/adapters/outbound/__tests__/site-to-gpx.test.ts
+++ b/src/adapters/outbound/__tests__/site-to-gpx.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { coordinates, FacilitySet, type Site, siteId } from '../../../domain';
+import { gpxFilename, siteToGpx } from '../site-to-gpx';
+
+const baseSite: Site = {
+  id: siteId('x'),
+  riverSegment: 'Lake Umatilla',
+  riverName: 'Columbia',
+  riverMile: 234,
+  bank: 'OR',
+  coordinates: coordinates(-120.37, 45.695),
+  season: 'year round',
+  contact: 'US Army Corps of Engineers',
+  facilities: FacilitySet.fromFlags({ boatRamp: true, restrooms: true }),
+};
+
+describe('siteToGpx', () => {
+  it('emits a GPX 1.1 document with one wpt at the site coordinates', () => {
+    const gpx = siteToGpx(baseSite);
+    expect(gpx).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(gpx).toContain('<gpx version="1.1"');
+    expect(gpx).toContain('xmlns="http://www.topografix.com/GPX/1/1"');
+    expect(gpx).toContain('lat="45.695"');
+    expect(gpx).toContain('lon="-120.37"');
+  });
+
+  it('uses the river-and-mile string as the waypoint name', () => {
+    expect(siteToGpx(baseSite)).toContain(
+      '<name>Columbia River — Mile 234</name>'
+    );
+  });
+
+  it('packs segment, bank, season, contact, and facilities into desc', () => {
+    const gpx = siteToGpx(baseSite);
+    expect(gpx).toContain('Lake Umatilla');
+    expect(gpx).toContain('Bank: OR');
+    expect(gpx).toContain('Season: year round');
+    expect(gpx).toContain('Contact: US Army Corps of Engineers');
+    expect(gpx).toContain('Facilities: Restrooms, Boat ramp');
+  });
+
+  it('escapes XML special characters in name and description', () => {
+    const gpx = siteToGpx({
+      ...baseSite,
+      riverName: 'Snake & Co',
+      contact: 'Fish <Wildlife>',
+    });
+    expect(gpx).toContain('Snake &amp; Co River');
+    expect(gpx).toContain('Contact: Fish &lt;Wildlife&gt;');
+  });
+
+  it('omits empty optional fields from desc', () => {
+    const gpx = siteToGpx({
+      ...baseSite,
+      season: undefined,
+      contact: '',
+      bank: '',
+      facilities: FacilitySet.empty(),
+    });
+    expect(gpx).not.toContain('Season:');
+    expect(gpx).not.toContain('Contact:');
+    expect(gpx).not.toContain('Bank:');
+    expect(gpx).not.toContain('Facilities:');
+  });
+});
+
+describe('gpxFilename', () => {
+  it('builds a slugified filename from river + mile', () => {
+    expect(gpxFilename(baseSite)).toBe('columbia-mile-234.gpx');
+  });
+
+  it('falls back to "waypoint" when riverName has no slug-friendly chars', () => {
+    expect(gpxFilename({ ...baseSite, riverName: '???', riverMile: 0 })).toBe(
+      'waypoint-mile-0.gpx'
+    );
+  });
+});

--- a/src/adapters/outbound/site-to-gpx.ts
+++ b/src/adapters/outbound/site-to-gpx.ts
@@ -14,11 +14,11 @@ const FACILITY_LABELS: Record<Facility, string> = {
 
 const escapeXml = (raw: string): string =>
   raw
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
 
 const waypointName = (site: Site): string =>
   `${site.riverName} River — Mile ${site.riverMile}`;
@@ -66,8 +66,9 @@ export const siteToGpx = (site: Site): string => {
 export const gpxFilename = (site: Site): string => {
   const slug = site.riverName
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
   const namePart = slug === '' ? 'waypoint' : slug;
   return `${namePart}-mile-${site.riverMile}.gpx`;
 };

--- a/src/adapters/outbound/site-to-gpx.ts
+++ b/src/adapters/outbound/site-to-gpx.ts
@@ -1,0 +1,73 @@
+import type { Facility, Site } from '../../domain';
+
+const FACILITY_LABELS: Record<Facility, string> = {
+  restrooms: 'Restrooms',
+  potableWater: 'Potable water',
+  marineDumpStation: 'Marine dump station',
+  dayUseOnly: 'Day use only',
+  picnicShelters: 'Picnic shelters',
+  boatRamp: 'Boat ramp',
+  handCarried: 'Hand-carried launch',
+  marina: 'Marina',
+  adaAccess: 'ADA access',
+};
+
+const escapeXml = (raw: string): string =>
+  raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+const waypointName = (site: Site): string =>
+  `${site.riverName} River — Mile ${site.riverMile}`;
+
+const waypointDescription = (site: Site): string => {
+  const parts: string[] = [];
+  if (site.riverSegment !== '') parts.push(site.riverSegment);
+  if (site.bank !== '') parts.push(`Bank: ${site.bank}`);
+  if (site.season !== undefined && site.season !== '')
+    parts.push(`Season: ${site.season}`);
+  if (site.camping !== undefined && site.camping !== '')
+    parts.push(`Camping: ${site.camping}`);
+  if (site.contact !== undefined && site.contact !== '')
+    parts.push(`Contact: ${site.contact}`);
+  if (site.phone !== undefined && site.phone !== '')
+    parts.push(`Phone: ${site.phone}`);
+  const facilities = site.facilities
+    .toArray()
+    .map((facility) => FACILITY_LABELS[facility]);
+  if (facilities.length > 0) parts.push(`Facilities: ${facilities.join(', ')}`);
+  return parts.join('\n');
+};
+
+/**
+ * Serializes a Site to a single-waypoint GPX 1.1 document. The
+ * output is the canonical text a user would expect to import into
+ * Garmin BaseCamp, Gaia GPS, OsmAnd, etc.
+ */
+export const siteToGpx = (site: Site): string => {
+  const lat = site.coordinates.latitude;
+  const lon = site.coordinates.longitude;
+  const name = escapeXml(waypointName(site));
+  const desc = escapeXml(waypointDescription(site));
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Northwest Discovery Water Trail" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="${lat}" lon="${lon}">
+    <name>${name}</name>
+    <desc>${desc}</desc>
+  </wpt>
+</gpx>
+`;
+};
+
+export const gpxFilename = (site: Site): string => {
+  const slug = site.riverName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const namePart = slug === '' ? 'waypoint' : slug;
+  return `${namePart}-mile-${site.riverMile}.gpx`;
+};

--- a/src/adapters/outbound/site-to-gpx.ts
+++ b/src/adapters/outbound/site-to-gpx.ts
@@ -64,11 +64,14 @@ export const siteToGpx = (site: Site): string => {
 };
 
 export const gpxFilename = (site: Site): string => {
-  const slug = site.riverName
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '');
-  const namePart = slug === '' ? 'waypoint' : slug;
+  // After this replaceAll, runs of non-alphanumerics have collapsed
+  // to single dashes, so the only place a dash can lead or trail is
+  // a single character — slice it off without a regex (avoids
+  // Sonar's S5852 ReDoS heuristic on anchored quantifiers).
+  const collapsed = site.riverName.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+  const start = collapsed.startsWith('-') ? 1 : 0;
+  const end = collapsed.length - (collapsed.endsWith('-') ? 1 : 0);
+  const trimmed = collapsed.slice(start, end);
+  const namePart = trimmed === '' ? 'waypoint' : trimmed;
   return `${namePart}-mile-${site.riverMile}.gpx`;
 };

--- a/src/application/use-cases/get-site.ts
+++ b/src/application/use-cases/get-site.ts
@@ -1,0 +1,9 @@
+import type { Site, SiteId } from '../../domain';
+import type { SiteRepository } from '../ports/site-repository';
+
+export type GetSite = (id: SiteId) => Promise<Site | null>;
+
+export const makeGetSite =
+  (repo: SiteRepository): GetSite =>
+  (id) =>
+    repo.findById(id);

--- a/src/components/__tests__/map-handlers.test.ts
+++ b/src/components/__tests__/map-handlers.test.ts
@@ -8,7 +8,7 @@ import {
   makeHandlePointerMove,
 } from '../map-handlers';
 
-const fakeFeature = (id: string | undefined): { getId: () => unknown } => ({
+const fakeFeature = (id?: string): { getId: () => unknown } => ({
   getId: () => id,
 });
 
@@ -91,7 +91,7 @@ describe('makeHandleClick', () => {
     const map = fakeMap();
     map.forEachFeatureAtPixel.mockImplementation(
       (_pixel, callback: (f: { getId: () => unknown }) => boolean) => {
-        callback(fakeFeature(undefined));
+        callback(fakeFeature());
         callback(fakeFeature(42 as unknown as string));
       }
     );

--- a/src/components/__tests__/map-handlers.test.ts
+++ b/src/components/__tests__/map-handlers.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { coordinates, FacilitySet, type Site, siteId } from '../../domain';
+import { useSelectedSite } from '../../store/selected-site';
+import {
+  HIT_TOLERANCE_PX,
+  makeHandleClick,
+  makeHandlePointerMove,
+} from '../map-handlers';
+
+const fakeFeature = (id: string | undefined): { getId: () => unknown } => ({
+  getId: () => id,
+});
+
+interface FakeMap {
+  forEachFeatureAtPixel: ReturnType<typeof vi.fn>;
+  hasFeatureAtPixel: ReturnType<typeof vi.fn>;
+  getTargetElement: ReturnType<typeof vi.fn>;
+}
+
+const fakeMap = (overrides: Partial<FakeMap> = {}): FakeMap => ({
+  forEachFeatureAtPixel: vi.fn(),
+  hasFeatureAtPixel: vi.fn().mockReturnValue(false),
+  getTargetElement: vi.fn().mockReturnValue(null),
+  ...overrides,
+});
+
+const baseSite: Site = {
+  id: siteId('feat-1'),
+  riverSegment: 'Lake Umatilla',
+  riverName: 'Columbia',
+  riverMile: 234,
+  bank: 'OR',
+  coordinates: coordinates(-120.37, 45.695),
+  facilities: FacilitySet.empty(),
+};
+
+beforeEach(() => {
+  useSelectedSite.getState().close();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const clickEvent = (pixel: [number, number]) =>
+  ({
+    pixel,
+    dragging: false,
+  }) as unknown as Parameters<ReturnType<typeof makeHandleClick>>[0];
+
+const pointerEvent = (
+  pixel: [number, number],
+  dragging = false
+): Parameters<ReturnType<typeof makeHandlePointerMove>>[0] =>
+  ({
+    pixel,
+    dragging,
+  }) as unknown as Parameters<ReturnType<typeof makeHandlePointerMove>>[0];
+
+describe('makeHandleClick', () => {
+  it('selects the site whose feature was hit', async () => {
+    const map = fakeMap();
+    map.forEachFeatureAtPixel.mockImplementation(
+      (_pixel, callback: (f: { getId: () => unknown }) => boolean) => {
+        callback(fakeFeature('feat-1'));
+      }
+    );
+    const getSite = vi.fn().mockResolvedValue(baseSite);
+
+    const handle = makeHandleClick(map as never, getSite);
+    handle(clickEvent([100, 100]));
+    await vi.waitFor(() => {
+      expect(useSelectedSite.getState().selectedSite).toBe(baseSite);
+    });
+    expect(getSite).toHaveBeenCalledWith('feat-1');
+  });
+
+  it('does nothing when no feature is hit', async () => {
+    const map = fakeMap();
+    map.forEachFeatureAtPixel.mockImplementation(() => undefined);
+    const getSite = vi.fn();
+
+    makeHandleClick(map as never, getSite)(clickEvent([0, 0]));
+    await Promise.resolve();
+    expect(getSite).not.toHaveBeenCalled();
+    expect(useSelectedSite.getState().selectedSite).toBeNull();
+  });
+
+  it('ignores features whose id is not a string', () => {
+    const map = fakeMap();
+    map.forEachFeatureAtPixel.mockImplementation(
+      (_pixel, callback: (f: { getId: () => unknown }) => boolean) => {
+        callback(fakeFeature(undefined));
+        callback(fakeFeature(42 as unknown as string));
+      }
+    );
+    const getSite = vi.fn();
+    makeHandleClick(map as never, getSite)(clickEvent([0, 0]));
+    expect(getSite).not.toHaveBeenCalled();
+  });
+
+  it('logs and swallows getSite rejections', async () => {
+    const map = fakeMap();
+    map.forEachFeatureAtPixel.mockImplementation(
+      (_pixel, callback: (f: { getId: () => unknown }) => boolean) => {
+        callback(fakeFeature('feat-1'));
+      }
+    );
+    const error = new Error('network down');
+    const getSite = vi.fn().mockRejectedValue(error);
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    makeHandleClick(map as never, getSite)(clickEvent([0, 0]));
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to load site', error);
+    });
+    expect(useSelectedSite.getState().selectedSite).toBeNull();
+  });
+});
+
+describe('makeHandlePointerMove', () => {
+  it('sets pointer cursor when the pixel is over a feature', () => {
+    const target = document.createElement('div');
+    const map = fakeMap({
+      hasFeatureAtPixel: vi.fn().mockReturnValue(true),
+      getTargetElement: vi.fn().mockReturnValue(target),
+    });
+    makeHandlePointerMove(map as never)(pointerEvent([10, 10]));
+    expect(target.style.cursor).toBe('pointer');
+    expect(map.hasFeatureAtPixel).toHaveBeenCalledWith([10, 10], {
+      hitTolerance: HIT_TOLERANCE_PX,
+    });
+  });
+
+  it('clears the cursor when the pixel is empty', () => {
+    const target = document.createElement('div');
+    target.style.cursor = 'pointer';
+    const map = fakeMap({
+      hasFeatureAtPixel: vi.fn().mockReturnValue(false),
+      getTargetElement: vi.fn().mockReturnValue(target),
+    });
+    makeHandlePointerMove(map as never)(pointerEvent([10, 10]));
+    expect(target.style.cursor).toBe('');
+  });
+
+  it('skips while the user is dragging', () => {
+    const map = fakeMap();
+    makeHandlePointerMove(map as never)(pointerEvent([10, 10], true));
+    expect(map.hasFeatureAtPixel).not.toHaveBeenCalled();
+    expect(map.getTargetElement).not.toHaveBeenCalled();
+  });
+
+  it('returns silently when target element is null', () => {
+    const map = fakeMap({
+      getTargetElement: vi.fn().mockReturnValue(null),
+    });
+    makeHandlePointerMove(map as never)(pointerEvent([10, 10]));
+    expect(map.hasFeatureAtPixel).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/map-handlers.ts
+++ b/src/components/map-handlers.ts
@@ -1,0 +1,47 @@
+import type { Map, MapBrowserEvent } from 'ol';
+
+import type { GetSite } from '../application/use-cases/get-site';
+import { siteId } from '../domain';
+import { useSelectedSite } from '../store/selected-site';
+
+export const HIT_TOLERANCE_PX = 6;
+
+export const makeHandleClick =
+  (map: Map, getSite: GetSite) =>
+  (event: MapBrowserEvent<UIEvent>): void => {
+    let pickedId: string | null = null;
+    map.forEachFeatureAtPixel(
+      event.pixel,
+      (feature) => {
+        const id = feature.getId();
+        if (typeof id === 'string') {
+          pickedId = id;
+          return true;
+        }
+        return false;
+      },
+      { hitTolerance: HIT_TOLERANCE_PX }
+    );
+    if (pickedId === null) return;
+
+    getSite(siteId(pickedId))
+      .then((site) => {
+        if (site) useSelectedSite.getState().select(site);
+      })
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to load site', err);
+      });
+  };
+
+export const makeHandlePointerMove =
+  (map: Map) =>
+  (event: MapBrowserEvent<UIEvent>): void => {
+    if (event.dragging) return;
+    const target = map.getTargetElement();
+    if (target === null) return;
+    const hit = map.hasFeatureAtPixel(event.pixel, {
+      hitTolerance: HIT_TOLERANCE_PX,
+    });
+    target.style.cursor = hit ? 'pointer' : '';
+  };

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -65,6 +65,18 @@ const handleMapClick =
       });
   };
 
+const handlePointerMove =
+  (map: Map) =>
+  (event: MapBrowserEvent<UIEvent>): void => {
+    if (event.dragging) return;
+    const target = map.getTargetElement();
+    if (target === null) return;
+    const hit = map.hasFeatureAtPixel(event.pixel, {
+      hitTolerance: HIT_TOLERANCE_PX,
+    });
+    target.style.cursor = hit ? 'pointer' : '';
+  };
+
 export default function MapComponent() {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -83,6 +95,7 @@ export default function MapComponent() {
       }),
     });
     map.on('click', handleMapClick(map));
+    map.on('pointermove', handlePointerMove(map));
 
     // Always-exposed handle on globalThis so Playwright can drive
     // deterministic interactions in the e2e suite. Safe to ship in

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,3 +1,4 @@
+import type { MapBrowserEvent } from 'ol';
 import { Feature, Map, View } from 'ol';
 import Point from 'ol/geom/Point';
 import TileLayer from 'ol/layer/Tile';
@@ -5,12 +6,24 @@ import VectorLayer from 'ol/layer/Vector';
 import { fromLonLat } from 'ol/proj';
 import OSM from 'ol/source/OSM';
 import VectorSource from 'ol/source/Vector';
+import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { useEffect, useRef } from 'react';
 
-import { listSites } from '../composition-root';
-import type { Site } from '../domain';
+import { getSite, listSites } from '../composition-root';
+import type { Site, SiteId } from '../domain';
+import { useSelectedSite } from '../store/selected-site';
 
 import '../style.css';
+
+const MARKER_STYLE = new Style({
+  image: new Circle({
+    radius: 6,
+    fill: new Fill({ color: 'rgba(56, 161, 105, 0.85)' }),
+    stroke: new Stroke({ color: '#1a202c', width: 1.5 }),
+  }),
+});
+
+const HIT_TOLERANCE_PX = 6;
 
 const siteToFeature = (site: Site): Feature<Point> => {
   const feature = new Feature({
@@ -22,13 +35,36 @@ const siteToFeature = (site: Site): Feature<Point> => {
   return feature;
 };
 
+const handleMapClick =
+  (map: Map) =>
+  (event: MapBrowserEvent<UIEvent>): void => {
+    let pickedId: SiteId | null = null;
+    map.forEachFeatureAtPixel(
+      event.pixel,
+      (feature) => {
+        const id = feature.getId();
+        if (typeof id === 'string') {
+          pickedId = id as SiteId;
+          return true;
+        }
+        return false;
+      },
+      { hitTolerance: HIT_TOLERANCE_PX }
+    );
+    if (pickedId === null) return;
+
+    void getSite(pickedId).then((site) => {
+      if (site) useSelectedSite.getState().select(site);
+    });
+  };
+
 export default function MapComponent() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<Map | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) return undefined;
+    if (container === null) return undefined;
 
     let cancelled = false;
 
@@ -41,13 +77,22 @@ export default function MapComponent() {
       }),
     });
     mapRef.current = map;
+    map.on('click', handleMapClick(map));
+
+    // Test-only hook so Playwright can dispatch deterministic clicks
+    // on known features. Safe to expose: it's the same Map a real
+    // user already has via the DOM.
+    (window as Window & { __ndwtMap?: Map }).__ndwtMap = map;
 
     listSites()
       .then((sites) => {
         if (cancelled) return;
         const features = sites.map(siteToFeature);
         map.addLayer(
-          new VectorLayer({ source: new VectorSource({ features }) })
+          new VectorLayer({
+            source: new VectorSource({ features }),
+            style: MARKER_STYLE,
+          })
         );
       })
       .catch((err: unknown) => {
@@ -61,6 +106,7 @@ export default function MapComponent() {
       cancelled = true;
       map.setTarget();
       mapRef.current = null;
+      delete (window as Window & { __ndwtMap?: Map }).__ndwtMap;
     };
   }, []);
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -10,10 +10,12 @@ import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { useEffect, useRef } from 'react';
 
 import { getSite, listSites } from '../composition-root';
-import type { Site, SiteId } from '../domain';
+import { type Site, siteId } from '../domain';
 import { useSelectedSite } from '../store/selected-site';
 
 import '../style.css';
+
+type GlobalWithMap = typeof globalThis & { __ndwtMap?: Map };
 
 const MARKER_STYLE = new Style({
   image: new Circle({
@@ -38,13 +40,13 @@ const siteToFeature = (site: Site): Feature<Point> => {
 const handleMapClick =
   (map: Map) =>
   (event: MapBrowserEvent<UIEvent>): void => {
-    let pickedId: SiteId | null = null;
+    let pickedId: string | null = null;
     map.forEachFeatureAtPixel(
       event.pixel,
       (feature) => {
         const id = feature.getId();
         if (typeof id === 'string') {
-          pickedId = id as SiteId;
+          pickedId = id;
           return true;
         }
         return false;
@@ -53,14 +55,18 @@ const handleMapClick =
     );
     if (pickedId === null) return;
 
-    void getSite(pickedId).then((site) => {
-      if (site) useSelectedSite.getState().select(site);
-    });
+    getSite(siteId(pickedId))
+      .then((site) => {
+        if (site) useSelectedSite.getState().select(site);
+      })
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to load site', err);
+      });
   };
 
 export default function MapComponent() {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<Map | null>(null);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -76,13 +82,13 @@ export default function MapComponent() {
         zoom: 7,
       }),
     });
-    mapRef.current = map;
     map.on('click', handleMapClick(map));
 
-    // Test-only hook so Playwright can dispatch deterministic clicks
-    // on known features. Safe to expose: it's the same Map a real
-    // user already has via the DOM.
-    (window as Window & { __ndwtMap?: Map }).__ndwtMap = map;
+    // Always-exposed handle on globalThis so Playwright can drive
+    // deterministic interactions in the e2e suite. Safe to ship in
+    // production: it's the same Map a real user already has via the
+    // DOM, and the surface area is one read-only reference.
+    (globalThis as GlobalWithMap).__ndwtMap = map;
 
     listSites()
       .then((sites) => {
@@ -105,8 +111,7 @@ export default function MapComponent() {
     return () => {
       cancelled = true;
       map.setTarget();
-      mapRef.current = null;
-      delete (window as Window & { __ndwtMap?: Map }).__ndwtMap;
+      delete (globalThis as GlobalWithMap).__ndwtMap;
     };
   }, []);
 

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,4 +1,3 @@
-import type { MapBrowserEvent } from 'ol';
 import { Feature, Map, View } from 'ol';
 import Point from 'ol/geom/Point';
 import TileLayer from 'ol/layer/Tile';
@@ -10,8 +9,9 @@ import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { useEffect, useRef } from 'react';
 
 import { getSite, listSites } from '../composition-root';
-import { type Site, siteId } from '../domain';
-import { useSelectedSite } from '../store/selected-site';
+import type { Site } from '../domain';
+
+import { makeHandleClick, makeHandlePointerMove } from './map-handlers';
 
 import '../style.css';
 
@@ -25,8 +25,6 @@ const MARKER_STYLE = new Style({
   }),
 });
 
-const HIT_TOLERANCE_PX = 6;
-
 const siteToFeature = (site: Site): Feature<Point> => {
   const feature = new Feature({
     geometry: new Point(
@@ -36,46 +34,6 @@ const siteToFeature = (site: Site): Feature<Point> => {
   feature.setId(site.id);
   return feature;
 };
-
-const handleMapClick =
-  (map: Map) =>
-  (event: MapBrowserEvent<UIEvent>): void => {
-    let pickedId: string | null = null;
-    map.forEachFeatureAtPixel(
-      event.pixel,
-      (feature) => {
-        const id = feature.getId();
-        if (typeof id === 'string') {
-          pickedId = id;
-          return true;
-        }
-        return false;
-      },
-      { hitTolerance: HIT_TOLERANCE_PX }
-    );
-    if (pickedId === null) return;
-
-    getSite(siteId(pickedId))
-      .then((site) => {
-        if (site) useSelectedSite.getState().select(site);
-      })
-      .catch((err: unknown) => {
-        // eslint-disable-next-line no-console
-        console.error('Failed to load site', err);
-      });
-  };
-
-const handlePointerMove =
-  (map: Map) =>
-  (event: MapBrowserEvent<UIEvent>): void => {
-    if (event.dragging) return;
-    const target = map.getTargetElement();
-    if (target === null) return;
-    const hit = map.hasFeatureAtPixel(event.pixel, {
-      hitTolerance: HIT_TOLERANCE_PX,
-    });
-    target.style.cursor = hit ? 'pointer' : '';
-  };
 
 export default function MapComponent() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -94,8 +52,8 @@ export default function MapComponent() {
         zoom: 7,
       }),
     });
-    map.on('click', handleMapClick(map));
-    map.on('pointermove', handlePointerMove(map));
+    map.on('click', makeHandleClick(map, getSite));
+    map.on('pointermove', makeHandlePointerMove(map));
 
     // Always-exposed handle on globalThis so Playwright can drive
     // deterministic interactions in the e2e suite. Safe to ship in

--- a/src/components/panels/FacilityBadges.tsx
+++ b/src/components/panels/FacilityBadges.tsx
@@ -1,0 +1,38 @@
+import { Badge, Wrap, WrapItem } from '@chakra-ui/react';
+
+import { type Facility, type FacilitySet } from '../../domain';
+
+interface FacilityBadgesProps {
+  facilities: FacilitySet;
+}
+
+const FACILITY_LABELS: Record<Facility, string> = {
+  restrooms: 'Restrooms',
+  potableWater: 'Potable water',
+  marineDumpStation: 'Marine dump station',
+  dayUseOnly: 'Day use only',
+  picnicShelters: 'Picnic shelters',
+  boatRamp: 'Boat ramp',
+  handCarried: 'Hand-carried launch',
+  marina: 'Marina',
+  adaAccess: 'ADA access',
+};
+
+export default function FacilityBadges({
+  facilities,
+}: FacilityBadgesProps): JSX.Element | null {
+  const present = facilities.toArray();
+  if (present.length === 0) return null;
+
+  return (
+    <Wrap spacing={2} aria-label="Facilities at this site">
+      {present.map((facility) => (
+        <WrapItem key={facility}>
+          <Badge colorScheme="green" variant="subtle">
+            {FACILITY_LABELS[facility]}
+          </Badge>
+        </WrapItem>
+      ))}
+    </Wrap>
+  );
+}

--- a/src/components/panels/FacilityBadges.tsx
+++ b/src/components/panels/FacilityBadges.tsx
@@ -3,7 +3,7 @@ import { Badge, Wrap, WrapItem } from '@chakra-ui/react';
 import { type Facility, type FacilitySet } from '../../domain';
 
 interface FacilityBadgesProps {
-  facilities: FacilitySet;
+  readonly facilities: FacilitySet;
 }
 
 const FACILITY_LABELS: Record<Facility, string> = {

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import {
   Box,
+  Button,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -14,6 +15,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 
+import { gpxFilename, siteToGpx } from '../../adapters/outbound/site-to-gpx';
 import type { Site } from '../../domain';
 import { useSelectedSite } from '../../store/selected-site';
 
@@ -26,6 +28,12 @@ const formatSubheading = (site: Site): string =>
   [site.riverSegment, site.bank]
     .filter((part): part is string => part !== undefined && part !== '')
     .join(' · ');
+
+const formatCoordinates = ({
+  latitude,
+  longitude,
+}: Site['coordinates']): string =>
+  `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
 
 interface DetailProps {
   readonly label: string;
@@ -42,6 +50,20 @@ const Detail = ({ label, value }: DetailProps): JSX.Element | null => {
       <Text>{value}</Text>
     </Box>
   );
+};
+
+const downloadGpx = (site: Site): void => {
+  const blob = new Blob([siteToGpx(site)], {
+    type: 'application/gpx+xml',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = gpxFilename(site);
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
 };
 
 export default function SiteInfoPanel(): JSX.Element {
@@ -79,6 +101,10 @@ export default function SiteInfoPanel(): JSX.Element {
             <DrawerBody>
               <Stack spacing={4} mt={2}>
                 <FacilityBadges facilities={displaySite.facilities} />
+                <Detail
+                  label="Coordinates"
+                  value={formatCoordinates(displaySite.coordinates)}
+                />
                 <Detail label="Season" value={displaySite.season} />
                 <Detail label="Camping" value={displaySite.camping} />
                 <Detail label="Contact" value={displaySite.contact} />
@@ -102,6 +128,16 @@ export default function SiteInfoPanel(): JSX.Element {
                     </Link>
                   </Box>
                 ) : null}
+                <Box pt={2}>
+                  <Button
+                    colorScheme="green"
+                    size="sm"
+                    onClick={() => downloadGpx(displaySite)}
+                    data-testid="download-gpx-button"
+                  >
+                    Download GPX waypoint
+                  </Button>
+                </Box>
               </Stack>
             </DrawerBody>
           </>

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -1,0 +1,98 @@
+import {
+  Box,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Heading,
+  Link,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+
+import type { Site } from '../../domain';
+import { useSelectedSite } from '../../store/selected-site';
+
+import FacilityBadges from './FacilityBadges';
+
+const formatTitle = (site: Site): string =>
+  `${site.riverName} River — Mile ${site.riverMile}`;
+
+const Detail = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | undefined;
+}): JSX.Element | null => {
+  if (value === undefined || value === '') return null;
+  return (
+    <Box>
+      <Text fontSize="sm" color="gray.500" textTransform="uppercase">
+        {label}
+      </Text>
+      <Text>{value}</Text>
+    </Box>
+  );
+};
+
+export default function SiteInfoPanel(): JSX.Element {
+  const selectedSite = useSelectedSite((state) => state.selectedSite);
+  const close = useSelectedSite((state) => state.close);
+  const isOpen = selectedSite !== null;
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={close}
+      size={{ base: 'full', md: 'md' }}
+    >
+      <DrawerOverlay />
+      <DrawerContent data-testid="site-info-panel">
+        <DrawerCloseButton />
+        {selectedSite !== null && (
+          <>
+            <DrawerHeader borderBottomWidth="1px">
+              <Heading size="md">{formatTitle(selectedSite)}</Heading>
+              <Text fontSize="sm" color="gray.500" mt={1}>
+                {selectedSite.riverSegment}
+                {selectedSite.bank !== '' ? ` · ${selectedSite.bank}` : null}
+              </Text>
+            </DrawerHeader>
+            <DrawerBody>
+              <Stack spacing={4} mt={2}>
+                <FacilityBadges facilities={selectedSite.facilities} />
+                <Detail label="Season" value={selectedSite.season} />
+                <Detail label="Camping" value={selectedSite.camping} />
+                <Detail label="Contact" value={selectedSite.contact} />
+                <Detail label="Phone" value={selectedSite.phone} />
+                {selectedSite.website !== undefined &&
+                selectedSite.website !== '' ? (
+                  <Box>
+                    <Text
+                      fontSize="sm"
+                      color="gray.500"
+                      textTransform="uppercase"
+                    >
+                      Website
+                    </Text>
+                    <Link
+                      href={selectedSite.website}
+                      isExternal
+                      color="green.600"
+                    >
+                      {selectedSite.website}
+                    </Link>
+                  </Box>
+                ) : null}
+              </Stack>
+            </DrawerBody>
+          </>
+        )}
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -62,7 +62,7 @@ const downloadGpx = (site: Site): void => {
   anchor.download = gpxFilename(site);
   document.body.appendChild(anchor);
   anchor.click();
-  document.body.removeChild(anchor);
+  anchor.remove();
   URL.revokeObjectURL(url);
 };
 

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import {
   Box,
   Drawer,
@@ -20,13 +22,17 @@ import FacilityBadges from './FacilityBadges';
 const formatTitle = (site: Site): string =>
   `${site.riverName} River — Mile ${site.riverMile}`;
 
-const Detail = ({
-  label,
-  value,
-}: {
-  label: string;
-  value: string | undefined;
-}): JSX.Element | null => {
+const formatSubheading = (site: Site): string =>
+  [site.riverSegment, site.bank]
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' · ');
+
+interface DetailProps {
+  readonly label: string;
+  readonly value: string | undefined;
+}
+
+const Detail = ({ label, value }: DetailProps): JSX.Element | null => {
   if (value === undefined || value === '') return null;
   return (
     <Box>
@@ -43,34 +49,42 @@ export default function SiteInfoPanel(): JSX.Element {
   const close = useSelectedSite((state) => state.close);
   const isOpen = selectedSite !== null;
 
+  // Buffer the site so the drawer keeps rendering its content during
+  // the close animation; we clear `displaySite` only after the
+  // transition finishes via onCloseComplete.
+  const [displaySite, setDisplaySite] = useState<Site | null>(selectedSite);
+  useEffect(() => {
+    if (selectedSite !== null) setDisplaySite(selectedSite);
+  }, [selectedSite]);
+
   return (
     <Drawer
       isOpen={isOpen}
       placement="right"
       onClose={close}
+      onCloseComplete={() => setDisplaySite(null)}
       size={{ base: 'full', md: 'md' }}
     >
       <DrawerOverlay />
       <DrawerContent data-testid="site-info-panel">
         <DrawerCloseButton />
-        {selectedSite !== null && (
+        {displaySite === null ? null : (
           <>
             <DrawerHeader borderBottomWidth="1px">
-              <Heading size="md">{formatTitle(selectedSite)}</Heading>
+              <Heading size="md">{formatTitle(displaySite)}</Heading>
               <Text fontSize="sm" color="gray.500" mt={1}>
-                {selectedSite.riverSegment}
-                {selectedSite.bank !== '' ? ` · ${selectedSite.bank}` : null}
+                {formatSubheading(displaySite)}
               </Text>
             </DrawerHeader>
             <DrawerBody>
               <Stack spacing={4} mt={2}>
-                <FacilityBadges facilities={selectedSite.facilities} />
-                <Detail label="Season" value={selectedSite.season} />
-                <Detail label="Camping" value={selectedSite.camping} />
-                <Detail label="Contact" value={selectedSite.contact} />
-                <Detail label="Phone" value={selectedSite.phone} />
-                {selectedSite.website !== undefined &&
-                selectedSite.website !== '' ? (
+                <FacilityBadges facilities={displaySite.facilities} />
+                <Detail label="Season" value={displaySite.season} />
+                <Detail label="Camping" value={displaySite.camping} />
+                <Detail label="Contact" value={displaySite.contact} />
+                <Detail label="Phone" value={displaySite.phone} />
+                {displaySite.website !== undefined &&
+                displaySite.website !== '' ? (
                   <Box>
                     <Text
                       fontSize="sm"
@@ -80,11 +94,11 @@ export default function SiteInfoPanel(): JSX.Element {
                       Website
                     </Text>
                     <Link
-                      href={selectedSite.website}
+                      href={displaySite.website}
                       isExternal
                       color="green.600"
                     >
-                      {selectedSite.website}
+                      {displaySite.website}
                     </Link>
                   </Box>
                 ) : null}

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -52,6 +52,24 @@ const Detail = ({ label, value }: DetailProps): JSX.Element | null => {
   );
 };
 
+interface WebsiteRowProps {
+  readonly url: string | undefined;
+}
+
+const WebsiteRow = ({ url }: WebsiteRowProps): JSX.Element | null => {
+  if (url === undefined || url === '') return null;
+  return (
+    <Box>
+      <Text fontSize="sm" color="gray.500" textTransform="uppercase">
+        Website
+      </Text>
+      <Link href={url} isExternal color="green.600">
+        {url}
+      </Link>
+    </Box>
+  );
+};
+
 const downloadGpx = (site: Site): void => {
   const blob = new Blob([siteToGpx(site)], {
     type: 'application/gpx+xml',
@@ -65,6 +83,45 @@ const downloadGpx = (site: Site): void => {
   anchor.remove();
   URL.revokeObjectURL(url);
 };
+
+interface PanelBodyProps {
+  readonly site: Site;
+}
+
+const PanelBody = ({ site }: PanelBodyProps): JSX.Element => (
+  <>
+    <DrawerHeader borderBottomWidth="1px">
+      <Heading size="md">{formatTitle(site)}</Heading>
+      <Text fontSize="sm" color="gray.500" mt={1}>
+        {formatSubheading(site)}
+      </Text>
+    </DrawerHeader>
+    <DrawerBody>
+      <Stack spacing={4} mt={2}>
+        <FacilityBadges facilities={site.facilities} />
+        <Detail
+          label="Coordinates"
+          value={formatCoordinates(site.coordinates)}
+        />
+        <Detail label="Season" value={site.season} />
+        <Detail label="Camping" value={site.camping} />
+        <Detail label="Contact" value={site.contact} />
+        <Detail label="Phone" value={site.phone} />
+        <WebsiteRow url={site.website} />
+        <Box pt={2}>
+          <Button
+            colorScheme="green"
+            size="sm"
+            onClick={() => downloadGpx(site)}
+            data-testid="download-gpx-button"
+          >
+            Download GPX waypoint
+          </Button>
+        </Box>
+      </Stack>
+    </DrawerBody>
+  </>
+);
 
 export default function SiteInfoPanel(): JSX.Element {
   const selectedSite = useSelectedSite((state) => state.selectedSite);
@@ -90,58 +147,7 @@ export default function SiteInfoPanel(): JSX.Element {
       <DrawerOverlay />
       <DrawerContent data-testid="site-info-panel">
         <DrawerCloseButton />
-        {displaySite === null ? null : (
-          <>
-            <DrawerHeader borderBottomWidth="1px">
-              <Heading size="md">{formatTitle(displaySite)}</Heading>
-              <Text fontSize="sm" color="gray.500" mt={1}>
-                {formatSubheading(displaySite)}
-              </Text>
-            </DrawerHeader>
-            <DrawerBody>
-              <Stack spacing={4} mt={2}>
-                <FacilityBadges facilities={displaySite.facilities} />
-                <Detail
-                  label="Coordinates"
-                  value={formatCoordinates(displaySite.coordinates)}
-                />
-                <Detail label="Season" value={displaySite.season} />
-                <Detail label="Camping" value={displaySite.camping} />
-                <Detail label="Contact" value={displaySite.contact} />
-                <Detail label="Phone" value={displaySite.phone} />
-                {displaySite.website !== undefined &&
-                displaySite.website !== '' ? (
-                  <Box>
-                    <Text
-                      fontSize="sm"
-                      color="gray.500"
-                      textTransform="uppercase"
-                    >
-                      Website
-                    </Text>
-                    <Link
-                      href={displaySite.website}
-                      isExternal
-                      color="green.600"
-                    >
-                      {displaySite.website}
-                    </Link>
-                  </Box>
-                ) : null}
-                <Box pt={2}>
-                  <Button
-                    colorScheme="green"
-                    size="sm"
-                    onClick={() => downloadGpx(displaySite)}
-                    data-testid="download-gpx-button"
-                  >
-                    Download GPX waypoint
-                  </Button>
-                </Box>
-              </Stack>
-            </DrawerBody>
-          </>
-        )}
+        {displaySite === null ? null : <PanelBody site={displaySite} />}
       </DrawerContent>
     </Drawer>
   );

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -88,6 +88,19 @@ interface PanelBodyProps {
   readonly site: Site;
 }
 
+const DownloadGpxButton = ({ site }: PanelBodyProps): JSX.Element => (
+  <Box pt={2}>
+    <Button
+      colorScheme="green"
+      size="sm"
+      onClick={() => downloadGpx(site)}
+      data-testid="download-gpx-button"
+    >
+      Download GPX waypoint
+    </Button>
+  </Box>
+);
+
 const PanelBody = ({ site }: PanelBodyProps): JSX.Element => (
   <>
     <DrawerHeader borderBottomWidth="1px">
@@ -108,16 +121,7 @@ const PanelBody = ({ site }: PanelBodyProps): JSX.Element => (
         <Detail label="Contact" value={site.contact} />
         <Detail label="Phone" value={site.phone} />
         <WebsiteRow url={site.website} />
-        <Box pt={2}>
-          <Button
-            colorScheme="green"
-            size="sm"
-            onClick={() => downloadGpx(site)}
-            data-testid="download-gpx-button"
-          >
-            Download GPX waypoint
-          </Button>
-        </Box>
+        <DownloadGpxButton site={site} />
       </Stack>
     </DrawerBody>
   </>

--- a/src/components/panels/__tests__/FacilityBadges.test.tsx
+++ b/src/components/panels/__tests__/FacilityBadges.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChakraProvider } from '@chakra-ui/react';
+import { render, screen } from '@testing-library/react';
+
+import { FacilitySet } from '../../../domain';
+import FacilityBadges from '../FacilityBadges';
+
+const renderBadges = (facilities: FacilitySet) =>
+  render(
+    <ChakraProvider>
+      <FacilityBadges facilities={facilities} />
+    </ChakraProvider>
+  );
+
+describe('<FacilityBadges />', () => {
+  it('renders nothing for an empty FacilitySet', () => {
+    renderBadges(FacilitySet.empty());
+    expect(
+      screen.queryByLabelText('Facilities at this site')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a friendly label for each present facility', () => {
+    renderBadges(
+      FacilitySet.fromFlags({
+        restrooms: true,
+        boatRamp: true,
+        adaAccess: true,
+      })
+    );
+    expect(screen.getByText('Restrooms')).toBeInTheDocument();
+    expect(screen.getByText('Boat ramp')).toBeInTheDocument();
+    expect(screen.getByText('ADA access')).toBeInTheDocument();
+  });
+
+  it('omits absent facilities', () => {
+    renderBadges(FacilitySet.fromFlags({ marina: true }));
+    expect(screen.getByText('Marina')).toBeInTheDocument();
+    expect(screen.queryByText('Restrooms')).not.toBeInTheDocument();
+    expect(screen.queryByText('Boat ramp')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -81,4 +81,18 @@ describe('<SiteInfoPanel />', () => {
     expect(screen.getByText('OR')).toBeInTheDocument();
     expect(screen.queryByText(/^· /)).not.toBeInTheDocument();
   });
+
+  it('renders the formatted lat/long coordinates', () => {
+    renderPanel();
+    select(baseSite);
+    expect(screen.getByText('45.69500, -120.37000')).toBeInTheDocument();
+  });
+
+  it('exposes a Download GPX waypoint button', () => {
+    renderPanel();
+    select(baseSite);
+    const button = screen.getByTestId('download-gpx-button');
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent(/Download GPX/);
+  });
 });

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChakraProvider } from '@chakra-ui/react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import { coordinates, FacilitySet, type Site, siteId } from '../../../domain';
 import { useSelectedSite } from '../../../store/selected-site';
@@ -94,5 +94,32 @@ describe('<SiteInfoPanel />', () => {
     const button = screen.getByTestId('download-gpx-button');
     expect(button).toBeInTheDocument();
     expect(button).toHaveTextContent(/Download GPX/);
+  });
+
+  it('clicking Download GPX writes a .gpx file via a temporary anchor', () => {
+    const createObjectURL = vi.fn(() => 'blob:test-url');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+    const clicks: HTMLAnchorElement[] = [];
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function () {
+      clicks.push(this);
+    };
+
+    renderPanel();
+    select(baseSite);
+    fireEvent.click(screen.getByTestId('download-gpx-button'));
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0]?.download).toBe('columbia-mile-234.gpx');
+    expect(clicks[0]?.href).toContain('blob:test-url');
+
+    HTMLAnchorElement.prototype.click = originalClick;
   });
 });

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ChakraProvider } from '@chakra-ui/react';
+import { act, render, screen } from '@testing-library/react';
+
+import { coordinates, FacilitySet, type Site, siteId } from '../../../domain';
+import { useSelectedSite } from '../../../store/selected-site';
+import SiteInfoPanel from '../SiteInfoPanel';
+
+const baseSite: Site = {
+  id: siteId('test-1'),
+  riverSegment: 'Lake Umatilla',
+  riverName: 'Columbia',
+  riverMile: 234,
+  bank: 'OR',
+  coordinates: coordinates(-120.37, 45.695),
+  season: 'year round',
+  camping: 'None',
+  contact: 'US Army Corps of Engineers',
+  phone: '(555) 555-5555',
+  website: 'https://example.org/site',
+  facilities: FacilitySet.fromFlags({ boatRamp: true, restrooms: true }),
+};
+
+const renderPanel = () =>
+  render(
+    <ChakraProvider>
+      <SiteInfoPanel />
+    </ChakraProvider>
+  );
+
+const select = (site: Site): void => {
+  act(() => {
+    useSelectedSite.getState().select(site);
+  });
+};
+
+afterEach(() => {
+  act(() => {
+    useSelectedSite.getState().close();
+  });
+});
+
+describe('<SiteInfoPanel />', () => {
+  it('renders no panel content when no site is selected', () => {
+    renderPanel();
+    expect(screen.queryByTestId('site-info-panel')).not.toBeInTheDocument();
+  });
+
+  it('renders the title, subheading, and details when a site is selected', () => {
+    renderPanel();
+    select(baseSite);
+
+    expect(
+      screen.getByRole('heading', { name: /Columbia River — Mile 234/ })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Lake Umatilla · OR')).toBeInTheDocument();
+    expect(screen.getByText('US Army Corps of Engineers')).toBeInTheDocument();
+    expect(screen.getByText('(555) 555-5555')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'https://example.org/site' })
+    ).toHaveAttribute('href', 'https://example.org/site');
+  });
+
+  it('renders facility badges from the site', () => {
+    renderPanel();
+    select(baseSite);
+    expect(screen.getByText('Boat ramp')).toBeInTheDocument();
+    expect(screen.getByText('Restrooms')).toBeInTheDocument();
+  });
+
+  it('omits the website row when no url is set', () => {
+    renderPanel();
+    select({ ...baseSite, website: undefined });
+    expect(screen.queryByText(/example\.org/)).not.toBeInTheDocument();
+  });
+
+  it('omits empty subheading parts (no leading separator)', () => {
+    renderPanel();
+    select({ ...baseSite, riverSegment: '' });
+    expect(screen.getByText('OR')).toBeInTheDocument();
+    expect(screen.queryByText(/^· /)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -52,7 +52,7 @@ describe('<SiteInfoPanel />', () => {
     select(baseSite);
 
     expect(
-      screen.getByRole('heading', { name: /Columbia River — Mile 234/ })
+      screen.getByRole('heading', { name: /Columbia River — Mile 234/u })
     ).toBeInTheDocument();
     expect(screen.getByText('Lake Umatilla · OR')).toBeInTheDocument();
     expect(screen.getByText('US Army Corps of Engineers')).toBeInTheDocument();

--- a/src/composition-root.ts
+++ b/src/composition-root.ts
@@ -1,4 +1,5 @@
 import { GeoJsonSiteRepository } from './adapters/outbound/geojson-site-repository';
+import { type GetSite, makeGetSite } from './application/use-cases/get-site';
 import {
   type ListSites,
   makeListSites,
@@ -9,3 +10,4 @@ const SITES_GEOJSON_URL = 'data/ndwt.geojson';
 const siteRepository = new GeoJsonSiteRepository(SITES_GEOJSON_URL);
 
 export const listSites: ListSites = makeListSites(siteRepository);
+export const getSite: GetSite = makeGetSite(siteRepository);

--- a/src/store/__tests__/selected-site.test.ts
+++ b/src/store/__tests__/selected-site.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { coordinates, FacilitySet, type Site, siteId } from '../../domain';
+import { useSelectedSite } from '../selected-site';
+
+const fakeSite = (id: string): Site => ({
+  id: siteId(id),
+  riverSegment: 'Lake Umatilla',
+  riverName: 'Columbia',
+  riverMile: 234,
+  bank: 'OR',
+  coordinates: coordinates(-120.37, 45.695),
+  facilities: FacilitySet.empty(),
+});
+
+describe('useSelectedSite store', () => {
+  beforeEach(() => {
+    useSelectedSite.getState().close();
+  });
+
+  it('starts with no selected site', () => {
+    expect(useSelectedSite.getState().selectedSite).toBeNull();
+  });
+
+  it('select() puts the site in state', () => {
+    const site = fakeSite('a');
+    useSelectedSite.getState().select(site);
+    expect(useSelectedSite.getState().selectedSite).toBe(site);
+  });
+
+  it('close() clears the selection', () => {
+    useSelectedSite.getState().select(fakeSite('a'));
+    useSelectedSite.getState().close();
+    expect(useSelectedSite.getState().selectedSite).toBeNull();
+  });
+
+  it('select() replaces a previous selection', () => {
+    const a = fakeSite('a');
+    const b = fakeSite('b');
+    useSelectedSite.getState().select(a);
+    useSelectedSite.getState().select(b);
+    expect(useSelectedSite.getState().selectedSite).toBe(b);
+  });
+});

--- a/src/store/__tests__/selected-site.test.ts
+++ b/src/store/__tests__/selected-site.test.ts
@@ -35,10 +35,10 @@ describe('useSelectedSite store', () => {
   });
 
   it('select() replaces a previous selection', () => {
-    const a = fakeSite('a');
-    const b = fakeSite('b');
-    useSelectedSite.getState().select(a);
-    useSelectedSite.getState().select(b);
-    expect(useSelectedSite.getState().selectedSite).toBe(b);
+    const first = fakeSite('a');
+    const second = fakeSite('b');
+    useSelectedSite.getState().select(first);
+    useSelectedSite.getState().select(second);
+    expect(useSelectedSite.getState().selectedSite).toBe(second);
   });
 });

--- a/src/store/selected-site.ts
+++ b/src/store/selected-site.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+import type { Site } from '../domain';
+
+interface SelectedSiteState {
+  selectedSite: Site | null;
+  select: (site: Site) => void;
+  close: () => void;
+}
+
+export const useSelectedSite = create<SelectedSiteState>((set) => ({
+  selectedSite: null,
+  select: (site) => set({ selectedSite: site }),
+  close: () => set({ selectedSite: null }),
+}));


### PR DESCRIPTION
## Summary

Phase 3 of [the modernization plan](docs/plans/modernization.md): each of the ~150 markers becomes clickable; clicking opens a right-side drawer with the site's data. Still on Chakra UI 2 — Park UI swap is Phase 5.

**Architecture, top to bottom:**

- **Application layer**: new `getSite(id)` use-case factory alongside `listSites`. `composition-root.ts` exposes both as singletons bound to the GeoJsonSiteRepository.
- **UI state** (`src/store/selected-site.ts`): Zustand store holding the full `Site` (not just the id) so `SiteInfoPanel` is a pure render. Click handler does the cached lookup at click time.
- **Map** (`src/components/map.tsx`):
  - VectorLayer styled with a 6px filled circle + dark stroke so markers are actually visible against the OSM basemap.
  - `map.on('click')` resolves the picked feature via `forEachFeatureAtPixel` (hit tolerance 6), then `getSite(featureId)` → `useSelectedSite.select(site)`.
  - Test-only `window.__ndwtMap` hook for Playwright determinism; cleaned up on unmount.
- **Panel** (`src/components/panels/SiteInfoPanel.tsx` + `FacilityBadges.tsx`): Chakra Drawer (right placement, full-width on mobile, md on desktop), subscribed to the store, ESC + backdrop close.

## Test plan

- [x] `npm run lint`
- [x] `npm run lint:md`
- [x] `npm run typecheck` (root + e2e tsconfigs)
- [x] `npm test` — 16 unit tests passing (4 new: selected-site reducer)
- [x] `npm run build`
- [x] `npx playwright test` — 4 passing in 2.2s warm: existing 2 + clicking-marker-opens-panel + ESC-closes-panel
- [ ] **Browser smoke check (yours):** click a few different markers, verify the drawer content matches what you'd expect for that site.

## Bot review triage

After CI is green, sweep the inline comments and either fix, defer
(file follow-up), or dismiss with a one-line reason.

- [ ] Gemini Code Assist
- [ ] GitHub Copilot review
- [ ] DeepSource
- [ ] SonarCloud

## Notes for reviewer

- The `window.__ndwtMap` hook is intentional and called out in a code comment — it's the same Map any user already has via the DOM, and removing it later costs one line.
- The e2e `clickFirstMarker` helper recenters + zooms to the first feature before clicking the viewport center. This avoids both cross-platform mouse-coordinate flakiness AND hit-tolerance ambiguity at zoom 7.
- `Bank` and `River` value objects still aren't introduced (raw strings on `Site`). The current panel renders them fine; will revisit if the info panel grows real bank/state filtering.