### PR TITLE
docs: phase 7 — README, CLAUDE.md, architecture diagrams, ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Hexagonal (ports and adapters):
 
 **Dependency rule** — domain depends on nothing; application on
 domain; adapters on application + domain; UI on application +
-domain *via the composition root*. UI never imports adapters
+domain _via the composition root_. UI never imports adapters
 directly.
 
 ## Hard rules (corrections that have already happened)
@@ -136,7 +136,7 @@ human review:
 4. Tick the "bot triage" checkbox in the PR template before
    requesting human review.
 
-For the full triage drill see the *Per-PR bot review triage*
+For the full triage drill see the _Per-PR bot review triage_
 section in `docs/plans/modernization.md`.
 
 ## Useful gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ directly.
   badge is the only current case).
 - **No `<html>` hydration mismatches**: `app/layout.tsx` keeps
   `suppressHydrationWarning` on `<html>` because next-themes
-  intentionally divergees the class on `<html>` between server and
+  intentionally diverges the class on `<html>` between server and
   client. The opt-out is one element deep; children still get
   full validation.
 - **OL touches `window` at import time** — keep the map

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,180 @@
+# Operating instructions for Claude in this repo
+
+This is the Northwest Discovery Water Trail map: a static export of
+a Next.js 16 + React 19 + OpenLayers + PandaCSS site. The whole
+site is built from a single GeoJSON dataset under `public/data/`
+and deployed to Netlify.
+
+For the full multi-phase rebuild story see
+[`docs/plans/modernization.md`](./docs/plans/modernization.md).
+
+## Stack at a glance
+
+- **Next.js 16** App Router, `output: 'export'` → `./out`
+- **React 19** + **TypeScript strict** (`noUncheckedIndexedAccess`)
+- **PandaCSS** + **`@park-ui/panda-preset`** + **Ark UI**
+- **OpenLayers 10** (`ol`) for the map
+- **Zustand** for one tiny piece of UI state (selected site)
+- **Vitest** unit tests; **Playwright** Chromium-only e2e
+- **Node 24** pinned in `package.json` engines, `netlify.toml`,
+  and the GitHub Actions workflow
+
+## Architecture
+
+Hexagonal (ports and adapters):
+
+- **`src/domain/`** — pure types (Site, Coordinates, Facility,
+  FacilitySet). No framework deps. No classes that need to cross
+  the RSC boundary.
+- **`src/application/`** — `SiteRepository` port + `listSites` /
+  `getSite` use-case factories.
+- **`src/adapters/inbound/next/load-sites.ts`** — server-only,
+  reads `public/data/ndwt.geojson` via `fs/promises` at build
+  time and returns `Site[]`.
+- **`src/adapters/outbound/`** — `GeoJsonSiteRepository`,
+  `InMemorySiteRepository`, `site-to-gpx` serializer.
+- **`src/composition-root.ts`** — `createComposition(sites)`
+  factory; pure, no globals.
+- **`src/components/`** — UI: layout shell, `ui/` primitives,
+  panels, map glue.
+
+**Dependency rule** — domain depends on nothing; application on
+domain; adapters on application + domain; UI on application +
+domain *via the composition root*. UI never imports adapters
+directly.
+
+## Hard rules (corrections that have already happened)
+
+- **Do NOT add Tailwind**, `@emotion/*`, `@chakra-ui/*`, or
+  `framer-motion`. PandaCSS + Park UI preset replaced all of them
+  in Phase 5; no runtime CSS-in-JS in this project.
+- **`FacilitySet` is a `readonly Facility[]`, not a class.** Next
+  cannot serialize class instances across the server→client
+  boundary, so the domain model is plain JSON. Helpers are exposed
+  as a const-as-namespace (`FacilitySet.empty()`,
+  `FacilitySet.fromFlags(...)`).
+- **No `<img>` tags** — use `next/image`. External hosts need a
+  `remotePatterns` entry in `next.config.mjs` (the Netlify deploy
+  badge is the only current case).
+- **No `<html>` hydration mismatches**: `app/layout.tsx` keeps
+  `suppressHydrationWarning` on `<html>` because next-themes
+  intentionally divergees the class on `<html>` between server and
+  client. The opt-out is one element deep; children still get
+  full validation.
+- **OL touches `window` at import time** — keep the map
+  client-only. `MapApp.tsx` dynamic-imports `map.tsx` with
+  `ssr: false`. Don't import `map.tsx` from a server component.
+- **`window.__ndwtMap` is intentional** — exposes the OL Map
+  instance to Playwright for deterministic interactions. Don't
+  remove it.
+- **`min-height: 0` on `<main>` is a footgun** — it lets main
+  shrink below content size and clips long pages. Phase 6's fix
+  was to drop it; don't reintroduce.
+
+## Conventions
+
+- **PandaCSS recipes**: prefer the `css({...})` helper at call
+  site for one-offs. For variants/sizes (Button, IconButton)
+  inline tables of `SystemStyleObject` — see
+  `src/components/ui/button.tsx` for the pattern.
+- **Color tokens**: `colorPalette.11` / `colorPalette.3` etc. with
+  `colorPalette: 'green' | 'sage'` set on the same object. Never
+  hardcode `gray.X` or `green.X` directly when a `colorPalette`
+  branch can carry it.
+- **Polymorphic component refs**: cast to `never` (TS escape
+  hatch), not `any`. See `src/components/ui/text.tsx`.
+- **Hoist consts above their consumers** — DeepSource's `JS-0357`
+  rule fires across this codebase and we treat it seriously.
+- **File names**: kebab-case for module files (`map-handlers.ts`,
+  `site-to-gpx.ts`); PascalCase for React component files where
+  the default export is a component (`Header.tsx`,
+  `SiteInfoPanel.tsx`).
+- **Test files**: colocated under `__tests__/`. Vitest for unit;
+  Playwright `e2e/*.spec.ts` for integration.
+
+## Commands
+
+```sh
+npm run dev               # Next dev (panda codegen first)
+npm run build             # Next static export → ./out
+npm run preview           # Serve ./out at :4173
+npm run lint              # ESLint over src + e2e + app
+npm run lint:md           # markdownlint-cli2
+npm run typecheck         # panda codegen + tsc (root + e2e configs)
+npm run test              # Vitest with v8 coverage
+npm run test:watch        # Vitest watch mode
+npx playwright test --workers=1   # e2e (CI-style serial run)
+```
+
+The pre-commit hook runs lint-staged (eslint + prettier on staged
+TS/TSX, markdownlint on staged MD). Don't skip it with
+`--no-verify` — fix the underlying lint instead.
+
+## CI / bot triage
+
+Every PR runs:
+
+- GitHub Actions: lint, lint:md, typecheck, vitest with coverage,
+  next build, Playwright e2e (Chromium), SonarCloud scan with
+  coverage upload
+- Netlify deploy preview
+- DeepSource JavaScript + Secrets + Code Formatters
+- SonarCloud Quality Gate (Action + automatic analysis)
+- GitGuardian secret scan
+- Inline reviews from Gemini Code Assist and GitHub Copilot
+
+After CI is green, sweep every bot's comments before requesting
+human review:
+
+1. `gh pr view <num> --comments` and
+   `gh api repos/:owner/:repo/pulls/<num>/comments` to dump every
+   inline thread.
+2. Bucket each comment as **fix / defer / dismiss**. Push fixup
+   commits with the SHA in your reply; mark threads resolved.
+3. For DeepSource, the report URL is in the commit status —
+   the user has to paste it because the dashboard requires auth.
+4. Tick the "bot triage" checkbox in the PR template before
+   requesting human review.
+
+For the full triage drill see the *Per-PR bot review triage*
+section in `docs/plans/modernization.md`.
+
+## Useful gotchas
+
+- **vitest can't resolve `server-only`** — aliased to a stub in
+  `vitest.config.ts`.
+- **vitest can't resolve `styled-system/*`** — aliased to the
+  `./styled-system` directory in `vitest.config.ts`.
+- **Sonar quality gate has a "new code coverage" threshold (80%)**
+  that catches new lines that aren't covered by Vitest. Map glue
+  and Next-only files (`load-sites.ts`, `MapApp.tsx`) need at
+  least smoke tests; the e2e suite alone doesn't count toward the
+  metric.
+- **DeepSource Code Formatters times out occasionally** — that's
+  a DS infra hiccup, not a real lint regression. The autofix bot
+  may also push a `style: format code with Prettier` commit on
+  your PR; rebase your branch onto it.
+- **Playwright e2e flakes in parallel** locally because the
+  `vite preview` server isn't perfectly isolated; run with
+  `--workers=1` (CI does this by default).
+- **Netlify build env defaults to a stale Node** — `netlify.toml`
+  pins `NODE_VERSION = "24"`. Don't drop the file.
+- **Sonar's CI Action and Sonar's automatic analysis collide**.
+  Automatic analysis must be off in the SonarCloud project
+  settings (Administration → Analysis Method) for the Action's
+  `lcov` upload to work.
+
+## When to stop and ask
+
+Before any of these, get explicit confirmation:
+
+- Force-pushing or rewriting history on a published branch
+- Adding a runtime CSS-in-JS library (Tailwind, Emotion,
+  Vanilla Extract) — the project explicitly avoided these
+- Switching the package manager (pnpm/yarn) — `package-lock.json`
+  is npm-shaped on purpose
+- Touching `panda.config.ts` Park UI preset (changing the accent
+  or gray palette is a visible site-wide change)
+
+Everything else: small, focused diffs, lint clean, tests green,
+push to a feature branch, open a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,19 @@ Hexagonal (ports and adapters):
   panels, map glue.
 
 **Dependency rule** — domain depends on nothing; application on
