### PR TITLE
feat: phase 6, layout polish — header, hero, footer, content pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -61,16 +61,18 @@ export default function AboutPage() {
       <h2 className={subheadingStyle}>About this site</h2>
       <p className={paragraphStyle}>
         This is an open-source rebuild of the original site (originally ASP.NET)
-        using React, OpenLayers, Next.js, and PandaCSS. Source data was scraped
-        from{' '}
+        using React, OpenLayers, Next.js, and PandaCSS. The official site lives
+        at{' '}
         <Link href="http://www.ndwt.org" external>
           ndwt.org
-        </Link>{' '}
-        and is published as static GeoJSON alongside the app at{' '}
+        </Link>
+        ; trail data on this site is published as static GeoJSON at{' '}
         <Link href="/data/ndwt.geojson" external>
           /data/ndwt.geojson
         </Link>{' '}
-        for anyone who wants to build their own map or trip planner.
+        for anyone who wants to build their own map or trip planner. A future
+        phase will integrate directly with WWTA&rsquo;s database and ArcGIS
+        layers.
       </p>
       <p className={paragraphStyle}>
         Code lives at{' '}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -60,11 +60,10 @@ export default function AboutPage() {
 
       <h2 className={subheadingStyle}>About this site</h2>
       <p className={paragraphStyle}>
-        This is an open-source rebuild of the original site (originally ASP.NET)
-        using React, OpenLayers, Next.js, and PandaCSS. The official site lives
-        at{' '}
-        <Link href="http://www.ndwt.org" external>
-          ndwt.org
+        This is an open-source rebuild of the original ASP.NET site using React,
+        OpenLayers, Next.js, and PandaCSS. The trail is managed by the{' '}
+        <Link href="https://www.wwta.org" external>
+          Washington Water Trails Association
         </Link>
         ; trail data on this site is published as static GeoJSON at{' '}
         <Link href="/data/ndwt.geojson" external>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from 'next';
+import { css } from 'styled-system/css';
+
+import { Link } from '@/components/ui/link';
+
+export const metadata: Metadata = {
+  title: 'About — Northwest Discovery Water Trail',
+  description: 'About the Northwest Discovery Water Trail and this map site.',
+};
+
+const pageStyle = css({
+  maxWidth: '3xl',
+  marginX: 'auto',
+  paddingX: { base: '4', md: '6' },
+  paddingY: { base: '6', md: '10' },
+  fontSize: { base: 'md', md: 'lg' },
+  lineHeight: 'relaxed',
+  color: 'fg.default',
+});
+
+const headingStyle = css({
+  fontSize: { base: '2xl', md: '3xl' },
+  fontWeight: 'bold',
+  margin: 0,
+  marginBottom: '4',
+  colorPalette: 'green',
+  color: 'colorPalette.11',
+});
+
+const subheadingStyle = css({
+  fontSize: { base: 'lg', md: 'xl' },
+  fontWeight: 'semibold',
+  marginTop: '8',
+  marginBottom: '3',
+});
+
+const paragraphStyle = css({ marginY: '3' });
+
+export default function AboutPage() {
+  return (
+    <article className={pageStyle}>
+      <h1 className={headingStyle}>About the Water Trail</h1>
+      <p className={paragraphStyle}>
+        The Northwest Discovery Water Trail is a 367-mile recreational boating
+        route on the region&rsquo;s defining waterways. It begins at Canoe Camp
+        on the Clearwater River in Idaho, follows the Snake River down to the
+        Columbia River, and ends at Bonneville Dam in the Columbia River Gorge.
+      </p>
+      <p className={paragraphStyle}>
+        The Water Trail connects you to nearly 150 sites to launch your boat,
+        picnic, or camp along these rivers when you travel by motorboat, canoe,
+        sailboat, or kayak. Whether you take a day trip or an overnight
+        excursion, the trail can link you to small riverside communities,
+        wildlife refuges and parks, riverside trails, museums and visitor
+        centers, and campgrounds. Following the paddle strokes of tribal
+        cultures and explorers like Lewis and Clark, the Water Trail will guide
+        you through a cross-section of the region&rsquo;s natural and cultural
+        wonders.
+      </p>
+
+      <h2 className={subheadingStyle}>About this site</h2>
+      <p className={paragraphStyle}>
+        This is an open-source rebuild of the original site (originally ASP.NET)
+        using React, OpenLayers, Next.js, and PandaCSS. Source data was scraped
+        from{' '}
+        <Link href="http://www.ndwt.org" external>
+          ndwt.org
+        </Link>{' '}
+        and is published as static GeoJSON alongside the app at{' '}
+        <Link href="/data/ndwt.geojson" external>
+          /data/ndwt.geojson
+        </Link>{' '}
+        for anyone who wants to build their own map or trip planner.
+      </p>
+      <p className={paragraphStyle}>
+        Code lives at{' '}
+        <Link href="https://github.com/ivanoats/ndwt-ol-chakra" external>
+          github.com/ivanoats/ndwt-ol-chakra
+        </Link>{' '}
+        under the MIT license. Issues and pull requests welcome.
+      </p>
+    </article>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,9 +9,7 @@ body {
 }
 
 #map {
-  min-width: 600px;
-  min-height: 500px;
-  margin: 50px;
-  height: 500px;
+  flex: 1;
   width: 100%;
+  min-height: 0;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,13 @@ export default function RootLayout({
   readonly children: ReactNode;
 }) {
   return (
+    // suppressHydrationWarning: next-themes injects an inline script
+    // in <head> that sets the theme class on <html> before React
+    // hydrates (kills FOUC). The server renders <html lang="en">; the
+    // post-script HTML is <html lang="en" class="light"|"dark">.
+    // React's hydration check would log a mismatch — the divergence
+    // is intentional and confined to <html>. This opt-out is one
+    // element deep; child elements still get full validation.
     <html lang="en" suppressHydrationWarning>
       <body
         className={css({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+import { css } from 'styled-system/css';
+
+import Footer from '../src/components/layout/Footer';
+import Header from '../src/components/layout/Header';
 
 import { Providers } from './providers';
 
@@ -19,14 +23,30 @@ export default function RootLayout({
   readonly children: ReactNode;
 }) {
   return (
-    // suppressHydrationWarning is the canonical fix for the
-    // next-themes mismatch: the library injects a script that sets
-    // the theme class on <html> before React hydrates (kills FOUC),
-    // so the server-rendered html and the post-script html always
-    // differ. The mismatch is intentional and limited to <html>.
     <html lang="en" suppressHydrationWarning>
-      <body>
-        <Providers>{children}</Providers>
+      <body
+        className={css({
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          color: 'fg.default',
+          backgroundColor: 'bg.default',
+        })}
+      >
+        <Providers>
+          <Header />
+          <main
+            className={css({
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: 0,
+            })}
+          >
+            {children}
+          </main>
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,13 @@
 import { loadSites } from '@/adapters/inbound/next/load-sites';
+import Hero from '@/components/layout/Hero';
 import MapApp from '@/components/MapApp';
 
 export default async function HomePage() {
   const sites = await loadSites();
-  return <MapApp sites={sites} />;
+  return (
+    <>
+      <Hero />
+      <MapApp sites={sites} />
+    </>
+  );
 }

--- a/app/trip-planning/page.tsx
+++ b/app/trip-planning/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from 'next';
+import { css } from 'styled-system/css';
+
+import { Link } from '@/components/ui/link';
+
+export const metadata: Metadata = {
+  title: 'Trip Planning — Northwest Discovery Water Trail',
+  description:
+    'Plan a trip on the Northwest Discovery Water Trail using the ' +
+    'interactive map, site facilities, and downloadable GPX waypoints.',
+};
+
+const pageStyle = css({
+  maxWidth: '3xl',
+  marginX: 'auto',
+  paddingX: { base: '4', md: '6' },
+  paddingY: { base: '6', md: '10' },
+  fontSize: { base: 'md', md: 'lg' },
+  lineHeight: 'relaxed',
+  color: 'fg.default',
+});
+
+const headingStyle = css({
+  fontSize: { base: '2xl', md: '3xl' },
+  fontWeight: 'bold',
+  margin: 0,
+  marginBottom: '4',
+  colorPalette: 'green',
+  color: 'colorPalette.11',
+});
+
+const subheadingStyle = css({
+  fontSize: { base: 'lg', md: 'xl' },
+  fontWeight: 'semibold',
+  marginTop: '8',
+  marginBottom: '3',
+});
+
+const paragraphStyle = css({ marginY: '3' });
+
+const listStyle = css({
+  marginY: '3',
+  paddingLeft: '6',
+  '& li': { marginY: '2' },
+});
+
+export default function TripPlanningPage() {
+  return (
+    <article className={pageStyle}>
+      <h1 className={headingStyle}>Trip Planning</h1>
+      <p className={paragraphStyle}>
+        The interactive <Link href="/">map</Link> is the starting point for
+        planning a trip on the Water Trail. Each green marker is a launch site,
+        campground, or day-use area along the route.
+      </p>
+
+      <h2 className={subheadingStyle}>Using the map</h2>
+      <ul className={listStyle}>
+        <li>
+          Pan and zoom to the section of river you&rsquo;re planning around.
+        </li>
+        <li>
+          Hover a marker — the cursor switches to a pointer when you&rsquo;re
+          over a clickable site.
+        </li>
+        <li>
+          Click a marker to open the site panel with river segment, mile, bank,
+          available facilities, season, contact information, and coordinates.
+        </li>
+        <li>
+          Hit <strong>Download GPX waypoint</strong> to save the site as a GPX
+          file you can import into Garmin BaseCamp, Gaia GPS, OsmAnd, or any
+          other GPS planner.
+        </li>
+        <li>
+          Press <kbd>Esc</kbd> or click the X to dismiss the panel; the map
+          stays interactive while the panel is open, so you can pop between
+          sites quickly.
+        </li>
+      </ul>
+
+      <h2 className={subheadingStyle}>What to bring</h2>
+      <p className={paragraphStyle}>
+        Permits, life jackets, and current river conditions are on you; the
+        Water Trail crosses tribal, state, and federal jurisdictions with their
+        own rules. Always check ahead before launching.
+      </p>
+
+      <p className={paragraphStyle}>
+        More planning tools (multi-day itineraries, downloadable route files,
+        river-mile filtering) are on the roadmap. If you have a feature request,
+        open an issue on{' '}
+        <Link href="https://github.com/ivanoats/ndwt-ol-chakra" external>
+          GitHub
+        </Link>
+        .
+      </p>
+    </article>
+  );
+}

--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -9,8 +9,8 @@
 | 2.5   | Playwright e2e harness                          | Done (PR #24) |
 | 3     | Info panel on Chakra (pre-Next/Panda)           | Done (PR #30) |
 | 4     | Migrate to Next.js 16 App Router (still Chakra) | Done (PR #31) |
-| 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | In progress   |
-| 6     | Layout & content polish                         | Pending       |
+| 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Done (PR #34) |
+| 6     | Layout & content polish                         | In progress   |
 | 7     | Docs & memory files                             | Pending       |
 
 ## Context

--- a/e2e/nav.spec.ts
+++ b/e2e/nav.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Site navigation', () => {
+  test('home page shows the hero, header, and footer', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: /367-mile/ })).toBeVisible();
+    await expect(
+      page.getByRole('navigation', { name: 'Primary' })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('contentinfo').getByText(/data scraped from/i)
+    ).toBeVisible();
+  });
+
+  test('clicking About navigates to /about and renders the page', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'About' }).click();
+    await expect(page).toHaveURL(/\/about\/?$/);
+    await expect(
+      page.getByRole('heading', { name: 'About the Water Trail' })
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'About' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  test('clicking Trip Planning navigates to /trip-planning', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Trip Planning' }).click();
+    await expect(page).toHaveURL(/\/trip-planning\/?$/);
+    await expect(
+      page.getByRole('heading', { name: 'Trip Planning' })
+    ).toBeVisible();
+  });
+
+  test('Map link returns to the home page', async ({ page }) => {
+    await page.goto('/about/');
+    await page.getByRole('link', { name: 'Map' }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole('heading', { name: /367-mile/ })).toBeVisible();
+  });
+});

--- a/e2e/nav.spec.ts
+++ b/e2e/nav.spec.ts
@@ -9,7 +9,7 @@ test.describe('Site navigation', () => {
       page.getByRole('navigation', { name: 'Primary' })
     ).toBeVisible();
     await expect(
-      page.getByRole('contentinfo').getByText(/data scraped from/i)
+      page.getByRole('contentinfo').getByText(/official site at/i)
     ).toBeVisible();
   });
 

--- a/e2e/nav.spec.ts
+++ b/e2e/nav.spec.ts
@@ -9,7 +9,7 @@ test.describe('Site navigation', () => {
       page.getByRole('navigation', { name: 'Primary' })
     ).toBeVisible();
     await expect(
-      page.getByRole('contentinfo').getByText(/official site at/i)
+      page.getByRole('contentinfo').getByText(/managed by/i)
     ).toBeVisible();
   });
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,17 @@
 const nextConfig = {
   allowedDevOrigins: ['192.168.0.115'],
   output: 'export',
-  images: { unoptimized: true },
+  images: {
+    unoptimized: true,
+    remotePatterns: [
+      // Netlify deploy badge in the Footer.
+      {
+        protocol: 'https',
+        hostname: 'api.netlify.com',
+        pathname: '/api/v1/badges/**',
+      },
+    ],
+  },
   reactStrictMode: true,
   trailingSlash: true,
 };

--- a/src/__tests__/MapApp.test.tsx
+++ b/src/__tests__/MapApp.test.tsx
@@ -27,10 +27,14 @@ const fakeSites: readonly Site[] = [
 ];
 
 describe('<MapApp />', () => {
-  it('renders the page title', () => {
+  it('renders the panel mount point and theme toggle without throwing', () => {
     render(<MapApp sites={fakeSites} />);
+    // The site info panel is always mounted (Ark UI semantics) so we
+    // can use it as a smoke marker that the component tree rendered.
+    expect(screen.getByTestId('site-info-panel')).toBeInTheDocument();
+    // Theme toggle button is in the tree too.
     expect(
-      screen.getByText('Northwest Discovery Water Trail')
+      screen.getByRole('button', { name: /Activate (light|dark) mode/ })
     ).toBeInTheDocument();
   });
 });

--- a/src/components/MapApp.tsx
+++ b/src/components/MapApp.tsx
@@ -23,28 +23,15 @@ export default function MapApp({ sites }: MapAppProps) {
   const composition = useMemo(() => createComposition(sites), [sites]);
 
   return (
-    <div>
-      <header
-        className={css({
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100vh',
-          fontSize: '3xl',
-        })}
-      >
-        <p
-          className={css({
-            fontSize: { base: '14px', sm: '18px', md: '24px', lg: '30px' },
-            margin: 0,
-            color: 'fg.default',
-          })}
-        >
-          Northwest Discovery Water Trail
-        </p>
-        <MapComponent sites={sites} getSite={composition.getSite} />
-      </header>
+    <div
+      className={css({
+        flex: 1,
+        position: 'relative',
+        display: 'flex',
+        minHeight: '60vh',
+      })}
+    >
+      <MapComponent sites={sites} getSite={composition.getSite} />
       <SiteInfoPanel />
       <ThemeToggleButton />
     </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { css } from 'styled-system/css';
 
 import { Link } from '../ui/link';
@@ -8,6 +9,7 @@ const NETLIFY_DEPLOYS_URL =
   'https://app.netlify.com/sites/ndwt-ol-chakra/deploys';
 const REPO_URL = 'https://github.com/ivanoats/ndwt-ol-chakra';
 const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
+const NDWT_URL = 'http://www.ndwt.org';
 
 export default function Footer() {
   return (
@@ -28,8 +30,8 @@ export default function Footer() {
       })}
     >
       <p className={css({ margin: 0 })}>
-        Northwest Discovery Water Trail · data scraped from{' '}
-        <Link href="http://www.ndwt.org" external>
+        Northwest Discovery Water Trail · official site at{' '}
+        <Link href={NDWT_URL} external>
           ndwt.org
         </Link>
       </p>
@@ -55,7 +57,7 @@ export default function Footer() {
           aria-label="Netlify deploy status"
           className={css({ display: 'inline-flex' })}
         >
-          <img
+          <Image
             src={NETLIFY_BADGE_SRC}
             alt="Netlify deploy status"
             width={114}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ const NETLIFY_DEPLOYS_URL =
   'https://app.netlify.com/sites/ndwt-ol-chakra/deploys';
 const REPO_URL = 'https://github.com/ivanoats/ndwt-ol-chakra';
 const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
-const NDWT_URL = 'http://www.ndwt.org';
+const WWTA_URL = 'https://www.wwta.org';
 
 export default function Footer() {
   return (
@@ -30,9 +30,9 @@ export default function Footer() {
       })}
     >
       <p className={css({ margin: 0 })}>
-        Northwest Discovery Water Trail · official site at{' '}
-        <Link href={NDWT_URL} external>
-          ndwt.org
+        Northwest Discovery Water Trail · managed by the{' '}
+        <Link href={WWTA_URL} external>
+          Washington Water Trails Association
         </Link>
       </p>
       <div

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,68 @@
+import { css } from 'styled-system/css';
+
+import { Link } from '../ui/link';
+
+const NETLIFY_BADGE_SRC =
+  'https://api.netlify.com/api/v1/badges/d3ab47fd-5352-4d1a-8f93-35687d3ed6e4/deploy-status';
+const NETLIFY_DEPLOYS_URL =
+  'https://app.netlify.com/sites/ndwt-ol-chakra/deploys';
+const REPO_URL = 'https://github.com/ivanoats/ndwt-ol-chakra';
+const LICENSE_URL = `${REPO_URL}/blob/main/LICENSE`;
+
+export default function Footer() {
+  return (
+    <footer
+      className={css({
+        display: 'flex',
+        flexDirection: { base: 'column', md: 'row' },
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '4',
+        paddingX: { base: '4', md: '6' },
+        paddingY: '4',
+        borderTopWidth: '1px',
+        borderColor: 'gray.6',
+        backgroundColor: 'bg.subtle',
+        fontSize: 'sm',
+        color: 'fg.muted',
+      })}
+    >
+      <p className={css({ margin: 0 })}>
+        Northwest Discovery Water Trail · data scraped from{' '}
+        <Link href="http://www.ndwt.org" external>
+          ndwt.org
+        </Link>
+      </p>
+      <div
+        className={css({
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+        })}
+      >
+        <Link href={REPO_URL} external>
+          GitHub
+        </Link>
+        <Link href={LICENSE_URL} external>
+          MIT License
+        </Link>
+        <a
+          href={NETLIFY_DEPLOYS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Netlify deploy status"
+          className={css({ display: 'inline-flex' })}
+        >
+          <img
+            src={NETLIFY_BADGE_SRC}
+            alt="Netlify deploy status"
+            width={114}
+            height={20}
+          />
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { css } from 'styled-system/css';
@@ -40,7 +41,7 @@ export default function Header() {
           _hover: { color: 'colorPalette.11', colorPalette: 'green' },
         })}
       >
-        <img src="/logo.svg" alt="" width={28} height={28} />
+        <Image src="/logo.svg" alt="" width={28} height={28} priority />
         <span
           className={css({
             fontSize: { base: 'md', md: 'lg' },

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { css } from 'styled-system/css';
+
+const NAV_ITEMS = [
+  { href: '/', label: 'Map' },
+  { href: '/about/', label: 'About' },
+  { href: '/trip-planning/', label: 'Trip Planning' },
+] as const;
+
+export default function Header() {
+  const pathname = usePathname();
+  return (
+    <header
+      className={css({
+        position: 'sticky',
+        top: 0,
+        zIndex: 'sticky',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingX: { base: '4', md: '6' },
+        paddingY: '3',
+        backgroundColor: 'bg.default',
+        borderBottomWidth: '1px',
+        borderColor: 'gray.6',
+      })}
+    >
+      <Link
+        href="/"
+        className={css({
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '2',
+          color: 'fg.default',
+          textDecoration: 'none',
+          fontWeight: 'semibold',
+          _hover: { color: 'colorPalette.11', colorPalette: 'green' },
+        })}
+      >
+        <img src="/logo.svg" alt="" width={28} height={28} />
+        <span
+          className={css({
+            fontSize: { base: 'md', md: 'lg' },
+            whiteSpace: 'nowrap',
+          })}
+        >
+          NW Discovery Water Trail
+        </span>
+      </Link>
+      <nav
+        aria-label="Primary"
+        className={css({
+          display: 'flex',
+          alignItems: 'center',
+          gap: { base: '3', md: '5' },
+        })}
+      >
+        {NAV_ITEMS.map((item) => {
+          const isActive =
+            item.href === '/'
+              ? pathname === '/' || pathname === ''
+              : pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={css({
+                fontSize: { base: 'sm', md: 'md' },
+                color: 'fg.default',
+                textDecoration: 'none',
+                paddingY: '1',
+                borderBottomWidth: '2px',
+                borderColor: 'transparent',
+                colorPalette: 'green',
+                _hover: { color: 'colorPalette.11' },
+                '&[aria-current="page"]': {
+                  color: 'colorPalette.11',
+                  borderColor: 'colorPalette.9',
+                },
+              })}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}

--- a/src/components/layout/Hero.tsx
+++ b/src/components/layout/Hero.tsx
@@ -1,0 +1,51 @@
+import { css } from 'styled-system/css';
+
+export default function Hero() {
+  return (
+    <section
+      className={css({
+        paddingX: { base: '4', md: '6' },
+        paddingY: { base: '4', md: '5' },
+        backgroundColor: 'bg.subtle',
+        borderBottomWidth: '1px',
+        borderColor: 'gray.6',
+      })}
+    >
+      <div
+        className={css({
+          maxWidth: '5xl',
+          marginX: 'auto',
+          textAlign: { base: 'center', md: 'left' },
+        })}
+      >
+        <h1
+          className={css({
+            margin: 0,
+            fontSize: { base: 'xl', md: '2xl' },
+            fontWeight: 'bold',
+            color: 'fg.default',
+            colorPalette: 'green',
+            '& strong': { color: 'colorPalette.11' },
+          })}
+        >
+          A <strong>367-mile</strong> recreational boating route from{' '}
+          <strong>Canoe Camp</strong> on the Clearwater River to{' '}
+          <strong>Bonneville Dam</strong> in the Columbia River Gorge.
+        </h1>
+        <p
+          className={css({
+            marginTop: '2',
+            marginBottom: 0,
+            fontSize: { base: 'sm', md: 'md' },
+            color: 'fg.muted',
+            maxWidth: '3xl',
+            marginX: { base: 'auto', md: 0 },
+          })}
+        >
+          Click any marker to see launch sites, facilities, and contact info, or
+          download the waypoint as a GPX file.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -5,9 +5,9 @@ import { render, screen } from '@testing-library/react';
 import Footer from '../Footer';
 
 describe('<Footer />', () => {
-  it('renders the data attribution + GitHub + license links', () => {
+  it('renders the official site attribution + GitHub + license links', () => {
     render(<Footer />);
-    expect(screen.getByText(/data scraped from/i)).toBeInTheDocument();
+    expect(screen.getByText(/official site at/i)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'ndwt.org' })).toHaveAttribute(
       'href',
       'http://www.ndwt.org'

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -5,13 +5,12 @@ import { render, screen } from '@testing-library/react';
 import Footer from '../Footer';
 
 describe('<Footer />', () => {
-  it('renders the official site attribution + GitHub + license links', () => {
+  it('renders the WWTA attribution + GitHub + license links', () => {
     render(<Footer />);
-    expect(screen.getByText(/official site at/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'ndwt.org' })).toHaveAttribute(
-      'href',
-      'http://www.ndwt.org'
-    );
+    expect(screen.getByText(/managed by/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Washington Water Trails Association' })
+    ).toHaveAttribute('href', 'https://www.wwta.org');
     expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
       'href',
       'https://github.com/ivanoats/ndwt-ol-chakra'

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+
+import Footer from '../Footer';
+
+describe('<Footer />', () => {
+  it('renders the data attribution + GitHub + license links', () => {
+    render(<Footer />);
+    expect(screen.getByText(/data scraped from/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'ndwt.org' })).toHaveAttribute(
+      'href',
+      'http://www.ndwt.org'
+    );
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/ivanoats/ndwt-ol-chakra'
+    );
+    expect(screen.getByRole('link', { name: 'MIT License' })).toHaveAttribute(
+      'href',
+      'https://github.com/ivanoats/ndwt-ol-chakra/blob/main/LICENSE'
+    );
+  });
+
+  it('shows the Netlify deploy badge', () => {
+    render(<Footer />);
+    expect(screen.getByAltText('Netlify deploy status')).toBeInTheDocument();
+  });
+
+  it('opens external links in a new tab with safe rel', () => {
+    render(<Footer />);
+    const githubLink = screen.getByRole('link', { name: 'GitHub' });
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    expect(githubLink.getAttribute('rel')).toContain('noopener');
+    expect(githubLink.getAttribute('rel')).toContain('noreferrer');
+  });
+});

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+
+import Header from '../Header';
+
+let pathnameMock = '/';
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameMock,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(() => {
+  pathnameMock = '/';
+});
+
+describe('<Header />', () => {
+  it('renders the site title and the three nav links', () => {
+    render(<Header />);
+    expect(screen.getByText(/NW Discovery Water Trail/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Trip Planning' })
+    ).toBeInTheDocument();
+  });
+
+  it('marks the home link as the current page when on /', () => {
+    pathnameMock = '/';
+    render(<Header />);
+    expect(screen.getByRole('link', { name: 'Map' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.getByRole('link', { name: 'About' })).not.toHaveAttribute(
+      'aria-current'
+    );
+  });
+
+  it('marks About as the current page on /about/', () => {
+    pathnameMock = '/about/';
+    render(<Header />);
+    expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('marks Trip Planning as the current page on /trip-planning/', () => {
+    pathnameMock = '/trip-planning/';
+    render(<Header />);
+    expect(screen.getByRole('link', { name: 'Trip Planning' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+});

--- a/src/components/layout/__tests__/Hero.test.tsx
+++ b/src/components/layout/__tests__/Hero.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+
+import Hero from '../Hero';
+
+describe('<Hero />', () => {
+  it('mentions the 367-mile distance and the Canoe Camp / Bonneville endpoints', () => {
+    render(<Hero />);
+    const heading = screen.getByRole('heading');
+    expect(heading.textContent).toMatch(/367-mile/);
+    expect(heading.textContent).toMatch(/Canoe Camp/);
+    expect(heading.textContent).toMatch(/Bonneville Dam/);
+  });
+
+  it('explains the marker-click + GPX flow', () => {
+    render(<Hero />);
+    expect(screen.getByText(/Click any marker/i)).toBeInTheDocument();
+    expect(screen.getByText(/GPX/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 6 of [the modernization plan](docs/plans/modernization.md). The site now reads like a small content site instead of a single map-page in a flex column.

**Layout shell** (\`app/layout.tsx\`): body is a flex column wrapping \`Header / main / Footer\`. The home page's map gets \`flex: 1\` so it fills whatever's left after the header bar + hero.

**Header** (\`src/components/layout/Header.tsx\`): sticky top, logo + site name on the left, three nav links on the right — Map (\`/\`), About (\`/about/\`), Trip Planning (\`/trip-planning/\`). \`next/link\` for client navigation; \`usePathname()\` drives the \`aria-current=\"page\"\` attribute and the underline on the active link.

**Hero** (\`src/components/layout/Hero.tsx\`): home-only strip with the 367-mile / Canoe Camp → Bonneville Dam tagline pulled from the original README intro. Subtitle nudges users toward the marker-click flow.

**Footer** (\`src/components/layout/Footer.tsx\`): data attribution + ndwt.org link, plus GitHub + MIT License + the live Netlify deploy badge (same badge ID as the original README so it tracks the same site).

**Content pages**:
- \`app/about/page.tsx\` — full README intro (paraphrased + tightened) plus an \"About this site\" section linking to the source and the static GeoJSON.
- \`app/trip-planning/page.tsx\` — how to use the map, marker click → panel, GPX download, ESC to close. Notes what's coming.
- Both set page-specific \`metadata\`.

## Test plan

- [x] \`npm run lint\`, \`npm run lint:md\`
- [x] \`npm run typecheck\`
- [x] \`npm test\` — 61 unit tests passing (10 new: 4 Header, 3 Footer, 2 Hero, 1 updated MapApp)
- [x] \`npm run build\` — Next.js static export to \`./out\`, 3 routes prerendered (\`/\`, \`/about/\`, \`/trip-planning/\`)
- [x] \`npx playwright test --workers=1\` — 9 passing (5 existing map + 4 new nav)
- [ ] **Browser smoke (yours):** \`npm run dev\` → header sticks, hero copy reads cleanly, map fills the rest, About / Trip Planning load on click, panel still opens on marker click.

## Bot review triage

- [ ] Gemini Code Assist
- [ ] GitHub Copilot review
- [ ] DeepSource
- [ ] SonarCloud

## Notes for reviewer

- Trailing slashes match Next 16's \`trailingSlash: true\` setting from Phase 4 — \`/about/\` not \`/about\`. The active-state logic in Header uses \`startsWith\` so deep links would still highlight correctly when we add them.
- Both new content pages are pure server components with no client interactivity beyond the shared client Header. Static export prerenders them at build time.
- The home Hero gets a green underlined accent on \"367-mile\", \"Canoe Camp\", \"Bonneville Dam\" — pulled the styling through the colorPalette virtual token.