-domain; adapters on application + domain; UI on application +
-domain _via the composition root_. UI never imports adapters
-directly.
+domain; adapters on application + domain. UI is split:
+
+- **Client UI** (anything `'use client'` — `MapApp`, `map.tsx`,
+  panels, layout components): consumes the application via the
+  composition root; never imports `src/adapters/*` directly.
+- **Server UI** (route handlers in `app/`, e.g. `page.tsx`): MAY
+  import **inbound** adapters directly. That's the canonical
+  hex-arch shape — the route handler is the framework's adapter
+  driving the application from outside, so `app/page.tsx`
+  awaiting `loadSites()` is by design, not a rule break.
+
+The composition root is the choke point for the client side; for
+the server side it's the inbound adapter itself.
 
 ## Hard rules (corrections that have already happened)
 
@@ -115,11 +125,15 @@ TS/TSX, markdownlint on staged MD). Don't skip it with
 Every PR runs:
 
 - GitHub Actions: lint, lint:md, typecheck, vitest with coverage,
-  next build, Playwright e2e (Chromium), SonarCloud scan with
-  coverage upload
+  next build, Playwright e2e (Chromium), and the SonarCloud scan
+  with `lcov` coverage upload via the CI Action (backed by the
+  `SONAR_TOKEN` repo secret)
 - Netlify deploy preview
 - DeepSource JavaScript + Secrets + Code Formatters
-- SonarCloud Quality Gate (Action + automatic analysis)
+- SonarCloud Quality Gate, gated by the CI Action's scan above —
+  the project's SonarCloud "Automatic Analysis" mode is **off** in
+  the project settings (Administration → Analysis Method) because
+  it conflicts with the Action and would block coverage upload
 - GitGuardian secret scan
 - Inline reviews from Gemini Code Assist and GitHub Copilot
 

--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ npm run preview      # serve ./out at http://localhost:4173
 
 ## Scripts
 
-| Command | What it does |
-|---|---|
-| `npm run dev` | Next.js dev server with Panda codegen |
-| `npm run build` | `panda codegen` then `next build` (static export) |
-| `npm run preview` | Serves `./out` via the `serve` package on port 4173 |
-| `npm run typecheck` | `panda codegen` then `tsc --noEmit` (root + e2e tsconfigs) |
-| `npm run test` | Vitest with v8 coverage |
-| `npm run test:watch` | Vitest in watch mode |
-| `npm run e2e` | Playwright tests (boots `npm run preview` automatically) |
-| `npm run e2e:ui` | Playwright UI mode |
-| `npm run e2e:install` | Install Chromium + system deps for Playwright |
-| `npm run lint` | ESLint over `src`, `e2e`, `app`, `playwright.config.ts` |
-| `npm run lint:md` | markdownlint-cli2 over every `.md` |
-| `npm run format` | Prettier over `src`, `e2e`, `app` |
+| Command               | What it does                                               |
+| --------------------- | ---------------------------------------------------------- |
+| `npm run dev`         | Next.js dev server with Panda codegen                      |
+| `npm run build`       | `panda codegen` then `next build` (static export)          |
+| `npm run preview`     | Serves `./out` via the `serve` package on port 4173        |
+| `npm run typecheck`   | `panda codegen` then `tsc --noEmit` (root + e2e tsconfigs) |
+| `npm run test`        | Vitest with v8 coverage                                    |
+| `npm run test:watch`  | Vitest in watch mode                                       |
+| `npm run e2e`         | Playwright tests (boots `npm run preview` automatically)   |
+| `npm run e2e:ui`      | Playwright UI mode                                         |
+| `npm run e2e:install` | Install Chromium + system deps for Playwright              |
+| `npm run lint`        | ESLint over `src`, `e2e`, `app`, `playwright.config.ts`    |
+| `npm run lint:md`     | markdownlint-cli2 over every `.md`                         |
+| `npm run format`      | Prettier over `src`, `e2e`, `app`                          |
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,136 @@
-# Northwest Discovery Water Trail
+# Northwest Discovery Water Trail map
 
-The Northwest Discovery Water Trail is a 367-mile recreational boating route on the region’s defining waterways. It begins at Canoe Camp on the Clearwater River in Idaho, follows the Snake River down to the Columbia River and ends at Bonneville Dam in the Columbia River Gorge.
-
-The Northwest Discovery Water Trail connects you to nearly 150 sites to launch your boat, picnic, or camp along these rivers when you travel by motorboat, canoe, sailboat, or kayak. Whether you take a day trip or an overnight excursion, the Water Trail can link you to small riverside communities, wildlife refuges and parks, riverside trails, museums and visitor centers, as well as campgrounds and lodging. Following the paddle strokes of tribal cultures and explorers like Lewis & Clark, the Water Trail will guide you through a cross-section of the region’s natural and cultural wonders.
-
-## Website project
+An interactive map of the [Northwest Discovery Water
+Trail](https://www.wwta.org) — a 367-mile recreational boating
+route from Canoe Camp on the Clearwater River to Bonneville Dam in
+the Columbia River Gorge. Each of ~150 launch sites, campgrounds,
+and day-use areas is plotted with facility info and a downloadable
+GPX waypoint.
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d3ab47fd-5352-4d1a-8f93-35687d3ed6e4/deploy-status)](https://app.netlify.com/sites/ndwt-ol-chakra/deploys)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
+[![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
+[![Reliability](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
+[![DeepSource](https://app.deepsource.com/gh/ivanoats/ndwt-ol-chakra.svg/?label=active+issues&show_trend=true)](https://app.deepsource.com/gh/ivanoats/ndwt-ol-chakra/)
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ivanoats_ndwt-ol-chakra&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ivanoats_ndwt-ol-chakra)
+## Stack
 
-This is a rebuild of the site from ASP.Net to ReactJS and OpenLayers. In progress.
+- **Next.js 16** App Router, static export to `out/`
+- **React 19** + **TypeScript** (strict; `noUncheckedIndexedAccess`)
+- **PandaCSS** + **Park UI preset** + **Ark UI** primitives —
+  build-time atomic CSS, no Emotion runtime
+- **OpenLayers 10** for the map; GeoJSON dataset baked into the
+  page tree at build time
+- **Zustand** for the selected-site UI state
+- **Vitest** + **React Testing Library** for unit tests;
+  **Playwright** for e2e (Chromium only)
+- **Netlify** static hosting; **GitHub Actions** CI
+
+## Quickstart
+
+Requires **Node 24** (`engines.node` enforces it).
+
+```sh
+npm install
+npm run dev          # http://localhost:3000
+npm run build        # static export to ./out
+npm run preview      # serve ./out at http://localhost:4173
+```
+
+## Scripts
+
+| Command | What it does |
+|---|---|
+| `npm run dev` | Next.js dev server with Panda codegen |
+| `npm run build` | `panda codegen` then `next build` (static export) |
+| `npm run preview` | Serves `./out` via the `serve` package on port 4173 |
+| `npm run typecheck` | `panda codegen` then `tsc --noEmit` (root + e2e tsconfigs) |
+| `npm run test` | Vitest with v8 coverage |
+| `npm run test:watch` | Vitest in watch mode |
+| `npm run e2e` | Playwright tests (boots `npm run preview` automatically) |
+| `npm run e2e:ui` | Playwright UI mode |
+| `npm run e2e:install` | Install Chromium + system deps for Playwright |
+| `npm run lint` | ESLint over `src`, `e2e`, `app`, `playwright.config.ts` |
+| `npm run lint:md` | markdownlint-cli2 over every `.md` |
+| `npm run format` | Prettier over `src`, `e2e`, `app` |
+
+## Project layout
+
+```text
+app/                     # Next.js App Router
+  layout.tsx             # html/body shell, Header + main + Footer
+  page.tsx               # home: Hero + MapApp (server component)
+  about/page.tsx
+  trip-planning/page.tsx
+  providers.tsx          # 'use client' next-themes provider
+  globals.css            # cascade layers + OL stylesheet + #map sizing
+src/
+  domain/                # Pure types: Site, Coordinates, Facility
+  application/
+    ports/               # SiteRepository interface
+    use-cases/           # listSites, getSite factories
+  adapters/
+    inbound/next/        # Server-side site loader
+    outbound/            # GeoJsonSiteRepository, InMemorySiteRepository, site-to-gpx
+  components/
+    layout/              # Header, Footer, Hero
+    ui/                  # Park UI-style primitives over Ark UI + Panda
+    panels/              # SiteInfoPanel, FacilityBadges
+    map.tsx              # OL Map wrapper
+    map-handlers.ts      # Pure click + pointermove handlers
+    MapApp.tsx           # 'use client' wrapper around the map + panel
+  composition-root.ts    # createComposition(sites) factory
+  store/selected-site.ts # Zustand UI state
+public/data/             # ndwt.geojson + sites.csv (source dataset)
+docs/
+  plans/                 # Multi-phase implementation plans
+  architecture/          # C4, hexagonal, data-flow, components diagrams
+  decisions/             # ADRs
+e2e/                     # Playwright tests
+styled-system/           # Generated by `panda codegen` (gitignored)
+```
+
+The dependency rule: `domain → nothing`. `application → domain`.
+`adapters → application + domain`. `ui → application + domain` via
+the composition root; UI never imports adapters directly.
+
+## Architecture docs
+
+- [`docs/architecture/overview.md`](./docs/architecture/overview.md) —
+  C4 context + container view
+- [`docs/architecture/hexagonal.md`](./docs/architecture/hexagonal.md) —
+  ports and adapters layout
+- [`docs/architecture/data-flow.md`](./docs/architecture/data-flow.md) —
+  build-time load + runtime click-to-panel sequence
+- [`docs/architecture/components.md`](./docs/architecture/components.md) —
+  module-level component diagram
+- [`docs/decisions/`](./docs/decisions/) — ADRs for the load-bearing
+  choices (Next.js + static export, PandaCSS over Chakra,
+  hexagonal architecture)
+- [`docs/plans/modernization.md`](./docs/plans/modernization.md) —
+  the 7-phase plan that produced the current shape
+- [`docs/gap-analysis.md`](./docs/gap-analysis.md) — capability /
+  copy comparison against the original ndwt.org
+
+## Contributing
+
+Pull requests welcome — small, focused diffs preferred. Local
+checks before pushing:
+
+```sh
+npm run lint && npm run lint:md && npm run typecheck && npm test && npm run build
+npx playwright test --workers=1
+```
+
+CI runs the same matrix on every PR plus SonarCloud, DeepSource,
+and GitGuardian. The PR template includes a "bot triage" checklist;
+take a sweep through every reviewer's comments before requesting
+human review.
+
+## License
+
+[MIT](./LICENSE) — Ivan Storck.
+
+The trail itself is managed by the
+[Washington Water Trails Association](https://www.wwta.org); this
+site is an independent open-source map.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,42 @@
 # Documentation
 
-Architecture and decision records for the Northwest Discovery Water
-Trail map site.
+Architecture, decisions, and plans for the Northwest Discovery
+Water Trail map site.
 
-- [`plans/`](./plans/) — multi-phase implementation plans. Start with
-  [`plans/modernization.md`](./plans/modernization.md) for the active
-  Vite → Next.js + PandaCSS rewrite.
-- [`architecture/`](./architecture/) — system diagrams (C4, hexagonal,
-  data-flow, components) using MermaidJS embedded in Markdown.
-- [`decisions/`](./decisions/) — Architecture Decision Records (ADRs).
+## Architecture
 
-These files are populated incrementally by the modernization plan.
-Phase 7 fills them in.
+Diagrams use [MermaidJS](https://mermaid.js.org) and render
+inline on GitHub.
+
+- [`architecture/overview.md`](./architecture/overview.md) — C4
+  context + container view (who uses the system, what runs where).
+- [`architecture/hexagonal.md`](./architecture/hexagonal.md) —
+  ports and adapters layout, the dependency rule, and where each
+  layer lives in the source tree.
+- [`architecture/data-flow.md`](./architecture/data-flow.md) —
+  build-time GeoJSON load and runtime click-to-panel sequence.
+- [`architecture/components.md`](./architecture/components.md) —
+  module-level component diagram of `app/`, `src/components/`,
+  `src/application/`, `src/adapters/`.
+
+## Decisions
+
+Architecture Decision Records explain the load-bearing choices:
+
+- [`decisions/0001-nextjs-app-router.md`](./decisions/0001-nextjs-app-router.md) —
+  Next.js 16 App Router with static export.
+- [`decisions/0002-pandacss-over-chakra.md`](./decisions/0002-pandacss-over-chakra.md) —
+  PandaCSS + Park UI preset over Chakra UI 2.
+- [`decisions/0003-hexagonal-architecture.md`](./decisions/0003-hexagonal-architecture.md) —
+  Hexagonal architecture for site data.
+
+## Plans
+
+- [`plans/modernization.md`](./plans/modernization.md) — the
+  7-phase Vite → Next.js + PandaCSS rewrite that produced the
+  current shape.
+
+## Other
+
+- [`gap-analysis.md`](./gap-analysis.md) — capability and copy
+  comparison vs. the original ndwt.org site.

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -1,6 +1,212 @@
 # Component diagram
 
-Component-level view of the `app/`, `ui/`, `application/`, and
-`adapters/` modules.
+A module-level view of the source tree. Useful when navigating the
+codebase or onboarding.
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## The diagram
+
+```mermaid
+graph TB
+  subgraph App["app/ — Next.js App Router"]
+    Layout["layout.tsx<br/>html/body shell"]
+    Providers["providers.tsx<br/>'use client'<br/>next-themes"]
+    HomePage["page.tsx<br/>server: Hero + MapApp"]
+    AboutPage["about/page.tsx<br/>article"]
+    TripPage["trip-planning/page.tsx<br/>article"]
+    Globals["globals.css<br/>cascade layers + #map"]
+  end
+
+  subgraph Layout_["src/components/layout/"]
+    Header["Header.tsx<br/>'use client'<br/>logo + nav + active state"]
+    Hero["Hero.tsx<br/>367-mile tagline"]
+    Footer["Footer.tsx<br/>WWTA + GitHub + Netlify badge"]
+  end
+
+  subgraph UI_["src/components/ui/"]
+    Box["box.tsx"]
+    Stack["stack.tsx<br/>HStack / VStack"]
+    Text["text.tsx"]
+    Heading["heading.tsx"]
+    Badge["badge.tsx"]
+    Link["link.tsx<br/>safe-by-default external rel"]
+    Button["button.tsx<br/>solid / ghost / outline"]
+    IconButton["icon-button.tsx"]
+    Drawer["drawer.tsx<br/>Ark UI Dialog<br/>modal=false"]
+  end
+
+  subgraph Map_["src/components/"]
+    MapApp["MapApp.tsx<br/>'use client'<br/>composition + dynamic map"]
+    MapTSX["map.tsx<br/>OL Map instance"]
+    Handlers["map-handlers.ts<br/>pure click + pointermove"]
+    Theme["ThemeToggleButton.tsx"]
+  end
+
+  subgraph Panels_["src/components/panels/"]
+    Panel["SiteInfoPanel.tsx<br/>drawer wrapper"]
+    Facilities["FacilityBadges.tsx"]
+  end
+
+  subgraph App_["src/application/"]
+    Port["ports/site-repository.ts<br/>SiteRepository interface"]
+    ListUC["use-cases/list-sites.ts"]
+    GetUC["use-cases/get-site.ts"]
+  end
+
+  subgraph Domain_["src/domain/"]
+    Site["site.ts"]
+    Coords["coordinates.ts"]
+    Fac["facility.ts"]
+    Idx["index.ts (barrel)"]
+  end
+
+  subgraph Adapters_["src/adapters/"]
+    LoadSites["inbound/next/<br/>load-sites.ts<br/>'server-only'"]
+    InMem["outbound/<br/>in-memory-site-repository.ts"]
+    Geo["outbound/<br/>geojson-site-repository.ts"]
+    Gpx["outbound/<br/>site-to-gpx.ts"]
+  end
+
+  Comp["composition-root.ts<br/>createComposition factory"]
+  Store["store/selected-site.ts<br/>Zustand"]
+
+  Layout --> Providers
+  Layout --> Header
+  Layout --> Footer
+  Layout --> Globals
+  HomePage --> Hero
+  HomePage --> MapApp
+  HomePage --> LoadSites
+
+  AboutPage --> Link
+  TripPage --> Link
+
+  MapApp --> MapTSX
+  MapApp --> Panel
+  MapApp --> Theme
+  MapApp --> Comp
+
+  MapTSX --> Handlers
+  Handlers --> Store
+
+  Panel --> Drawer
+  Panel --> Heading
+  Panel --> Stack
+  Panel --> Box
+  Panel --> Link
+  Panel --> Button
+  Panel --> Facilities
+  Panel --> Store
+  Panel --> Gpx
+
+  Facilities --> Stack
+  Facilities --> Badge
+
+  Theme --> IconButton
+
+  Comp --> InMem
+  Comp --> ListUC
+  Comp --> GetUC
+  ListUC --> Port
+  GetUC --> Port
+  InMem -.implements.-> Port
+  Geo -.implements.-> Port
+
+  LoadSites --> Geo
+  Site --> Coords
+  Site --> Fac
+  Idx --> Site
+
+  classDef route fill:#dbeafe,stroke:#2563eb;
+  classDef ui fill:#f3e8ff,stroke:#9333ea;
+  classDef domain fill:#dcfce7,stroke:#16a34a;
+  classDef app fill:#fef3c7,stroke:#d97706;
+  classDef adapter fill:#fef3c7,stroke:#d97706;
+  classDef glue fill:#fee2e2,stroke:#dc2626;
+
+  class Layout,Providers,HomePage,AboutPage,TripPage,Globals route
+  class Header,Hero,Footer,Box,Stack,Text,Heading,Badge,Link,Button,IconButton,Drawer,Panel,Facilities,MapApp,MapTSX,Theme ui
+  class Site,Coords,Fac,Idx domain
+  class Port,ListUC,GetUC app
+  class LoadSites,InMem,Geo,Gpx adapter
+  class Comp,Store,Handlers glue
+```
+
+## What lives where
+
+### `app/`
+
+Next.js App Router entry points only. `layout.tsx` sets the
+HTML shell and global chrome (Header / main / Footer / Providers);
+`page.tsx` per route is a thin server component that fetches the
+data it needs and renders a presentation component. The whole
+folder ships as RSC server components except `providers.tsx`
+(client) which hosts `next-themes`.
+
+### `src/components/layout/`
+
+Shared chrome: Header (sticky top, nav, active state), Hero
+(home-page-only intro), Footer (attribution + Netlify badge).
+Tested with React Testing Library.
+
+### `src/components/ui/`
+
+The replacement for Chakra: thin styled primitives over Ark UI's
+headless primitives + Panda's `css()` helper. Each file is one
+component with optional variants. Hand-rolled rather than copied
+from Park UI's full library because we only need nine and the
+Panda preset already carries the design tokens.
+
+### `src/components/panels/`
+
+The site info Drawer and its supporting badges. The Drawer is
+non-modal — clicking outside doesn't dismiss; ESC and the close
+button do.
+
+### `src/components/map.tsx` + `map-handlers.ts` + `MapApp.tsx`
+
+The OpenLayers integration:
+
+- `MapApp.tsx` is the `'use client'` boundary. It builds the
+  composition once per `sites` prop via `useMemo` and dynamic-
+  imports the OL component with `ssr: false`.
+- `map.tsx` owns the `ol.Map` instance and its lifecycle (mount
+  on `useEffect`, set the global test handle, clean up).
+- `map-handlers.ts` exports curried pure functions
+  (`makeHandleClick`, `makeHandlePointerMove`) that don't import
+  any UI deps — straightforward to unit test against a fake Map.
+
+### `src/domain/`
+
+Pure types only. Adding a non-pure dependency here is a code
+review red flag.
+
+### `src/application/`
+
+Port (`SiteRepository`) and the two use-case factories. No data,
+no state.
+
+### `src/adapters/`
+
+Two outbound adapters (`InMemorySiteRepository`,
+`GeoJsonSiteRepository`) and one inbound (`load-sites.ts`,
+`'server-only'`). The serializer `site-to-gpx.ts` is also here —
+strictly speaking it's an outbound port for an export format, not
+the repository port.
+
+### `src/composition-root.ts`
+
+The single `createComposition(sites)` factory. UI imports from
+here, never directly from adapters.
+
+### `src/store/`
+
+A single Zustand slice for the selected site. The split between
+"domain data" (in the composition) and "ephemeral UI state" (in
+Zustand) is intentional.
+
+## See also
+
+- [`overview.md`](./overview.md) — system context & containers
+- [`hexagonal.md`](./hexagonal.md) — port/adapter layout
+- [`data-flow.md`](./data-flow.md) — runtime + build-time
+  sequences against this component layout

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -63,6 +63,7 @@ graph TB
     LoadSites["inbound/next/<br/>load-sites.ts<br/>'server-only'"]
     InMem["outbound/<br/>in-memory-site-repository.ts"]
     Geo["outbound/<br/>geojson-site-repository.ts"]
+    Parser["outbound/<br/>parseSitesFromGeoJson<br/>(shared parser)"]
     Gpx["outbound/<br/>site-to-gpx.ts"]
   end
 
@@ -111,7 +112,8 @@ graph TB
   InMem -.implements.-> Port
   Geo -.implements.-> Port
 
-  LoadSites --> Geo
+  LoadSites --> Parser
+  Geo --> Parser
   Site --> Coords
   Site --> Fac
   Idx --> Site
@@ -127,7 +129,7 @@ graph TB
   class Header,Hero,Footer,Box,Stack,Text,Heading,Badge,Link,Button,IconButton,Drawer,Panel,Facilities,MapApp,MapTSX,Theme ui
   class Site,Coords,Fac,Idx domain
   class Port,ListUC,GetUC app
-  class LoadSites,InMem,Geo,Gpx adapter
+  class LoadSites,InMem,Geo,Parser,Gpx adapter
   class Comp,Store,Handlers glue
 ```
 
@@ -195,8 +197,20 @@ the repository port.
 
 ### `src/composition-root.ts`
 
-The single `createComposition(sites)` factory. UI imports from
-here, never directly from adapters.
+The single `createComposition(sites)` factory. **Client UI**
+imports from here, never directly from adapters. **Server UI**
+(route handlers in `app/`) imports inbound adapters directly —
+that's the canonical hex-arch shape, where the route handler is
+the framework's adapter driving the application from outside.
+`app/page.tsx` awaiting `loadSites()` is by design, not a rule
+break.
+
+The "shared parser" node in the diagram (`parseSitesFromGeoJson`)
+is currently a named export from `geojson-site-repository.ts`
+that `load-sites.ts` reuses. It's adapter-internal infrastructure
+shared across two adapters; if the parser ever grows real logic
+beyond mapping GeoJSON properties to `Site` fields, extracting
+it to its own module would be a clean refactor.
 
 ### `src/store/`
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -15,7 +15,7 @@ sequenceDiagram
   participant Loader as load-sites.ts<br/>(server-only)
   participant FS as public/data/<br/>ndwt.geojson
   participant Parser as parseSitesFromGeoJson
-  participant MapApp as <MapApp sites>
+  participant MapApp as MapApp (sites prop)
   participant Out as out/index.html
 
   CI->>Next: npm run build
@@ -26,7 +26,7 @@ sequenceDiagram
   Loader->>Parser: parseSitesFromGeoJson(body)
   Parser-->>Loader: readonly Site[]
   Loader-->>Page: Site[]
-  Page->>MapApp: <MapApp sites={sites} />
+  Page->>MapApp: render MapApp with sites prop
   Note over Page,MapApp: sites embedded as JSON<br/>in the React tree
   MapApp-->>Next: rendered HTML + RSC payload
   Next->>Out: writes static index.html<br/>with sites inline

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -107,4 +107,4 @@ sequenceDiagram
   in
 - ADR [0001](../decisions/0001-nextjs-app-router.md) (static
   export) and [0003](../decisions/0003-hexagonal-architecture.md)
-  (hex-arch) underpin the choice to baking data at build time
+  (hex-arch) underpin the choice to bake data at build time

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,7 +1,110 @@
 # Data flow
 
-Sequence: build-time GeoJSON load → server component → client
-`SiteMap` → OpenLayers click → `selected-site` store →
-`SiteInfoPanel`.
+There are two distinct flows worth understanding: the **build-time
+load** that bakes the trail data into the static export, and the
+**runtime click** that opens the info panel for a selected marker.
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## Build-time: GeoJSON → static HTML
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant CI as GitHub Actions
+  participant Next as next build
+  participant Page as app/page.tsx<br/>(server)
+  participant Loader as load-sites.ts<br/>(server-only)
+  participant FS as public/data/<br/>ndwt.geojson
+  participant Parser as parseSitesFromGeoJson
+  participant MapApp as <MapApp sites>
+  participant Out as out/index.html
+
+  CI->>Next: npm run build
+  Next->>Page: render HomePage()
+  Page->>Loader: await loadSites()
+  Loader->>FS: readFile('public/data/ndwt.geojson')
+  FS-->>Loader: JSON text
+  Loader->>Parser: parseSitesFromGeoJson(body)
+  Parser-->>Loader: readonly Site[]
+  Loader-->>Page: Site[]
+  Page->>MapApp: <MapApp sites={sites} />
+  Note over Page,MapApp: sites embedded as JSON<br/>in the React tree
+  MapApp-->>Next: rendered HTML + RSC payload
+  Next->>Out: writes static index.html<br/>with sites inline
+```
+
+**What this means in practice:**
+
+- `npm run build` deterministically embeds the current GeoJSON
+  into `out/index.html`. There is no runtime fetch of the dataset.
+- A change to `public/data/ndwt.geojson` requires a rebuild
+  (`npm run build` or a fresh deploy). Not a runtime concern.
+- The same parser (`parseSitesFromGeoJson`) is used by the
+  inbound/server loader and the outbound/client `GeoJsonSiteRepository`.
+  Both produce identical `Site[]` shapes.
+
+## Runtime: marker click → info panel
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant User
+  participant Browser as Browser<br/>(hydrated bundle)
+  participant MapApp as MapApp.tsx
+  participant Comp as createComposition
+  participant Map as map.tsx<br/>(client only)
+  participant Handler as makeHandleClick
+  participant Repo as InMemorySiteRepository
+  participant Store as Zustand<br/>selected-site
+  participant Panel as SiteInfoPanel
+
+  Note over Browser: HTML loads, React<br/>hydrates with sites prop
+
+  Browser->>MapApp: render with sites
+  MapApp->>Comp: createComposition(sites)
+  Comp-->>MapApp: { listSites, getSite }
+  MapApp->>Map: dynamic import (ssr: false)
+  Map->>Browser: new ol.Map() + vector layer
+  Note over Map: window.__ndwtMap exposed<br/>for Playwright
+  Map->>Handler: makeHandleClick(map, getSite)
+
+  User->>Browser: clicks marker
+  Browser->>Handler: ol.click event
+  Handler->>Map: forEachFeatureAtPixel
+  Map-->>Handler: feature.getId() = SiteId
+  Handler->>Repo: getSite(siteId)
+  Repo-->>Handler: Site | null
+  Handler->>Store: useSelectedSite.select(site)
+  Store-->>Panel: re-renders with selected site
+  Panel->>User: drawer opens with site info
+```
+
+## Notable design decisions in this flow
+
+- **`MapApp` builds a fresh composition per render** via `useMemo`
+  on `sites`. There is **no module-level mutable state** — every
+  click goes through the same per-render `getSite` closure.
+  Removing the previous `hydrateSites(sites)` global was a
+  concurrent-React safety fix (Phase 4 PR review).
+- **`map.tsx` is dynamic-imported with `ssr: false`** because OL
+  reads `window` at module init. Loading it on the server would
+  crash the build.
+- **Click handler is a pure curried function** in
+  `src/components/map-handlers.ts`, unit-tested with a fake Map.
+  The wrapper component `map.tsx` only owns the OL instance and
+  the cleanup; logic stays testable.
+- **Selected-site state is in Zustand**, not React state, because
+  the click happens inside an OL event handler that doesn't have
+  React context. Zustand's `getState()` works from anywhere.
+- **The drawer is non-modal** (`Dialog.Root modal={false}`) so the
+  map stays clickable while the panel is open. Different markers
+  update the panel content in place.
+
+## See also
+
+- [`hexagonal.md`](./hexagonal.md) — the layer separation that
+  makes this two-stage flow possible
+- [`components.md`](./components.md) — which file each step lives
+  in
+- ADR [0001](../decisions/0001-nextjs-app-router.md) (static
+  export) and [0003](../decisions/0003-hexagonal-architecture.md)
+  (hex-arch) underpin the choice to baking data at build time

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -1,10 +1,10 @@
 # Hexagonal architecture
 
 The source is organized as a hexagonal (ports + adapters) system.
-The *domain* is pure types with no framework dependencies; an
-*application* layer exposes use cases against a port interface;
-*adapters* implement the port for the build-time fs read and the
-runtime in-memory lookup; the *UI* talks to the application via a
+The _domain_ is pure types with no framework dependencies; an
+_application_ layer exposes use cases against a port interface;
+_adapters_ implement the port for the build-time fs read and the
+runtime in-memory lookup; the _UI_ talks to the application via a
 thin composition root.
 
 ## The diagram

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -1,6 +1,128 @@
 # Hexagonal architecture
 
-Ports and adapters layout for the application: domain, application,
-adapters (inbound and outbound).
+The source is organized as a hexagonal (ports + adapters) system.
+The *domain* is pure types with no framework dependencies; an
+*application* layer exposes use cases against a port interface;
+*adapters* implement the port for the build-time fs read and the
+runtime in-memory lookup; the *UI* talks to the application via a
+thin composition root.
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## The diagram
+
+```mermaid
+graph TB
+  subgraph UI["UI ('use client' boundary)"]
+    MapApp[MapApp.tsx<br/>composes the page]
+    Map[map.tsx<br/>OL Map + click handler]
+    Panel[SiteInfoPanel.tsx<br/>Drawer + GPX button]
+    Store[(Zustand<br/>selected-site store)]
+  end
+
+  subgraph Server["Server boundary (Next App Router)"]
+    Layout[app/layout.tsx]
+    Page[app/page.tsx<br/>server component]
+    Loader[load-sites.ts<br/>'server-only']
+  end
+
+  subgraph App["Application"]
+    ListPort[/SiteRepository<br/>port<br/>list / findById/]
+    ListUC[makeListSites]
+    GetUC[makeGetSite]
+  end
+
+  subgraph Domain["Domain (pure)"]
+    Site[Site<br/>SiteId branded]
+    Coords[Coordinates]
+    Facility[Facility<br/>FacilitySet = readonly Facility[]]
+  end
+
+  subgraph Adapters["Adapters"]
+    Comp[composition-root.ts<br/>createComposition]
+    InMem[InMemorySiteRepository]
+    GeoJSON[GeoJsonSiteRepository<br/>fetch path; not used in prod]
+    Parser[parseSitesFromGeoJson]
+    Gpx[site-to-gpx]
+  end
+
+  Page -->|loadSites| Loader
+  Loader -->|reads| FS[(public/data/<br/>ndwt.geojson)]
+  Loader -->|parser| Parser
+  Page -->|sites prop| MapApp
+
+  MapApp -->|sites prop| Comp
+  Comp --> InMem
+  InMem -.implements.-> ListPort
+  GeoJSON -.implements.-> ListPort
+  ListUC -->|consumes| ListPort
+  GetUC -->|consumes| ListPort
+
+  MapApp -->|getSite| Map
+  Map -->|selectedSite| Store
+  Panel -->|reads| Store
+  Panel -->|on click| Gpx
+
+  ListPort -.uses.-> Site
+  Site --> Coords
+  Site --> Facility
+  Parser --> Site
+  Gpx --> Site
+
+  classDef domain fill:#dcfce7,stroke:#16a34a,color:#0c4a3a;
+  classDef app fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef adapter fill:#fef3c7,stroke:#d97706,color:#78350f;
+  classDef ui fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+  classDef ext fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+
+  class Site,Coords,Facility domain
+  class ListPort,ListUC,GetUC app
+  class Comp,InMem,GeoJSON,Parser,Gpx adapter
+  class MapApp,Map,Panel,Store,Layout,Page,Loader ui
+  class FS ext
+```
+
+## Dependency rule
+
+```text
+  domain   ←   nothing
+  application  ←   domain
+  adapters  ←   application + domain
+  ui   ←   application + domain  (via composition root)
+```
+
+Concrete enforcement points:
+
+- **`src/domain/`** has zero imports outside its own folder. Adding
+  one (e.g. `import 'react'`) is a code review red flag.
+- **`src/application/ports/`** declares interfaces only. The use
+  cases under `src/application/use-cases/` consume the port and
+  return domain values; no React, no fs, no fetch.
+- **`src/adapters/`** is the only place allowed to import platform
+  APIs (`node:fs/promises`, `fetch`, the UI runtime). The
+  `inbound/next/load-sites.ts` adapter uses `'server-only'` to
+  guarantee it never gets bundled into the client.
+- **`src/components/`** imports `@/composition-root` for runtime
+  wiring and `@/domain` for types. Direct imports from
+  `@/adapters/*` from a UI module are a smell — the composition
+  root is the choke point.
+
+## Why hexagonal here
+
+The data path is small (one file, one in-memory map, one fs read
+at build time). Hex-arch is structurally heavier than this app
+strictly needs. We picked it anyway because:
+
+1. **The repository pattern lets the same UI run with two
+   different data adapters.** Phase 2 used `GeoJsonSiteRepository`
+   (fetch URL); Phase 4 swapped to `InMemorySiteRepository`
+   (pre-loaded by Next). The map and panel didn't change.
+2. **Future WWTA integration will be a third adapter** — an
+   ArcGIS REST adapter or a database loader — and the gap from
+   "swap an adapter" to "rewrite the page" is the difference
+   between a one-PR change and a one-month change.
+3. **The domain stays serializable across the React Server
+   Components boundary** because it has no framework deps.
+   `FacilitySet` is `readonly Facility[]`, not a class, for
+   exactly this reason.
+
+See [ADR 0003](../decisions/0003-hexagonal-architecture.md) for
+the full rationale.

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -75,19 +75,31 @@ graph TB
 
   class Site,Coords,Facility domain
   class ListPort,ListUC,GetUC app
-  class Comp,InMem,GeoJSON,Parser,Gpx adapter
-  class MapApp,Map,Panel,Store,Layout,Page,Loader ui
+  class Comp,InMem,GeoJSON,Parser,Gpx,Loader adapter
+  class MapApp,Map,Panel,Store,Layout,Page ui
   class FS ext
 ```
 
 ## Dependency rule
 
 ```text
-  domain   ←   nothing
-  application  ←   domain
-  adapters  ←   application + domain
-  ui   ←   application + domain  (via composition root)
+  domain        ←   nothing
+  application   ←   domain
+  adapters      ←   application + domain
+  client UI     ←   application + domain   (via composition root)
+  server UI     ←   inbound adapters       (the route-handler shape)
 ```
+
+UI is split:
+
+- **Client UI** — anything `'use client'`: `MapApp`, `map.tsx`,
+  `SiteInfoPanel`, `Header`, etc. Consumes the application via
+  the composition root; never imports `src/adapters/*` directly.
+- **Server UI** — route handlers in `app/` (server components by
+  default). MAY import **inbound** adapters directly. That's the
+  canonical hex-arch shape: the route handler is the framework's
+  adapter driving the application from outside, so
+  `app/page.tsx` awaiting `loadSites()` is by design.
 
 Concrete enforcement points:
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,87 @@
 # System overview
 
-C4 context and container diagrams for the Northwest Discovery Water
-Trail map site.
+C4 Context (level 1) and Container (level 2) views of the
+Northwest Discovery Water Trail map site. Diagrams use
+[MermaidJS](https://mermaid.js.org) and render directly on GitHub.
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## Context
+
+The whole product fits in one diagram: a public, browser-based
+map. Source data is a static GeoJSON file we maintain in this
+repository; the deployed site is a static export served by
+Netlify's CDN.
+
+```mermaid
+C4Context
+  title System Context — NW Discovery Water Trail map
+
+  Person(boater, "Boater / trip planner", "Plans a trip on the Snake / Columbia / Clearwater corridor")
+  Person(maintainer, "Maintainer", "Adds features, fixes bugs, edits content")
+
+  System(site, "NW Discovery Water Trail map", "Static Next.js site<br/>~150 launch sites + GPX downloads")
+
+  System_Ext(netlify, "Netlify CDN", "Hosts the static export at deploy_url")
+  System_Ext(github, "GitHub", "Source repo, CI, PR reviews, dependabot")
+  System_Ext(osm, "OpenStreetMap tile servers", "Basemap tiles loaded by OL")
+  System_Ext(wwta, "Washington Water Trails Assoc.", "Manages the trail<br/>(future data integration)")
+
+  Rel(boater, site, "Browses map, opens site panel, downloads GPX")
+  Rel(maintainer, github, "PRs, reviews, dependency bumps")
+  Rel(github, netlify, "Auto-deploys on merge to main")
+  Rel(boater, netlify, "HTTPS")
+  Rel(site, osm, "Tile fetches in browser")
+  Rel(wwta, site, "Trail-data sync<br/>(planned, ArcGIS / DB)")
+```
+
+## Container
+
+The container view zooms into the deployable units. Notice that
+**the only dynamic component is the user's browser** — Netlify
+serves pre-rendered HTML and the trail data is baked into each
+page at build time.
+
+```mermaid
+C4Container
+  title Container — what runs where
+
+  Person(boater, "Boater")
+
+  System_Boundary(deploy, "Static deploy on Netlify") {
+    Container(html, "Pre-rendered HTML", "Next.js static export", "/, /about/, /trip-planning/<br/>Site[] inlined into the page tree")
+    Container(js, "Hydration bundle", "React 19 + OpenLayers 10", "Mounts the map after page load<br/>handles clicks + GPX download")
+    Container(css, "Atomic CSS", "PandaCSS", "Generated at build time<br/>no runtime CSS-in-JS")
+    Container(data, "/data/ndwt.geojson", "Static asset", "147 sites + facility flags<br/>still served for external GIS consumers")
+  }
+
+  System_Ext(github_actions, "GitHub Actions CI", "Lint / typecheck / Vitest / Playwright / SonarCloud / DeepSource on every PR")
+  System_Ext(osm_tiles, "OSM tile servers", "Fetched on demand by the OL map")
+  System_Ext(repo, "ivanoats/ndwt-ol-chakra", "Source of truth — public/data/ndwt.geojson")
+
+  Rel(boater, html, "Loads")
+  Rel(html, js, "Hydrates")
+  Rel(js, osm_tiles, "Tile requests")
+  Rel(repo, github_actions, "Push triggers")
+  Rel(github_actions, deploy, "Static export → out/")
+
+  UpdateRelStyle(html, js, $offsetY="-10")
+```
+
+## Why this shape
+
+- **Static export** keeps hosting cheap and the deploy preview
+  fast. No server runtime, no API routes, no cold starts.
+- **Trail data baked in at build time** kills the runtime fetch
+  hop and gives the map paint at first byte. The `/data/ndwt.geojson`
+  file is still published unchanged so anyone running their own
+  map / trip planner can ingest the dataset directly.
+- **OL is the only meaningful client-side dependency** — the
+  hydration bundle stays small because we don't ship a UI runtime
+  (Park UI components compile to plain elements + atomic CSS).
+
+## See also
+
+- [`hexagonal.md`](./hexagonal.md) — how the source code is
+  organized into ports and adapters
+- [`data-flow.md`](./data-flow.md) — the build-time + runtime
+  sequence that produces what's described above
+- [`components.md`](./components.md) — module-level layout

--- a/docs/decisions/0001-nextjs-app-router.md
+++ b/docs/decisions/0001-nextjs-app-router.md
@@ -1,6 +1,115 @@
-# ADR 0001: Next.js App Router with static export
+# ADR 0001: Next.js 16 App Router with static export
 
-- Status: Proposed
-- Date: 2026-04-25
+- **Status:** Accepted (Phase 4, 2026-04)
+- **Deciders:** Ivan Storck
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## Context
+
+The original site was an ASP.NET site at ndwt.org. Phases 1–3 of
+the modernization plan rebuilt the front-end as a Vite SPA
+(React 18 + Chakra UI 2 + OpenLayers) and shipped a static bundle
+to Netlify. By the end of Phase 3 we had:
+
+- A working interactive map with click-to-open info panel
+- ~150 sites loaded from `public/data/ndwt.geojson` at runtime
+  via `fetch`
+- Hexagonal architecture with a `SiteRepository` port
+- E2E coverage with Playwright
+
+The plan called for a Next.js migration in Phase 4. The question
+was *which* Next.js shape to ship: SPA-style with a client-side
+data fetch, App Router with server components, full SSR with a
+running Node server, or static export.
+
+## Decision
+
+Next.js 16 (App Router) with `output: 'export'`, generating a
+static `out/` directory served by Netlify. No running Node
+process at request time. Trail data is loaded server-side **at
+build time only** (`'server-only'` `loadSites` reads
+`public/data/ndwt.geojson` via `fs/promises`) and inlined into
+each prerendered page tree.
+
+React 19 throughout. Image optimization disabled
+(`images: { unoptimized: true }`) so the static export ships
+real `<img>` tags via `next/image` with no edge optimizer.
+
+## Consequences
+
+**Wins:**
+
+- The Netlify deploy keeps the same shape it had in Phases 1–3:
+  static files, free hosting, sub-second cold paint, no cold
+  starts.
+- Replacing the runtime GeoJSON fetch with a build-time fs read
+  removes a network round-trip from first paint and gives Sonar
+  / Lighthouse fewer things to complain about.
+- Server components naturally express the "load this once at
+  build time" use case without us inventing a static-data
+  pipeline. `app/page.tsx`'s `await loadSites()` reads as the
+  thing it is.
+- App Router's nested-layout model lets `app/layout.tsx` own the
+  Header/Footer chrome once for every route. Adding new routes
+  (`/about`, `/trip-planning`) is a per-page file with no
+  layout boilerplate.
+- The codebase gets free static-export niceties: per-route
+  `metadata`, file-based routing, automatic `<head>` building.
+
+**Costs / hazards:**
+
+- Static export disables a long list of Next features (API
+  routes, ISR, dynamic params without `generateStaticParams`,
+  middleware, image optimization). We don't currently need any
+  of them, but choosing this constrains future moves.
+- Anything that touches `window` at module import has to be
+  dynamic-imported with `ssr: false`. OL is the canonical
+  example; `MapApp.tsx` does this for `map.tsx`. Easy to forget
+  and the build error message is awkward.
+- Static export and the Sonar Action's automatic-analysis mode
+  collide; you have to pick CI-Action *or* automatic. We chose
+  the Action so we get coverage upload, and disabled automatic
+  analysis in the SonarCloud project settings.
+- The new-code coverage gate (Sonar's 80% threshold) doesn't
+  count Playwright. Anything new that lives only in glue
+  (`load-sites.ts`, `MapApp.tsx`, `app/`) needs at least a smoke
+  test in Vitest, even when the Playwright suite covers the
+  user-visible behavior.
+
+## Alternatives considered
+
+### Plain Vite SPA (the Phase 3 shape)
+
+- **Why considered:** It worked. Phase 1–3 was already shipping.
+- **Why rejected:** No native server-component model means
+  build-time data fetching is a custom pipeline (Vite plugin or
+  prebuild script). We'd have to write the equivalent of
+  `'server-only' load-sites.ts` ourselves. The site is also
+  small enough that introducing the App Router conventions now
+  is cheaper than introducing them later when we have more
+  routes / features.
+
+### Next.js with full SSR / SSG hybrid (no `output: 'export'`)
+
+- **Why considered:** Gives us API routes, ISR, image
+  optimization "for free" if we ever need them.
+- **Why rejected:** Requires a running Node server. The trail
+  dataset doesn't change minute-to-minute and the site's traffic
+  is small; paying for compute is wrong-shape. Netlify's
+  Next.js plugin can do SSR-on-Lambda but the cold starts and
+  variability are real costs for zero current benefit.
+
+### Astro
+
+- **Why considered:** Genuinely competitive for content sites
+  with a small interactive island.
+- **Why rejected:** OL, Park UI / Ark UI, and `next-themes` all
+  have first-class Next adapters; switching frameworks for a
+  marginal differentiator wasn't worth re-platforming the work
+  that was already done.
+
+## Notes
+
+- See [`docs/architecture/data-flow.md`](../architecture/data-flow.md)
+  for the build-time and runtime sequence diagrams.
+- The migration was PR
+  [#31](https://github.com/ivanoats/ndwt-ol-chakra/pull/31).

--- a/docs/decisions/0001-nextjs-app-router.md
+++ b/docs/decisions/0001-nextjs-app-router.md
@@ -17,7 +17,7 @@ to Netlify. By the end of Phase 3 we had:
 - E2E coverage with Playwright
 
 The plan called for a Next.js migration in Phase 4. The question
-was *which* Next.js shape to ship: SPA-style with a client-side
+was _which_ Next.js shape to ship: SPA-style with a client-side
 data fetch, App Router with server components, full SSR with a
 running Node server, or static export.
 
@@ -66,7 +66,7 @@ real `<img>` tags via `next/image` with no edge optimizer.
   example; `MapApp.tsx` does this for `map.tsx`. Easy to forget
   and the build error message is awkward.
 - Static export and the Sonar Action's automatic-analysis mode
-  collide; you have to pick CI-Action *or* automatic. We chose
+  collide; you have to pick CI-Action _or_ automatic. We chose
   the Action so we get coverage upload, and disabled automatic
   analysis in the SonarCloud project settings.
 - The new-code coverage gate (Sonar's 80% threshold) doesn't

--- a/docs/decisions/0002-pandacss-over-chakra.md
+++ b/docs/decisions/0002-pandacss-over-chakra.md
@@ -1,6 +1,138 @@
-# ADR 0002: PandaCSS + Ark UI + Park UI over Chakra UI 2
+# ADR 0002: PandaCSS + Park UI preset over Chakra UI 2
 
-- Status: Proposed
-- Date: 2026-04-25
+- **Status:** Accepted (Phase 5, 2026-04)
+- **Deciders:** Ivan Storck
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## Context
+
+Phases 1–4 used **Chakra UI 2** for the styling system. Chakra v2 is
+built on Emotion's runtime CSS-in-JS — stylesheets are computed and
+injected during render. By Phase 5 the install had:
+
+- `@chakra-ui/react`, `@chakra-ui/icons`, `@chakra-ui/system`
+- `@emotion/react`, `@emotion/styled`
+- `framer-motion` (a Chakra peer dep)
+
+The App Router migration in Phase 4 worked, but Chakra v2 + RSC has
+known FOUC + hydration awkwardness, and the runtime CSS engine
+adds bundle weight to a site whose JavaScript surface is otherwise
+just OL + a small Zustand slice.
+
+The Phase 5 plan was to swap Chakra for the
+**PandaCSS + Park UI + Ark UI** stack from the same authors as
+Chakra (Segun & co.).
+
+## Decision
+
+Adopt:
+
+- **PandaCSS** as the styling engine — build-time atomic CSS, no
+  runtime, type-safe tokens generated into `./styled-system/`.
+- **`@park-ui/panda-preset`** for design tokens and recipes
+  (Radix-style 12-step palettes, configured for accent: green,
+  gray: sage, radius: md).
+- **Ark UI** (`@ark-ui/react`) for headless primitives — `Dialog`
+  powers our Drawer; future popovers, tooltips, dropdowns will
+  use it.
+- **`next-themes`** for light/dark color mode (no FOUC, App
+  Router-aware).
+- **`lucide-react`** for icons (Park UI's recommended pairing).
+
+We **hand-rolled** the nine UI components we actually need
+(`box`, `stack`, `text`, `heading`, `badge`, `link`, `button`,
+`icon-button`, `drawer`) under `src/components/ui/`, rather than
+adopting Park UI's full copy-paste component library. The Park UI
+preset carries the design tokens; the rendered components are our
+own thin wrappers.
+
+Removed:
+
+- `@chakra-ui/*`, `@emotion/*`, `framer-motion`
+- `src/theme.ts` (theme now lives in `panda.config.ts`)
+
+## Consequences
+
+**Wins:**
+
+- Zero runtime CSS-in-JS — Panda compiles all styles to atomic
+  classes at build time. The hydration bundle drops several
+  hundred KB (Chakra + Emotion + framer-motion combined).
+- No FOUC + no SSR/CSR Emotion cache choreography. Static export
+  works exactly as it would for Tailwind.
+- Type-safe design tokens. The `colorPalette` virtual token
+  pattern lets a single component render in any palette by
+  setting `colorPalette: 'green' | 'sage' | ...`.
+- Component primitives are **in our repo, not behind a
+  dependency boundary**. When Ark UI's Dialog API changes, we
+  update one file. When we want a non-modal Drawer, we add
+  `modal={false}` to one place.
+
+**Costs / hazards:**
+
+- Park UI's full component library is shadcn-style copy-paste.
+  We chose to hand-roll instead — for nine components that's
+  fine, but if we add many more we should consider running
+  the Park UI CLI rather than adding dozens of bespoke files.
+- `FacilitySet` had to be refactored from a class to a plain
+  array because Park UI / Panda doesn't change anything about
+  the React Server Components serializer — class instances
+  still can't cross the RSC boundary. This was a Phase 4 fix
+  that this ADR documents because it's load-bearing for the
+  styling stack to "just work."
+- PandaCSS's codegen step (`panda codegen`) is required before
+  TypeScript can resolve `styled-system/css` etc. We prefix dev
+  / build / typecheck / test scripts with
+  `panda codegen --silent` — not free, but invisible in normal
+  use.
+- Ark UI's Dialog mounts even when closed (`data-state="closed"`,
+  `hidden`), unlike Chakra v2's Drawer which unmounted. Tests
+  needed updating to assert visibility rather than DOM presence.
+  The buffered-`displaySite` pattern from Phase 3 (Chakra-era
+  workaround for the close-animation flash) became unnecessary.
+
+## Alternatives considered
+
+### Tailwind CSS
+
+- **Why considered:** It's the obvious default for a static-CSS
+  pipeline.
+- **Why rejected:** The plan explicitly excludes Tailwind ("No
+  Tailwind"). PandaCSS's recipe / token model is closer to what
+  we already had with Chakra and lets us write the `css({...})`
+  call site syntax that's most natural for component-local
+  styles. Tailwind's `class="..."` strings would have been a
+  bigger context shift.
+
+### Stay on Chakra UI 2 indefinitely
+
+- **Why considered:** It was working.
+- **Why rejected:** Chakra v3 (Park UI essentially) was the
+  evolution path the Chakra team was taking anyway. Going
+  there directly via Park UI gets us off Emotion, off framer-
+  motion, and off Chakra v2's hydration model. The Chakra v2
+  → v3 migration would have been roughly the same diff as
+  Chakra v2 → Park UI.
+
+### Vanilla Extract
+
+- **Why considered:** Build-time CSS-in-JS, type-safe, popular.
+- **Why rejected:** Smaller ecosystem of recipes/presets;
+  Park UI's preset gives us a Radix-grade design system out of
+  the box. Vanilla Extract would have been a pure-styling pick
+  with no component primitives included.
+
+### Plain CSS Modules
+
+- **Why considered:** Simplest possible answer.
+- **Why rejected:** No design tokens, no recipes, no primitive
+  components. Would have meant rebuilding most of what Park UI
+  gives us by hand.
+
+## Notes
+
+- The migration was PR
+  [#34](https://github.com/ivanoats/ndwt-ol-chakra/pull/34).
+- See [`docs/architecture/components.md`](../architecture/components.md)
+  for what each `src/components/ui/*` file does.
+- See [ADR 0001](./0001-nextjs-app-router.md) for the static-
+  export decision that motivates removing runtime CSS-in-JS.

--- a/docs/decisions/0003-hexagonal-architecture.md
+++ b/docs/decisions/0003-hexagonal-architecture.md
@@ -1,6 +1,142 @@
-# ADR 0003: Hexagonal architecture
+# ADR 0003: Hexagonal architecture for site data
 
-- Status: Proposed
-- Date: 2026-04-25
+- **Status:** Accepted (Phase 2, 2026-04)
+- **Deciders:** Ivan Storck
 
-> Placeholder — to be authored in Phase 7 of the modernization plan.
+## Context
+
+Phase 1 of the modernization plan inherited a single-file Vite SPA
+where the OpenLayers map fetched `public/data/ndwt.geojson`
+directly via `VectorSource`'s URL prop. The data path looked like:
+
+```text
+React component → OL VectorSource → fetch → GeoJSON → render
+```
+
+This was fine for Phase 1 ("just keep it working") but tightly
+coupled the rendering logic to the runtime fetch. Three things
+were already on the roadmap that would each require a different
+data path:
+
+1. **Phase 3** (info panel): clicking a marker needs to look up
+   site details by id, not just hand the GeoJSON to the map.
+2. **Phase 4** (Next.js): the new home page wants to load the
+   GeoJSON server-side at build time and pass the data to the
+   client as a prop, not fetch it at runtime.
+3. **Future WWTA integration**: the source dataset will eventually
+   come from WWTA's database / ArcGIS layers instead of the
+   static GeoJSON.
+
+Three different data paths into the same UI is a setup that wants
+ports and adapters.
+
+## Decision
+
+Adopt a hexagonal (ports + adapters) layout for `src/`:
+
+- **`src/domain/`** — pure types: `Site`, `SiteId` (branded),
+  `Coordinates`, `Facility`, `FacilitySet`. No framework deps. No
+  classes. Plain JSON serializable so values can cross the React
+  Server Components boundary.
+- **`src/application/ports/site-repository.ts`** — a single
+  interface (`list()`, `findById()`).
+- **`src/application/use-cases/`** — `makeListSites(repo)`,
+  `makeGetSite(repo)` factory functions that return functions
+  consuming the port.
+- **`src/adapters/outbound/geojson-site-repository.ts`** — fetch
+  the JSON URL and parse (the original Phase 2 implementation).
+- **`src/adapters/outbound/in-memory-site-repository.ts`** — wrap
+  a pre-loaded `Site[]` with O(1) `findById` (added in Phase 4
+  when sites started arriving as a prop from the server).
+- **`src/adapters/inbound/next/load-sites.ts`** — `'server-only'`
+  fs read of the GeoJSON, used by `app/page.tsx` at build time.
+- **`src/composition-root.ts`** — pure factory:
+  `createComposition(sites): { listSites, getSite }`. UI imports
+  from here, never directly from adapters.
+
+The dependency rule is **strict**:
+
+```text
+domain        ← nothing
+application   ← domain
+adapters      ← application + domain
+ui            ← application + domain  (via composition root)
+```
+
+## Consequences
+
+**Wins:**
+
+- The Phase 4 migration didn't touch any UI code. We added a
+  new outbound adapter (`InMemorySiteRepository`) and a new
+  inbound adapter (`load-sites.ts`); the panel's `getSite` call
+  unchanged. End-to-end PR diff was localized to where the data
+  shape change actually was.
+- The Phase 2 click-handler refactor became unit-testable. The
+  curried `makeHandleClick(map, getSite)` accepts a `GetSite`
+  function — tests pass a `vi.fn()` and assert against the
+  Zustand store. No mocked `fetch`, no jsdom OL setup.
+- The future WWTA integration will be a third outbound adapter
+  (something like `WwtaArcgisSiteRepository`). The composition
+  root picks one. UI doesn't change.
+- The domain stays serializable. When Phase 4 moved `Site[]`
+  through the RSC boundary, `FacilitySet`'s class shape was
+  the only blocker — replaced with `readonly Facility[]` and
+  the migration was unblocked.
+
+**Costs / hazards:**
+
+- Structurally heavier than this app's data flow strictly
+  needs. One file, one in-memory map, one fs read at build time
+  — a less ceremonious design (e.g. `loadSites()` directly
+  exporting a `Site[]` constant) would also work.
+- Several layers of indirection for someone reading the code
+  for the first time. The use-case factories
+  (`makeListSites`, `makeGetSite`) are essentially one-liners
+  — kept for symmetry with `findById` and to make the pattern
+  scale uniformly.
+- "UI never imports adapters" is enforced by code review, not
+  a lint rule. Easy to drift if a future PR takes a shortcut.
+
+## Alternatives considered
+
+### Direct module-level `Site[]` export
+
+- **Why considered:** The dataset is small and static. We could
+  have just had `src/sites.ts` export the parsed array.
+- **Why rejected:** Couples build-time pipeline to UI structure;
+  no clean way to support "swap in a database adapter later."
+  The plan called out the WWTA integration as an explicit future
+  use case.
+
+### React Context provider for the repo
+
+- **Why considered:** Common React pattern for "wired
+  dependencies."
+- **Why rejected:** The first cut of the composition root used
+  a module-level mutable `repository` and a `hydrateSites()`
+  function called from `MapApp`. The bot review on Phase 4
+  caught that mutating module-level state during render is a
+  concurrent-React hazard. We pivoted to a pure
+  `createComposition(sites)` factory called via `useMemo`.
+  React Context would have worked too but the factory pattern
+  was simpler — UI components consume `getSite` as a closure,
+  no `useContext` plumbing.
+
+### Skip the abstraction; let `map.tsx` `fetch()` the JSON
+
+- **Why considered:** That's literally what Phase 1 did and it
+  was fine.
+- **Why rejected:** Once Phase 3 needed `findById` for the
+  click-to-panel flow and Phase 4 needed build-time loading,
+  putting that logic in `map.tsx` would have grown the
+  component into a god class. The repository abstraction is
+  the natural seam.
+
+## Notes
+
+- The architecture was introduced in PR
+  [#23](https://github.com/ivanoats/ndwt-ol-chakra/pull/23).
+- See [`docs/architecture/hexagonal.md`](../architecture/hexagonal.md)
+  for the full ports/adapters diagram and the dependency rule
+  enforcement points.

--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -10,8 +10,8 @@
 | 3     | Info panel on Chakra (pre-Next/Panda)           | Done (PR #30) |
 | 4     | Migrate to Next.js 16 App Router (still Chakra) | Done (PR #31) |
 | 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Done (PR #34) |
-| 6     | Layout & content polish                         | In progress   |
-| 7     | Docs & memory files                             | Pending       |
+| 6     | Layout & content polish                         | Done (PR #35) |
+| 7     | Docs & memory files                             | In progress   |
 
 ## Context
 


### PR DESCRIPTION
## Summary

The last phase of the 7-phase [modernization plan](docs/plans/modernization.md). Documents everything the codebase has come to be.

**README.md (rewritten)** — replaces the original 2-paragraph blurb with stack summary, badges, quickstart, scripts table, folder layout, dependency rule, links to all the docs, contributing checklist, license + WWTA attribution.

**CLAUDE.md (new, project-local)** — operating manual for any Claude session in this repo. Stack at a glance, hex-arch dependency rule, all the **hard rules accumulated across the rebuild** (no Tailwind / Emotion / Chakra / framer-motion; FacilitySet must stay a plain array because of RSC serialization; \`window.__ndwtMap\` is intentional; \`min-height: 0\` on \`<main>\` is a footgun; \`<html>\`'s \`suppressHydrationWarning\` is needed for next-themes; etc.). Conventions, commands cheat sheet, CI / bot triage drill, gotchas (vitest aliases, Sonar coverage, DeepSource autofix loops).

**`docs/architecture/`** — four MermaidJS-embedded diagrams:

- \`overview.md\` — C4 Context + Container.
- \`hexagonal.md\` — ports + adapters graph.
- \`data-flow.md\` — build-time GeoJSON → static HTML, runtime click → panel.
- \`components.md\` — module-level component graph.

**`docs/decisions/`** — three ADRs (replacing the Phase 1 placeholders):

- \`0001-nextjs-app-router.md\` — why Next.js 16 + static export. Alternatives considered: Vite SPA, full SSR, Astro.
- \`0002-pandacss-over-chakra.md\` — why we swapped. Alternatives: Tailwind, Chakra v3 directly, Vanilla Extract, CSS Modules.
- \`0003-hexagonal-architecture.md\` — why ports + adapters. Alternatives: direct module-level export, React Context, no abstraction at all.

**Plan + index updates** — marked Phase 6 done, Phase 7 in progress in the plan; refreshed `docs/README.md` to point at now-populated sections.

## Test plan

- [x] \`npm run lint:md\` — 13 markdown files clean
- [x] \`npm run lint\` / \`typecheck\` — green
- [x] \`npm test\` — 61 unit tests passing
- [x] \`npm run build\` — static export still produces \`./out\`
- [ ] **Open the architecture docs on GitHub** and confirm each MermaidJS diagram renders. Mermaid syntax can be picky; if any block fails to render I want to fix the source rather than ship a broken image.

## Bot review triage

- [ ] Gemini Code Assist
- [ ] GitHub Copilot review
- [ ] DeepSource (will be no-op — pure docs)
- [ ] SonarCloud (no code changes; quality gate should pass on no-new-code)

## Notes for reviewer

- This is doc-only. Zero code changes. The only file in `src/` or `app/` that moved is the plan's status table.
- Once this lands, the modernization plan's Phase 7 row flips to ✅ and the multi-PR arc is closed. Any follow-on work (gap-analysis priorities, WWTA integration, per-site URLs) belongs in new dedicated branches.