### PR TITLE
feat: phase 8 — data enrichment from ndwt.org

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,59 @@
+# Content provenance and reuse permission
+
+## Northwest Discovery Water Trail content
+
+This site reuses content originally published on
+[ndwt.org](http://www.ndwt.org), including:
+
+- Per-site display names, state, county, camping fees, and notes,
+  scraped from individual `site.asp?site=<id>` pages and
+  committed to this repository as `public/data/ndwt-enriched.json`
+  (see [`scripts/scrape-ndwt-sites.ts`](./scripts/scrape-ndwt-sites.ts)).
+- Editorial content for the Water Safety, River Navigation,
+  Leave No Trace, Natural World, Past & Present, and About
+  sections (added in later phases of the rebuild — see
+  [`docs/plans/feature-parity.md`](./docs/plans/feature-parity.md)).
+
+This reuse is **expressly permitted** by the
+[Washington Water Trails Association](https://www.wwta.org)
+(WWTA), which manages the trail. The Executive Director granted
+full reuse rights for ndwt.org's content and copy in
+correspondence with the maintainer of this repository, ahead of
+Phase 8 (data enrichment) of the modernization plan.
+
+The Northwest Discovery Water Trail itself is a project of:
+
+- **Washington Water Trails Association** — current management
+  and stewardship.
+- **National Park Service / Lewis and Clark Challenge Cost Share
+  Program** — original funding (the funder of record on the
+  legacy ndwt.org site).
+
+## Code
+
+The application code (everything in `src/`, `app/`,
+`scripts/`, etc.) is licensed under MIT — see [`LICENSE`](./LICENSE).
+The reused trail-organization content remains the property of
+WWTA and its predecessors; this repository's MIT license applies
+only to the code that wraps it.
+
+## Spatial dataset
+
+`public/data/ndwt.geojson` and `public/data/sites.csv` are the
+original GeoJSON dataset (~150 launch sites with facility flags
+and coordinates). They were captured from ndwt.org during
+Phases 1–3 of the rebuild and are republished here under the
+same WWTA permission.
+
+## Map basemap
+
+OpenStreetMap tile imagery is served by OpenStreetMap's tile
+infrastructure under the
+[Open Database License](https://www.openstreetmap.org/copyright).
+Attribution is rendered in the bottom-right of the map.
+
+## Questions or corrections
+
+Open an issue at
+[github.com/ivanoats/ndwt-ol-chakra](https://github.com/ivanoats/ndwt-ol-chakra)
+or contact WWTA directly via [wwta.org](https://www.wwta.org).

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -49,7 +49,7 @@ key for the redirect map (Phase 14) but isn't user-visible.
 
 | Item                                      | Decision                                                                                                                                                                                                                            |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Per-site URL shape                        | `/sites/<slug>` — kebab-case from canonical name. The legacy `web-scraper-order` ID stays as `Site.id` and is reused for the Phase 14 redirect map.                                                                                  |
+| Per-site URL shape                        | `/sites/<slug>` — kebab-case from canonical name. The legacy `web-scraper-order` ID stays as `Site.id` and is reused for the Phase 14 redirect map.                                                                                 |
 | Content authoring format                  | MDX under `content/`; rendered via per-route `page.tsx` that imports the MDX. Lets us embed PandaCSS-styled callouts without giving up static export.                                                                               |
 | Site name source                          | One-time scrape of ndwt.org's per-site pages (`site.asp?site=<id>`) to populate name, state, county, camping fee, notes. Saved as a separate `public/data/ndwt-enriched.json` with the GeoJSON kept as the spatial source of truth. |
 | Editorial content source                  | One-time scrape of ndwt.org's static pages, converted to MDX, hand-edited for voice + accuracy + accessibility. Each page footer cites "Originally published on ndwt.org; reused with permission from WWTA."                        |
@@ -121,6 +121,7 @@ shareable, bookmarkable, indexable, and printable.
      URL, but only the duplicate site bears it.
 
   Slug computed once at parse time and stored on `Site.slug`.
+
 - New route: `app/sites/[slug]/page.tsx` (server component) using
   `generateStaticParams` to enumerate all slugs. Static export
   emits one HTML file per site.

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -2,15 +2,15 @@
 
 ## Status
 
-| Phase | Description                                           | State   |
-| ----- | ----------------------------------------------------- | ------- |
+| Phase | Description                                           | State     |
+| ----- | ----------------------------------------------------- | --------- |
 | 8     | Data enrichment — names, notes, fees, state/county    | In review |
-| 9     | Per-site canonical URLs (`/sites/<slug>`)             | Planned |
-| 10    | Site index / browse-by-list                           | Planned |
-| 11    | Water Safety + River Navigation + Leave No Trace      | Planned |
-| 12    | Natural World + Past & Present                        | Planned |
-| 13    | About expansion + Get Involved + Photo Gallery        | Planned |
-| 14    | Cutover — redirects, sitemap, SEO, custom-domain swap | Planned |
+| 9     | Per-site canonical URLs (`/sites/<slug>`)             | Planned   |
+| 10    | Site index / browse-by-list                           | Planned   |
+| 11    | Water Safety + River Navigation + Leave No Trace      | Planned   |
+| 12    | Natural World + Past & Present                        | Planned   |
+| 13    | About expansion + Get Involved + Photo Gallery        | Planned   |
+| 14    | Cutover — redirects, sitemap, SEO, custom-domain swap | Planned   |
 
 This plan picks up where
 [`modernization.md`](./modernization.md) left off (phases 1–7).

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -49,7 +49,7 @@ key for the redirect map (Phase 14) but isn't user-visible.
 
 | Item                                      | Decision                                                                                                                                                                                                                            |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Per-site URL shape                        | `/sites/<slug>` — kebab-case from canonical name. Numeric ID kept in domain as `legacyId` for redirects only.                                                                                                                       |
+| Per-site URL shape                        | `/sites/<slug>` — kebab-case from canonical name. The legacy `web-scraper-order` ID stays as `Site.id` and is reused for the Phase 14 redirect map.                                                                                  |
 | Content authoring format                  | MDX under `content/`; rendered via per-route `page.tsx` that imports the MDX. Lets us embed PandaCSS-styled callouts without giving up static export.                                                                               |
 | Site name source                          | One-time scrape of ndwt.org's per-site pages (`site.asp?site=<id>`) to populate name, state, county, camping fee, notes. Saved as a separate `public/data/ndwt-enriched.json` with the GeoJSON kept as the spatial source of truth. |
 | Editorial content source                  | One-time scrape of ndwt.org's static pages, converted to MDX, hand-edited for voice + accuracy + accessibility. Each page footer cites "Originally published on ndwt.org; reused with permission from WWTA."                        |
@@ -83,10 +83,12 @@ camping fee, and notes when ndwt.org has them.
   and content provenance. Linked from About and Footer.
 - Domain model updates:
   - `Site.name: string` (required after enrichment)
-  - `Site.legacyId: string` (the `web-scraper-order` value;
-    kept for redirects)
   - `Site.state?: string`, `Site.county?: string`,
     `Site.campingFee?: string`, `Site.notes?: string`
+  - `Site.id` already carries the `web-scraper-order` value
+    (the legacy ndwt.org primary key) — that's the join key
+    against `ndwt-enriched.json` and the source of truth for the
+    Phase 14 redirect map. No separate `legacyId` field needed.
 - Parser merges `ndwt.geojson` + `ndwt-enriched.json` at build time
   via the existing inbound adapter. If the enriched record is
   missing, fall back to a generated placeholder name like
@@ -105,9 +107,20 @@ camping fee, and notes when ndwt.org has them.
 shareable, bookmarkable, indexable, and printable.
 
 - Slug derivation: `slugify(site.name)` →
-  `"Blalock Canyon"` → `"blalock-canyon"`. Collision handling:
-  append `-<state>` then `-<legacyId>` if needed. Slug computed
-  once at parse time and stored on `Site`.
+  `"Blalock Canyon"` → `"blalock-canyon"`. Collision handling
+  (3 known cases — Hood Park, Fishhook Park, Granite Point):
+  1. If `slugify(name)` is unique → use it.
+  2. Otherwise try `slugify(name)-mile-<N>` (river mile).
+     This resolves Hood Park (mile 2 vs 2.5 → `hood-park-mile-2`
+     vs `hood-park-mile-2-5`) and Fishhook Park (different
+     rivers, same mile-suffix idea).
+  3. If still colliding (Granite Point: both records sit at
+     Snake mile 113 — apparently a true source-data duplicate),
+     fall back to `slugify(name)-<site.id>` (the
+     `web-scraper-order` value) for guaranteed uniqueness. Ugly
+     URL, but only the duplicate site bears it.
+
+  Slug computed once at parse time and stored on `Site.slug`.
 - New route: `app/sites/[slug]/page.tsx` (server component) using
   `generateStaticParams` to enumerate all slugs. Static export
   emits one HTML file per site.
@@ -272,8 +285,9 @@ Created:
 
 Modified:
 
-- `src/domain/site.ts` — add `name`, `legacyId`, `state`,
-  `county`, `campingFee`, `notes`, `slug`
+- `src/domain/site.ts` — add `name`, `state`, `county`,
+  `campingFee`, `notes`, `slug` (slug lands in Phase 9; `Site.id`
+  already carries the legacy ndwt.org ID for redirects)
 - `src/adapters/inbound/next/load-sites.ts` — merge enriched
   record at parse time
 - `src/components/panels/SiteInfoPanel.tsx` — name in header,

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -1,0 +1,342 @@
+# Feature parity: replace ndwt.org
+
+## Status
+
+| Phase | Description                                           | State   |
+| ----- | ----------------------------------------------------- | ------- |
+| 8     | Data enrichment — names, notes, fees, state/county    | In review |
+| 9     | Per-site canonical URLs (`/sites/<slug>`)             | Planned |
+| 10    | Site index / browse-by-list                           | Planned |
+| 11    | Water Safety + River Navigation + Leave No Trace      | Planned |
+| 12    | Natural World + Past & Present                        | Planned |
+| 13    | About expansion + Get Involved + Photo Gallery        | Planned |
+| 14    | Cutover — redirects, sitemap, SEO, custom-domain swap | Planned |
+
+This plan picks up where
+[`modernization.md`](./modernization.md) left off (phases 1–7).
+Same shape: one PR per phase, each independently reviewable, bot
+triage on every PR before requesting human review.
+
+## Context
+
+After Phase 7 the site is a modern, accessible, fast Next.js +
+PandaCSS map of ~150 boating sites. It still falls short of
+[ndwt.org](http://www.ndwt.org) in two ways:
+
+1. **Data gaps** — the GeoJSON we ship has no site name, no
+   notes, no camping fee, no state/county. Our panel header
+   reads "Columbia River — Mile 234" instead of "Blalock Canyon."
+2. **Content gaps** — ndwt.org has six topical sections
+   (Water Safety, River Navigation, Natural World, Past & Present,
+   About, Get Involved) that our site doesn't have at all.
+
+Goal: **fully replace ndwt.org** as the public site for the
+Northwest Discovery Water Trail. After Phase 14, requests to the
+old ASP URLs are redirected here, the WWTA-managed editorial
+content lives here, and ndwt.org can be retired.
+
+**Permission basis**: the Washington Water Trails Association
+Executive Director has granted full reuse rights for ndwt.org's
+content and copy. We'll record that in `NOTICE.md` and surface
+attribution on the About page.
+
+**Naming preference**: per-site routes use **slugs derived from
+the canonical site name** (`/sites/blalock-canyon`), not the
+legacy numeric IDs. The numeric ID stays in the data as a join
+key for the redirect map (Phase 14) but isn't user-visible.
+
+## Scope decisions
+
+| Item                                      | Decision                                                                                                                                                                                                                            |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-site URL shape                        | `/sites/<slug>` — kebab-case from canonical name. Numeric ID kept in domain as `legacyId` for redirects only.                                                                                                                       |
+| Content authoring format                  | MDX under `content/`; rendered via per-route `page.tsx` that imports the MDX. Lets us embed PandaCSS-styled callouts without giving up static export.                                                                               |
+| Site name source                          | One-time scrape of ndwt.org's per-site pages (`site.asp?site=<id>`) to populate name, state, county, camping fee, notes. Saved as a separate `public/data/ndwt-enriched.json` with the GeoJSON kept as the spatial source of truth. |
+| Editorial content source                  | One-time scrape of ndwt.org's static pages, converted to MDX, hand-edited for voice + accuracy + accessibility. Each page footer cites "Originally published on ndwt.org; reused with permission from WWTA."                        |
+| Forum / Trip Reports / Donate / Volunteer | Out of scope — link out to WWTA's existing flows. Phase 13 adds the links.                                                                                                                                                          |
+| Press Coverage                            | Permanently deferred — low engagement value.                                                                                                                                                                                        |
+| Photo Gallery                             | Phase 13, conditional on WWTA having a photo library to point at. Otherwise deferred.                                                                                                                                               |
+| Search                                    | Out of scope for now — site index list (Phase 10) covers most of the use case. Revisit after Phase 14 if user feedback asks for it.                                                                                                 |
+
+## Per-PR bot review triage
+
+Same drill as the modernization plan — see
+[`modernization.md` § Per-PR bot review triage](./modernization.md#per-pr-bot-review-triage).
+
+## Build sequence (one PR per phase)
+
+### Phase 8 — Data enrichment
+
+**Goal**: every site has a display name, plus state, county,
+camping fee, and notes when ndwt.org has them.
+
+- Add a one-shot scraper script
+  (`scripts/scrape-ndwt-sites.ts`) that walks every
+  `web-scraper-start-url` from the GeoJSON, extracts:
+  - Site name from `<title>` / `<h1>`
+  - State, county, camping fee, notes from the detail table
+  - Sanitizes free-text fields (strip HTML, normalize whitespace)
+- Output: `public/data/ndwt-enriched.json` keyed by legacy ID,
+  committed to the repo. The script is **one-shot** — re-run
+  manually if ndwt.org changes; not part of the build.
+- `NOTICE.md` at repo root documents the WWTA permission grant
+  and content provenance. Linked from About and Footer.
+- Domain model updates:
+  - `Site.name: string` (required after enrichment)
+  - `Site.legacyId: string` (the `web-scraper-order` value;
+    kept for redirects)
+  - `Site.state?: string`, `Site.county?: string`,
+    `Site.campingFee?: string`, `Site.notes?: string`
+- Parser merges `ndwt.geojson` + `ndwt-enriched.json` at build time
+  via the existing inbound adapter. If the enriched record is
+  missing, fall back to a generated placeholder name like
+  `"Columbia River — Mile 234"` (current behavior) and log the
+  gap for follow-up.
+- `SiteInfoPanel` header now shows the site name. Add conditional
+  rows for state, county, camping fee, notes.
+- Tests: parser merge edge cases (missing enriched record,
+  partial fields); panel snapshot with all fields populated.
+- Verify: every marker's panel header shows a real name; sample
+  three sites against ndwt.org for accuracy.
+
+### Phase 9 — Per-site canonical URLs
+
+**Goal**: every site has its own page at `/sites/<slug>`,
+shareable, bookmarkable, indexable, and printable.
+
+- Slug derivation: `slugify(site.name)` →
+  `"Blalock Canyon"` → `"blalock-canyon"`. Collision handling:
+  append `-<state>` then `-<legacyId>` if needed. Slug computed
+  once at parse time and stored on `Site`.
+- New route: `app/sites/[slug]/page.tsx` (server component) using
+  `generateStaticParams` to enumerate all slugs. Static export
+  emits one HTML file per site.
+- Detail page renders the same content as the panel plus a
+  print-friendly layout (tested with Playwright's
+  `emulateMedia({ media: 'print' })`).
+- Map marker click behavior:
+  - **Default**: open the in-page panel (current UX) and
+    push `?site=<slug>` to the URL via `history.replaceState` —
+    so the URL is shareable without a full navigation.
+  - **Direct visit** to `/?site=<slug>` opens the panel on load.
+  - **`/sites/<slug>` direct visit** renders the dedicated page
+    (no map). The page has a "View on map" link back to
+    `/?site=<slug>`.
+- Per-page metadata: `generateMetadata` per site emits
+  `<title>{site.name} — NW Discovery Water Trail</title>` and an
+  OpenGraph description from the river/mile/bank.
+- Tests:
+  - Vitest: slug derivation including collisions.
+  - Playwright: deep-link `/?site=blalock-canyon` opens the
+    panel; visiting `/sites/blalock-canyon` renders the detail
+    page; print media query yields a single-column layout.
+- Verify: `npm run build` produces ~150 `out/sites/<slug>.html`
+  files; sharing a URL on Slack/iMessage produces correct OG.
+
+### Phase 10 — Site index / browse-by-list
+
+**Goal**: a sortable, filterable list of every site for the
+"I know the name but not the location" use case.
+
+- New route: `app/sites/page.tsx` (server component) listing
+  every site with: name, river, mile, bank, top-level facility
+  badges, link to `/sites/<slug>`.
+- Default sort: by river then mile. Toggle: alphabetical.
+- Client-side filter (Zustand or `useState`): name substring,
+  facility checkboxes, river dropdown.
+- Header nav adds "Sites" link pointing at `/sites`.
+- Tests:
+  - Vitest: filter logic on a fixture of 5 sites.
+  - Playwright: type "blalock", verify result narrows to 1; pick
+    the result, land on `/sites/blalock-canyon`.
+- Verify: page loads under 200 ms server time; filter is
+  instant on a 150-row list with no virtualization needed.
+
+### Phase 11 — Operational content (Water Safety, River Navigation, Leave No Trace)
+
+**Goal**: the editorial content boaters actually need on the
+water lives here.
+
+- Scrape ndwt.org pages once (manual; not a build step) into
+  MDX under `content/`:
+  - `content/water-safety/{index,weather,barge-traffic,communications,reading-the-rivers,float-plans,safety-gear}.mdx`
+  - `content/river-navigation/{index,lock-and-dam,portage-guide}.mdx`
+  - `content/leave-no-trace.mdx`
+- Each MDX file gets a hand-edit pass for: voice consistency
+  (full "Northwest Discovery Water Trail" on first reference),
+  accessibility (alt text, heading order), broken-link triage,
+  and a permission attribution footer.
+- Routes: `app/water-safety/[[...slug]]/page.tsx`,
+  `app/river-navigation/[[...slug]]/page.tsx`,
+  `app/leave-no-trace/page.tsx`. Each imports the MDX, wraps in
+  the existing layout, generates static metadata.
+- Header nav: add "Safety", "Navigation", "Leave No Trace"
+  (consider grouping under a single "Resources" dropdown to
+  avoid header overflow on mobile).
+- Tests: Playwright smoke — visit each new route, check for an
+  `h1` and the attribution footer.
+- Verify: print Lighthouse a11y score for one sub-page; aim for
+  ≥ 95.
+
+### Phase 12 — Cultural / natural content (Natural World, Past & Present)
+
+**Goal**: the historical and ecological context that makes the
+trail more than a marker dataset.
+
+- MDX under `content/natural-world/{index,flora-fauna,geology,invasive-species}.mdx`
+  and `content/past-and-present/{index,tribal-communities,early-explorers,trade-and-industry}.mdx`.
+- Tribal Communities page gets an explicit content review with
+  WWTA before merge — the original ndwt.org copy is from the
+  early 2010s and may need updating to reflect current tribal
+  partnerships and language preferences.
+- Routes mirror the safety/navigation pattern.
+- Header nav: "Natural World", "Past & Present" added under
+  Resources.
+- Tests: Playwright smoke per route.
+- Verify: MD lint passes; a11y check on one page.
+
+### Phase 13 — About expansion + Get Involved + (optional) Photo Gallery
+
+**Goal**: the meta-pages — who runs the trail, who funded it,
+how to get involved.
+
+- `app/about/partners/page.tsx` — funding (NPS / Lewis & Clark
+  Challenge Cost Share), management (WWTA), agency partners
+  (USACE, BLM, state parks, tribal partners). Logos with proper
+  alt text via `next/image`.
+- `app/about/history/page.tsx` — project history MDX.
+- `app/about/contact/page.tsx` — mailto link or pointer to WWTA
+  contact form. No custom form (no backend).
+- `app/get-involved/page.tsx` — three outbound CTAs: Volunteer
+  (WWTA), Donate (WWTA), Trip Reports (WWTA forum or wherever
+  WWTA hosts these now). Confirm exact URLs with WWTA before
+  merging.
+- Photo Gallery: include only if WWTA hands over a photo set
+  with usage rights. Implementation: `app/gallery/page.tsx`
+  rendering a Panda-styled grid; clicking a photo opens an Ark
+  UI Dialog with full size + caption. If no photos available
+  by start of Phase 13, defer to a follow-up phase.
+- Header nav: collapse less-used items into a `<details>`
+  "Resources" dropdown so the bar doesn't overflow.
+- Tests: Playwright smoke; verify all outbound links return 200.
+- Verify: full nav reachable on mobile (320px width).
+
+### Phase 14 — Cutover
+
+**Goal**: ndwt.org redirects to this site; search engines
+re-index correctly; the old ASP site can be retired.
+
+- `app/sitemap.ts` emits a per-route URL list including all
+  `/sites/<slug>` pages and all editorial routes.
+- `public/robots.txt` allows all crawlers, points at sitemap.
+- `next.config.mjs` `metadataBase` set to the production
+  domain.
+- Per-page OpenGraph + Twitter Card metadata audited.
+- Netlify `_redirects` (or `netlify.toml [[redirects]]`):
+  - `301 /ndwt/explore/site.asp?site=:id /sites/<slug>` —
+    legacy-ID-to-slug map generated from the enriched data.
+  - `301 /ndwt/safety/* /water-safety/*` — pattern map for
+    each section.
+  - Catch-all `301 /ndwt/* /` for anything not explicitly
+    mapped.
+- Custom domain (`ndwt.org` or whatever WWTA picks) added in
+  Netlify. DNS swap is a manual step coordinated with WWTA's
+  domain registrar; document it in `docs/operations/dns-cutover.md`.
+- Final audits before requesting the DNS swap:
+  - Lighthouse: Performance ≥ 90, A11y ≥ 95, Best Practices ≥
+    95, SEO ≥ 95 on three sample routes (`/`, `/sites/<slug>`,
+    `/water-safety/`).
+  - Manual screen-reader pass with VoiceOver on macOS.
+  - Broken-link sweep (`linkinator` or similar) on the deploy
+    preview.
+- Coordinate with WWTA on social-media + email announcement
+  pointing at the new site.
+
+## Files to create / modify
+
+Created:
+
+- `scripts/scrape-ndwt-sites.ts` (one-shot enricher)
+- `public/data/ndwt-enriched.json` (keyed by legacy ID)
+- `NOTICE.md` (permission attribution)
+- `app/sites/[slug]/page.tsx`
+- `app/sites/page.tsx` (index)
+- `app/water-safety/`, `app/river-navigation/`,
+  `app/leave-no-trace/`, `app/natural-world/`,
+  `app/past-and-present/`, `app/about/{partners,history,contact}/`,
+  `app/get-involved/`, optionally `app/gallery/`
+- `content/**/*.mdx` (editorial content)
+- `app/sitemap.ts`, `public/robots.txt`,
+  `public/_redirects` (or equivalent in `netlify.toml`)
+- `docs/operations/dns-cutover.md`
+
+Modified:
+
+- `src/domain/site.ts` — add `name`, `legacyId`, `state`,
+  `county`, `campingFee`, `notes`, `slug`
+- `src/adapters/inbound/next/load-sites.ts` — merge enriched
+  record at parse time
+- `src/components/panels/SiteInfoPanel.tsx` — name in header,
+  conditional rows for new fields
+- `src/components/layout/Header.tsx` — Sites + Resources nav
+- `next.config.mjs` — MDX support, metadataBase
+- `package.json` — `@next/mdx`, `slugify` (or hand-rolled)
+
+## Verification (end of Phase 14)
+
+1. Every marker shows a real name in the panel.
+2. `/sites/<slug>` exists for every site; share a URL → preview
+   card shows site name + river segment.
+3. Site index `/sites/` lists every site, filter narrows to the
+   right results.
+4. All editorial routes (`/water-safety/*`,
+   `/river-navigation/*`, `/leave-no-trace`,
+   `/natural-world/*`, `/past-and-present/*`,
+   `/about/*`, `/get-involved`) render with attribution footers.
+5. `out/sitemap.xml` lists every public route.
+6. `_redirects` maps every legacy ASP URL pattern to a 301.
+7. Lighthouse scores on three sample routes meet the targets.
+8. WWTA reviewer signs off on the Tribal Communities page and
+   the Partners page.
+9. DNS swap executed; ndwt.org now serves this site.
+
+Done when: a paddler can do every task on the new site that
+they could do on ndwt.org, the old ASP site is retired, and
+search results for "northwest discovery water trail" land on
+`/` or the relevant editorial route within 30 days of cutover.
+
+## Open questions
+
+1. **Domain ownership**: who controls the ndwt.org DNS today —
+   WWTA, the legacy NPS contact, or a personal account that
+   needs to be transferred? Phase 14 can't ship until this is
+   answered.
+   Answer: WWTA controls the domain and will coordinate the DNS swap when we get to Phase 14.
+2. **Tribal Communities content**: who at WWTA owns the review?
+   Some original copy uses early-2010s phrasing that may need
+   updating in consultation with the relevant tribal partners.
+   Answer: defer to WWTA's judgment on this one; we have permission to reuse
+3. **Photo Gallery**: does WWTA have a usable photo library,
+   and do those photos have clear reuse rights (model releases
+   for any people, location-tagged for site association)?
+   Answer: WWTA has a wordpress site with NextGen Gallery plugin that has photos
+   with usage rights; we can link to that in Phase 13 without building our own
+   gallery page, or we can build a gallery page that sources from the Wordpress
+   library via RSS or similar. Defer the decision until Phase 13 when we know
+   more about the photo set and WWTA's preferences. I do have admin access to
+   the wordpress site so I can install plugins or make config changes if needed
+   to get the photos accessible to our frontend.
+
+4. **Volunteer / Donate / Trip Reports outbound URLs**: the
+   exact WWTA URLs to link to in Phase 13 need confirmation.
+5. **Email alias**: Phase 13's Contact page wants a `mailto:`
+   target. Should it be a WWTA address (`info@wwta.org`?), or a
+   project-specific alias (`maintainers@ndwt.org`)?
+   Answer: <info@wwta.org>
+
+## See also
+
+- [`modernization.md`](./modernization.md) — Phases 1–7 (the
+  baseline this plan builds on)
+- [`../gap-analysis.md`](../gap-analysis.md) — the source
+  inventory that drove the phase ordering above

--- a/docs/plans/modernization.md
+++ b/docs/plans/modernization.md
@@ -11,7 +11,11 @@
 | 4     | Migrate to Next.js 16 App Router (still Chakra) | Done (PR #31) |
 | 5     | Swap Chakra for PandaCSS + Ark UI + Park UI     | Done (PR #34) |
 | 6     | Layout & content polish                         | Done (PR #35) |
-| 7     | Docs & memory files                             | In progress   |
+| 7     | Docs & memory files                             | Done (PR #38) |
+
+Phases 8–14 continue in
+[`feature-parity.md`](./feature-parity.md) — closing the gap to
+ndwt.org and replacing it as the public site for the trail.
 
 ## Context
 

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -47,8 +47,13 @@ test.describe('Northwest Discovery Water Trail map', () => {
 
     const panel = page.getByTestId('site-info-panel');
     await expect(panel).toBeVisible();
-    // Every site renders "<river> River — Mile <n>" into the header.
-    await expect(panel.getByRole('heading')).toContainText(/Mile/);
+    // Every site has a non-empty canonical name in the header (post
+    // Phase 8 enrichment).
+    const heading = panel.getByRole('heading').first();
+    await expect(heading).toBeVisible();
+    await expect(heading).not.toBeEmpty();
+    // Subheading carries the river-and-mile context.
+    await expect(panel.getByText(/Mile \d/)).toBeVisible();
     // Coordinates row + GPX download button are part of the panel.
     await expect(panel.getByText(/Coordinates/i)).toBeVisible();
     await expect(panel.getByTestId('download-gpx-button')).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.3.2",
+        "@types/jsdom": "^28.0.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -4356,6 +4357,52 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4416,6 +4463,13 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -14076,7 +14130,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -19899,6 +19952,41 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "@types/jsdom": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0",
+        "undici-types": "^7.21.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+          "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+          "dev": true,
+          "requires": {
+            "entities": "^6.0.0"
+          }
+        },
+        "undici-types": {
+          "version": "7.25.0",
+          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+          "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+          "dev": true
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -19952,6 +20040,12 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -26809,7 +26903,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
           "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck": "panda codegen --silent && tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",
     "test": "panda codegen --silent && vitest run --coverage",
     "test:watch": "vitest",
+    "scrape:sites": "node --experimental-strip-types scripts/scrape-ndwt-sites.ts",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.3.2",
+    "@types/jsdom": "^28.0.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/public/data/ndwt-enriched.json
+++ b/public/data/ndwt-enriched.json
@@ -666,7 +666,7 @@
     "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=109",
     "state": "OR",
     "county": "Umatilla",
-    "notes": "Pets must be kept on a leash. Private campground, store, and caf� nearby, for information visit www.hatrockcampground.com"
+    "notes": "Pets must be kept on a leash. Private campground, store, and café nearby, for information visit www.hatrockcampground.com"
   },
   "1639846211-170": {
     "name": "Chief Timothy Habitat Management Unit",

--- a/public/data/ndwt-enriched.json
+++ b/public/data/ndwt-enriched.json
@@ -510,8 +510,7 @@
     "name": "Hells Gate State Park",
     "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=34",
     "state": "ID",
-    "county": "Nez Perce",
-    "campingFee": "X"
+    "county": "Nez Perce"
   },
   "1639845985-67": {
     "name": "Avery Park",
@@ -579,8 +578,7 @@
     "name": "Canoe Camp",
     "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=1",
     "state": "ID",
-    "county": "Clearwater",
-    "campingFee": "X"
+    "county": "Clearwater"
   },
   "1639846264-191": {
     "name": "Arrow Bridge",
@@ -783,8 +781,7 @@
     "name": "Marina Park( Cascade Locks Boat Ramp)",
     "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=172",
     "state": "OR",
-    "county": "Hood River",
-    "campingFee": "X"
+    "county": "Hood River"
   },
   "1639845841-5": {
     "name": "Steelhead Park",

--- a/public/data/ndwt-enriched.json
+++ b/public/data/ndwt-enriched.json
@@ -848,7 +848,7 @@
     "name": "Lewiston Levee Parkway",
     "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=39",
     "state": "ID",
-    "county": "Nez Perice"
+    "county": "Nez Perce"
   },
   "1639846132-134": {
     "name": "Lost Island (Votaw)",

--- a/public/data/ndwt-enriched.json
+++ b/public/data/ndwt-enriched.json
@@ -1,0 +1,1010 @@
+{
+  "1639846015-81": {
+    "name": "Blalock Canyon",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=130"
+  },
+  "1639845856-12": {
+    "name": "Harper's Bend",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=202",
+    "state": "ID",
+    "county": "Nez Perce",
+    "notes": "Popular site for fishing salmon and steelhead."
+  },
+  "1639846035-90": {
+    "name": "Paterson Boat Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=121",
+    "state": "WA",
+    "notes": "Gently sloping rock into water, no real ramp."
+  },
+  "1639845951-52": {
+    "name": "Hood River Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=159",
+    "state": "OR",
+    "county": "Hood River",
+    "notes": "Closes at dusk, no overnight camping or parking. A group shelter can be reserved for a fee. Marina slips are for monthly and annual tenants.The guest dock has a 3 day maximum, and a fee."
+  },
+  "1639845940-47": {
+    "name": "The Hook",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=164",
+    "state": "OR",
+    "county": "Hood River",
+    "notes": "Fishing, windsurfing, kiteboarding (from designated points)."
+  },
+  "1639845957-55": {
+    "name": "Bingen Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=156",
+    "state": "WA",
+    "county": "Klickitat",
+    "notes": "No Alcohol, no commercial fishing"
+  },
+  "1639846134-135": {
+    "name": "Hollebeke",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=76",
+    "state": "WA",
+    "county": "Walla Walla"
+  },
+  "1639845931-43": {
+    "name": "Home Valley",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=168",
+    "state": "WA",
+    "county": "Skamania",
+    "notes": "Baseball fields, playground equipment, windsurfing, horseshoe pits, beach, wetlands to observe."
+  },
+  "1639846094-117": {
+    "name": "Yakima River",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=94"
+  },
+  "1639845911-34": {
+    "name": "Bonneville Portage Downstream/Hamilton Island Boat Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=177",
+    "state": "WA",
+    "county": "Skamania"
+  },
+  "1639846099-119": {
+    "name": "Hanford Reach NM Visitor Center",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=92",
+    "state": "WA",
+    "county": "Benton"
+  },
+  "1639845948-51": {
+    "name": "Inn Beach(Hood River Inn)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=160",
+    "state": "OR",
+    "county": "Hood River"
+  },
+  "1639845998-73": {
+    "name": "Rufus",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=138"
+  },
+  "1639845955-54": {
+    "name": "Bingen Ramp (Sailboard Park at Point)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=157",
+    "state": "WA",
+    "county": "Klickitat"
+  },
+  "1639845834-2": {
+    "name": "Howard Amon Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=212"
+  },
+  "1639846046-95": {
+    "name": "Nugent Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=116",
+    "state": "OR",
+    "county": "Umatilla",
+    "notes": "Nugent Park is on the Umatilla River, one mile up from the confluence with the Columbia River."
+  },
+  "1639846139-137": {
+    "name": "Windust",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=74",
+    "state": "WA",
+    "county": "Franklin",
+    "campingFee": "No fee",
+    "notes": "No wake area around swimming area. Pets must be kept on a leash."
+  },
+  "1639846011-79": {
+    "name": "Le Page Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=132",
+    "state": "OR",
+    "county": "Hood River",
+    "campingFee": "$12 per tent per night",
+    "notes": "Reservations need to be made 4 days in advance. On weekdays, minimum stay length is 2 days, and on weekends and holidays you must stay for at least 3 days. No off road vehicles."
+  },
+  "1639846083-112": {
+    "name": "Clover Island Inn Boat Dock",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=99",
+    "state": "WA",
+    "county": "Benton"
+  },
+  "1639846039-92": {
+    "name": "Patterson Ferry Road Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=119",
+    "state": "OR",
+    "county": "Morrow"
+  },
+  "1639845893-28": {
+    "name": "Lower Goose Pasture",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=185",
+    "state": "ID",
+    "county": "Nez Perce"
+  },
+  "1639846257-188": {
+    "name": "Cherry Lane Sports Access",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=21",
+    "state": "ID",
+    "county": "Nez Perce",
+    "notes": "http://fishandgame.idaho.gov/"
+  },
+  "1639846154-144": {
+    "name": "Lyons Ferry Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=67",
+    "state": "WA",
+    "county": "Columbia",
+    "campingFee": "$10.75 per tent site",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited."
+  },
+  "1639846068-105": {
+    "name": "Washington/Oregon State Line",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=106"
+  },
+  "1639846028-87": {
+    "name": "Crow Butte Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=124",
+    "state": "WA",
+    "county": "Benton",
+    "campingFee": "15$ per site per day.",
+    "notes": "Pets must be kept on a leash"
+  },
+  "1639846090-115": {
+    "name": "Wye Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=96",
+    "county": "Franklin",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited."
+  },
+  "1639846088-114": {
+    "name": "Columbia Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=97",
+    "state": "WA",
+    "county": "Benton",
+    "notes": "Campgrounds are closed until further notice (May 16, 2008)"
+  },
+  "1639846245-183": {
+    "name": "Nez Perce National Historic Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=26",
+    "state": "ID"
+  },
+  "1639846026-86": {
+    "name": "Alderdale",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=125"
+  },
+  "1639846059-101": {
+    "name": "McNary Beach Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=110",
+    "state": "OR",
+    "county": "Umatilla",
+    "notes": "Take a stroll on the Lewis & Clark Commemorative Trail"
+  },
+  "1639845845-7": {
+    "name": "Myrtle Recreation Site",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=207",
+    "state": "ID",
+    "county": "Nez Perce",
+    "campingFee": "$8 per tent or RV"
+  },
+  "1639846017-82": {
+    "name": "Roosevelt Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=129",
+    "state": "WA",
+    "notes": "Popular spot for windsurfing, kiteboarding, and swimming."
+  },
+  "1639845928-42": {
+    "name": "Boat Ramp( Port Dock)Stevensen Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=169",
+    "state": "WA",
+    "county": "Skamania"
+  },
+  "1639845933-44": {
+    "name": "Viento State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=167",
+    "state": "OR",
+    "county": "Hood River",
+    "campingFee": "$10-14 per site (Price varies with season).",
+    "notes": "$3 for day use."
+  },
+  "1639845973-62": {
+    "name": "Kiwanis Park at Kildits Cove",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=149",
+    "state": "OR",
+    "county": "Wasco"
+  },
+  "1639846163-148": {
+    "name": "Riparia",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=63",
+    "state": "WA",
+    "county": "Whitman",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10."
+  },
+  "1639845847-8": {
+    "name": "Ankeny",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=206",
+    "state": "OR"
+  },
+  "1639845924-40": {
+    "name": "Cascade Boat Launch & Pebble Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=171",
+    "state": "WA",
+    "county": "Skamania",
+    "notes": "The Cascade Boat Launch and Pebble Beach are separate sites. However, they are within walking distance on each other. Dog must be on a leash."
+  },
+  "1639846202-166": {
+    "name": "Wawawai Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=45",
+    "state": "WA",
+    "county": "Whitman",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Charcoal and propane fires are acceptable."
+  },
+  "1639846218-173": {
+    "name": "Greenbelt Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=38",
+    "state": "WA",
+    "county": "Asotin",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed. Charcoal and propane fires are acceptable. Public telephone available."
+  },
+  "1639846121-129": {
+    "name": "Charbonneau Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=82",
+    "state": "WA",
+    "county": "Walla Walla",
+    "campingFee": "18$ for a regular site, and $8 for overflow sites.",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited inside the developed park. Fire pits, grills, and hot showers available, along with a trailer dump station."
+  },
+  "1639846209-169": {
+    "name": "Chief Timothy Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=42",
+    "state": "WA",
+    "county": "Asotin",
+    "campingFee": "$20 for a standard campsite",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. Golden Age and Access Passports will not be accepted. No open fires allowed from June 10 through October 10."
+  },
+  "1639846207-168": {
+    "name": "Nisqually John Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=43",
+    "state": "WA",
+    "county": "Whitman",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Charcoal and propane fires are acceptable."
+  },
+  "1639846125-131": {
+    "name": "Big Flat",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=80",
+    "state": "WA",
+    "county": "Franklin",
+    "notes": "Hunting is allowed for waterfowl, upland game birds and deer with shotgun only. Hunting seasons and hours are set by WDFW."
+  },
+  "1639846070-106": {
+    "name": "Walla Walla Yacht Club",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=105",
+    "state": "WA",
+    "notes": "Pets must be kept on a leash. The marina is private and open only to club members. A sani-can is available at the boat ramp."
+  },
+  "1639845887-25": {
+    "name": "Granite Point",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=188",
+    "state": "WA"
+  },
+  "1639846145-140": {
+    "name": "Lower Monumental Dam",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=71",
+    "state": "WA",
+    "county": "Franklin"
+  },
+  "1639846136-136": {
+    "name": "Walker",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=75",
+    "state": "WA",
+    "county": "Walla Walla",
+    "notes": "Camping space is somewhat limited and there are no designated spots."
+  },
+  "1639845900-30": {
+    "name": "Granite Point",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=182",
+    "state": "WA",
+    "campingFee": "none"
+  },
+  "1639846072-107": {
+    "name": "Port of Wallula",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=104"
+  },
+  "1639846103-121": {
+    "name": "Sacajawea State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=90",
+    "state": "WA",
+    "county": "Franklin",
+    "campingFee": "Free",
+    "notes": "Pets must be kept on a leash. Restrooms closed Oct-Mar. Campsite accomodates 8 on first come first serve basis. Parties larger than 8 call: (506) 545-2361"
+  },
+  "1639845920-38": {
+    "name": "Port of Cascade Locks Marine Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=173",
+    "state": "OR",
+    "county": "Hood River",
+    "campingFee": "$15/night",
+    "notes": "No campfires in the campground. Enjoy a playground, museum, and visitor center. Sternwheelers depart from this park."
+  },
+  "1639846275-196": {
+    "name": "East Clearwater Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=13",
+    "state": "ID",
+    "county": "Nez Perce",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited."
+  },
+  "1639846055-99": {
+    "name": "Washington Boat Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=112",
+    "state": "WA",
+    "county": "Benton"
+  },
+  "1639846156-145": {
+    "name": "Lyons Ferry Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=66",
+    "state": "WA",
+    "county": "Franklin",
+    "campingFee": "$10.75 per tent site",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. A snack bar is available May 25th through Labor Day."
+  },
+  "1639846053-98": {
+    "name": "Oregon Boat Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=113",
+    "state": "OR",
+    "county": "Umatilla"
+  },
+  "1639846074-108": {
+    "name": "Hover Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=103",
+    "state": "WA",
+    "county": "Benton"
+  },
+  "1639846079-110": {
+    "name": "Two Rivers Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=101",
+    "state": "WA",
+    "county": "Benton",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited. Public phones are available."
+  },
+  "1639846183-157": {
+    "name": "Rice Bar Habitat Unit",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=54"
+  },
+  "1639845953-53": {
+    "name": "Event Site( Hood River)(Marina)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=158",
+    "state": "OR",
+    "county": "Hood River"
+  },
+  "1639846161-147": {
+    "name": "Texas Rapids",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=64",
+    "state": "WA",
+    "county": "Columbia",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Charcoal and propane fires are acceptable."
+  },
+  "1639845960-56": {
+    "name": "Swell City",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=155",
+    "state": "WA",
+    "county": "Klickitat",
+    "notes": "Windsurfing and kiteboarding area. Day use fee of $4 per person."
+  },
+  "1639845993-71": {
+    "name": "Peach Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=140",
+    "state": "WA",
+    "notes": "Landing only for hand-carried boats, other boats use Maryhill State Park boat ramp. Privately owned RV Park."
+  },
+  "1639846022-84": {
+    "name": "Earl Snell Memorial Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=127",
+    "state": "OR",
+    "county": "Gilliam"
+  },
+  "1639846222-175": {
+    "name": "Swallows Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=36",
+    "state": "WA",
+    "county": "Asotin",
+    "notes": "Walking trails available"
+  },
+  "1639846196-163": {
+    "name": "Lower Granite Portage Upstream",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=48",
+    "state": "WA",
+    "county": "Garfield"
+  },
+  "1639845946-50": {
+    "name": "Koberg Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=161",
+    "state": "OR",
+    "county": "Hood River",
+    "notes": "Adjacent tribal in lieu fishing site with boat launch and picnic area not open to the public."
+  },
+  "1639846117-127": {
+    "name": "Ice Harbor Portage Upstream",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=84",
+    "state": "WA",
+    "county": "Walla Walla"
+  },
+  "1639846229-178": {
+    "name": "Chief Looking Glass Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=33",
+    "state": "WA",
+    "county": "Asotin"
+  },
+  "1639846224-176": {
+    "name": "ACOE Clarkston Resource Management Office",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=35"
+  },
+  "1639845987-68": {
+    "name": "Celilo Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=143",
+    "state": "OR",
+    "county": "Wasco"
+  },
+  "1639846174-153": {
+    "name": "Ridpath Wildlife Habitat Unit",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=58"
+  },
+  "1639845962-57": {
+    "name": "Rock Creek",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=154",
+    "state": "OR",
+    "county": "Wasco",
+    "notes": "Very primitive area, windsurfing, entrance fee, gravel entrance road and parking lot, blind turn into parking lot under bridge. Only one lane available."
+  },
+  "1639846279-198": {
+    "name": "North Lewiston Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=11",
+    "state": "ID",
+    "county": "Nez Perce"
+  },
+  "1639846172-152": {
+    "name": "Little Goose Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=59",
+    "state": "WA",
+    "county": "Columbia",
+    "notes": "Hunting is prohibited. No open fires allowed from June 10 to October 10. Charcoal and propane fires allowed year round."
+  },
+  "1639846189-160": {
+    "name": "Boyer Park and Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=51",
+    "state": "WA",
+    "county": "Whitman",
+    "campingFee": "$7.00",
+    "notes": "Pets must be kept on a leash. Aircraft landing field located adjacent to park."
+  },
+  "1639845937-46": {
+    "name": "Spring Creek Fish Hatchery Recreation Area",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=165",
+    "state": "WA",
+    "county": "Skamania",
+    "notes": "Windsurfing and kiteboarding spot. No overnight camping nor parking. Day use fee. Visitor center at the fish hatchery. Beach launch only, kayaks possible."
+  },
+  "1639846042-93": {
+    "name": "Irrigon Marina Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=118",
+    "state": "OR",
+    "notes": "Pets must be kept on a leash."
+  },
+  "1639846141-138": {
+    "name": "Matthews",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=73",
+    "state": "WA",
+    "county": "Walla Walla",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited."
+  },
+  "1639846213-171": {
+    "name": "Hells Canyon Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=40",
+    "state": "WA",
+    "county": "Asotin",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed. Charcoal and propane fires are acceptable."
+  },
+  "1639846227-177": {
+    "name": "Hells Gate State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=34",
+    "state": "ID",
+    "county": "Nez Perce",
+    "campingFee": "X"
+  },
+  "1639845985-67": {
+    "name": "Avery Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=144",
+    "notes": "Avery Park is a shared use"
+  },
+  "1639845915-36": {
+    "name": "Bonneville(Washington Shore)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=175",
+    "state": "WA",
+    "county": "Skamania"
+  },
+  "1639846198-164": {
+    "name": "Offield Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=47",
+    "state": "WA",
+    "county": "Garfield",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Charcoal and propane fires are acceptable Boat launch is free of charge."
+  },
+  "1639845854-11": {
+    "name": "Madame Dorian",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=203",
+    "state": "WA",
+    "county": "Walla Walla",
+    "campingFee": "None",
+    "notes": "Madame Dorian sits at the confluence of the Walla Walla River and the Columbia. Paddlers and shallow draft boats will enjoy exploring the wetlands of the Walla Walla delta."
+  },
+  "1639846185-158": {
+    "name": "Illia Dunes",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=53",
+    "state": "WA",
+    "county": "Garfield"
+  },
+  "1639846180-156": {
+    "name": "Willow Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=55",
+    "state": "WA",
+    "county": "Garfield",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited."
+  },
+  "1639845969-60": {
+    "name": "Riverfront Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=151",
+    "state": "OR",
+    "county": "Wasco"
+  },
+  "1639846105-122": {
+    "name": "Hood Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=89",
+    "state": "WA",
+    "county": "Walla Walla"
+  },
+  "1639845991-70": {
+    "name": "Sam Hill Bridge",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=141"
+  },
+  "1639845966-59": {
+    "name": "Mayer State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=152",
+    "state": "OR",
+    "county": "Wasco",
+    "notes": "Migratory bird hunting when in season. Day use fee of $3."
+  },
+  "1639846301-208": {
+    "name": "Canoe Camp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=1",
+    "state": "ID",
+    "county": "Clearwater",
+    "campingFee": "X"
+  },
+  "1639846264-191": {
+    "name": "Arrow Bridge",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=18",
+    "state": "ID"
+  },
+  "1639845942-48": {
+    "name": "Port of Hood River",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=163",
+    "state": "OR",
+    "county": "Hood River"
+  },
+  "1639846152-143": {
+    "name": "Ayer Boat Basin",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=68",
+    "state": "WA",
+    "county": "Walla Walla",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited. Undesignated camping sites can accommodate approximately 20 tents or RV's."
+  },
+  "1639846033-89": {
+    "name": "Boardman Marine Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=122",
+    "state": "OR",
+    "county": "Morrow",
+    "notes": "Pets must be on a leash."
+  },
+  "1639846085-113": {
+    "name": "Clover Island Boat Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=98",
+    "state": "WA",
+    "county": "Benton",
+    "notes": "Adjacent to the Clover Island Inn."
+  },
+  "1639846176-154": {
+    "name": "Port of Garfield",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=57",
+    "state": "WA",
+    "county": "Garfield"
+  },
+  "1639846044-94": {
+    "name": "Plymouth Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=117",
+    "state": "OR",
+    "county": "Umatilla",
+    "campingFee": "12$ per tent sight",
+    "notes": "Fire pits and grills and hot showers."
+  },
+  "1639846205-167": {
+    "name": "Blyton Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=44",
+    "state": "WA",
+    "county": "Whitman",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Charcoal and propane fires are acceptable."
+  },
+  "1639845944-49": {
+    "name": "Bozo Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=162",
+    "state": "WA",
+    "county": "Klickitat"
+  },
+  "1639846000-74": {
+    "name": "Giles French Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=137",
+    "state": "OR",
+    "county": "Sherman",
+    "notes": "Popular fishing spot."
+  },
+  "1639846037-91": {
+    "name": "Irrigon Fish Hatchery",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=120",
+    "state": "OR",
+    "county": "Morrow"
+  },
+  "1639846187-159": {
+    "name": "Illia Landing",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=52",
+    "state": "WA",
+    "county": "Garfield",
+    "notes": "Pets must be kept on a leash. Hunting is prohibited."
+  },
+  "1639846061-102": {
+    "name": "Hat Rock State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=109",
+    "state": "OR",
+    "county": "Umatilla",
+    "notes": "Pets must be kept on a leash. Private campground, store, and caf� nearby, for information visit www.hatrockcampground.com"
+  },
+  "1639846211-170": {
+    "name": "Chief Timothy Habitat Management Unit",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=41",
+    "state": "WA",
+    "county": "Asotin"
+  },
+  "1639846031-88": {
+    "name": "Fishhook Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=123"
+  },
+  "1639846270-194": {
+    "name": "Pepsi Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=15"
+  },
+  "1639846114-126": {
+    "name": "Ice Harbor Dam",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=85",
+    "state": "WA",
+    "county": "Franklin and Walla Walla"
+  },
+  "1639846150-142": {
+    "name": "Devils Bench",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=69",
+    "state": "WA",
+    "county": "Franklin",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited."
+  },
+  "1639846024-85": {
+    "name": "Quesnell Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=126",
+    "state": "OR",
+    "county": "Gilliam"
+  },
+  "1639846013-80": {
+    "name": "Rock Creek Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=131"
+  },
+  "1639846092-116": {
+    "name": "Chiawana Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=95",
+    "state": "WA",
+    "county": "Franklin",
+    "notes": "Pets must be kept on a leash."
+  },
+  "1639846178-155": {
+    "name": "Central Ferry Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=56",
+    "state": "WA",
+    "county": "Whitman",
+    "campingFee": "$17 per standard campsite",
+    "notes": "Pets must be kept on a leash. Golden Age and Access Passports will not be accepted. Hot shower available."
+  },
+  "1639846266-192": {
+    "name": "Area adjacent to railroad bridge just upstream from Spalding on old highway",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=17",
+    "state": "ID"
+  },
+  "1639845982-66": {
+    "name": "Columbia Hills State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=145",
+    "state": "WA",
+    "campingFee": "$17 per standard campsite",
+    "notes": "Pay phone is available."
+  },
+  "1639846191-161": {
+    "name": "Lower Granite Portage Downstream",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=50",
+    "state": "WA",
+    "county": "Garfield"
+  },
+  "1639845964-58": {
+    "name": "Rock Creek Natural Preserve and Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=153",
+    "state": "OR",
+    "county": "Wasco",
+    "notes": "Park only in the gravel area between I-84 and the Railroad Tracks. Overflow parking is East of the Mosier sewage treatment plant parallel to the Railroad Tracks. Parking fees are $5 a day."
+  },
+  "1639845913-35": {
+    "name": "Bonneville(Oregon )",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=176",
+    "state": "OR",
+    "county": "Multnomah"
+  },
+  "1639846194-162": {
+    "name": "Lower Granite Dam",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=49",
+    "state": "WA",
+    "county": "Garfield"
+  },
+  "1639846200-165": {
+    "name": "Wawawai County Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=46",
+    "state": "WA",
+    "county": "Whitman",
+    "campingFee": "$15 per night",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited. No open fires allowed from June 10 through October 10. Water available April 15 to October 15."
+  },
+  "1639845898-29": {
+    "name": "Lambi Creek",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=183",
+    "state": "WA",
+    "county": "Garfield",
+    "campingFee": "None",
+    "notes": "This is the last launching/landing spot for hand-carried boats before Central Ferry, nearly twenty miles downstream."
+  },
+  "1639845836-3": {
+    "name": "Leslie R. Groves Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=211",
+    "state": "OR",
+    "county": "Benton"
+  },
+  "1639845922-39": {
+    "name": "Marina Park( Cascade Locks Boat Ramp)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=172",
+    "state": "OR",
+    "county": "Hood River",
+    "campingFee": "X"
+  },
+  "1639845841-5": {
+    "name": "Steelhead Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=209",
+    "state": "ID",
+    "county": "Nez Perce/Clearwater",
+    "notes": "Also see: North Lewiston Ramp"
+  },
+  "1639845850-9": {
+    "name": "Lenore",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=205",
+    "state": "ID"
+  },
+  "1639846130-133": {
+    "name": "Lake Emma",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=78",
+    "state": "WA",
+    "campingFee": "No fee",
+    "notes": "No designated camping spots."
+  },
+  "1639845883-24": {
+    "name": "Gibbs Eddy",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=190",
+    "state": "ID",
+    "notes": "Parking available"
+  },
+  "1639845935-45": {
+    "name": "Drano Lake",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=166",
+    "state": "WA",
+    "county": "Skamania",
+    "notes": "Boat launch and parking lot only. Day use fee. No overnight camping nor parking."
+  },
+  "1639846006-77": {
+    "name": "Railroad Island",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=134",
+    "state": "WA",
+    "county": "Klickitat"
+  },
+  "1639845926-41": {
+    "name": "Bob's Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=170",
+    "state": "WA",
+    "county": "Skamania",
+    "notes": "Changing rooms available. Adjacent to Columbia Gorge Riverside Lodge."
+  },
+  "1639846167-150": {
+    "name": "Little Goose Dam",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=61",
+    "state": "WA",
+    "county": "Columbia"
+  },
+  "1639846081-111": {
+    "name": "Pasco Boat Basin",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=100",
+    "state": "WA",
+    "county": "Franklin",
+    "notes": "Pets must be kept on a leash."
+  },
+  "1639846216-172": {
+    "name": "Lewiston Levee Parkway",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=39",
+    "state": "ID",
+    "county": "Nez Perice"
+  },
+  "1639846132-134": {
+    "name": "Lost Island (Votaw)",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=77",
+    "state": "WA",
+    "county": "Franklin"
+  },
+  "1639845989-69": {
+    "name": "Heritage Landing State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=142",
+    "state": "OR",
+    "county": "Wasco",
+    "campingFee": "*Boater Pass Fee",
+    "notes": "Caution: access from Columbia River means boating upstream on the Deshutes River. Deschutes Boater Pass may be required, call 800-551-6949. Camping across river at Deschutes State Recreation Area."
+  },
+  "1639846119-128": {
+    "name": "Ramp @ Ice Harbor Dam",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=83",
+    "state": "WA",
+    "county": "Walla Walla"
+  },
+  "1639845971-61": {
+    "name": "Port of the Dalles Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=150",
+    "state": "OR",
+    "county": "Wasco"
+  },
+  "1639846220-174": {
+    "name": "Southway Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=37",
+    "state": "ID",
+    "county": "Nez Perce"
+  },
+  "1639845902-31": {
+    "name": "Sand Station Recreation",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=181",
+    "state": "OR",
+    "county": "Umatilla"
+  },
+  "1639846128-132": {
+    "name": "Fishhook Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=79",
+    "state": "WA",
+    "county": "Walla Walla",
+    "campingFee": "$22.00 Tents Sites, $8.00 Boat Camping",
+    "notes": "No wake area around swimming area. Reservations are accepted for group shelter by calling 509-547-2048."
+  },
+  "1639845839-4": {
+    "name": "Upper Hog Island",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=210",
+    "state": "ID",
+    "county": "Nez Perce/Clearwater"
+  },
+  "1639845843-6": {
+    "name": "Beardy Gulch Fishing Access",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=208",
+    "county": "Nez Perce"
+  },
+  "1639846288-202": {
+    "name": "LenoreAccess",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=7",
+    "state": "ID",
+    "county": "Nez Perce",
+    "notes": "Today the site is covered by highly maintained lawns and trees, but was once a Nez Perce village. An archeological excavation revealed continuous habitation at this site for over 8,000 years."
+  },
+  "1639845891-27": {
+    "name": "Upper Goose Pasture",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=186",
+    "county": "Nez Perce",
+    "notes": "No parking available"
+  },
+  "1639846020-83": {
+    "name": "Port of Arlington Marina",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=128",
+    "state": "OR",
+    "county": "Gilliam",
+    "notes": "Payment is $15/night for RVs and $7/night otherwise. Only 2 tent sites available."
+  },
+  "1639846048-96": {
+    "name": "Umatilla Marina Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=115",
+    "county": "Umatilla",
+    "campingFee": "15$ per tent site",
+    "notes": "Pets must be kept on a leash. Horses and hunting are prohibited."
+  },
+  "1639846277-197": {
+    "name": "Clearwater Ramp",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=12",
+    "state": "ID",
+    "county": "Nez Perce"
+  },
+  "1639845869-18": {
+    "name": "Dougs Beach State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=196",
+    "state": "WA",
+    "county": "Klickitat"
+  },
+  "1639846123-130": {
+    "name": "Levey Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=81",
+    "state": "WA",
+    "county": "Franklin",
+    "notes": "Reservations are accepted for group shelter by calling 509-547-2048 during weekday business hours, but not more than 3 months in advance. A $55.00 reservation fee is required."
+  },
+  "1639845995-72": {
+    "name": "Maryhill State Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=139",
+    "state": "WA",
+    "county": "Klickitat County",
+    "campingFee": "$17 for a standard campsite.",
+    "notes": "Maximum of 8 people per campsite."
+  },
+  "1639846063-103": {
+    "name": "Warehouse Beach",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=108",
+    "state": "OR",
+    "county": "Umatilla"
+  },
+  "1639846096-118": {
+    "name": "Bateman Island",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=93"
+  },
+  "1639846158-146": {
+    "name": "Tucannon WLF Habitat Unit",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=65"
+  },
+  "1639846108-123": {
+    "name": "Hood Park",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=88",
+    "state": "WA",
+    "county": "Walla Walla",
+    "campingFee": "$18 per site",
+    "notes": "Pets must be on leash, and horses/hunting are prohibited. Reservations accepted for group shelters by calling (509)-547-2048, but cannot be made more than 3 months in advance."
+  },
+  "1639846236-181": {
+    "name": "McGill Hole",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=30",
+    "state": "ID"
+  },
+  "1639846250-185": {
+    "name": "Lower Hog Island",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=24",
+    "state": "ID",
+    "county": "Nez Perce"
+  },
+  "1639846077-109": {
+    "name": "McNary National Wildlife Refuge",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=102",
+    "state": "WA",
+    "county": "Umatilla"
+  },
+  "1639846299-207": {
+    "name": "Pink House",
+    "sourceUrl": "http://www.ndwt.org/ndwt/explore/site.asp?site=2",
+    "state": "ID",
+    "campingFee": "$10/night for campsite.",
+    "notes": "Maximum of a 14 day stay. Handicap accessible."
+  }
+}

--- a/scripts/scrape-ndwt-sites.ts
+++ b/scripts/scrape-ndwt-sites.ts
@@ -1,0 +1,202 @@
+/**
+ * One-shot scraper that walks every ndwt.org site detail page and
+ * captures fields the GeoJSON dataset is missing: site name, state,
+ * county, camping fee, notes.
+ *
+ * Run with:
+ *   npm run scrape:sites
+ *
+ * Re-run manually if ndwt.org changes. The output JSON is committed
+ * to the repo and merged into the build at load time. See
+ * docs/plans/feature-parity.md § Phase 8.
+ *
+ * Permission to reuse ndwt.org content was granted by the
+ * Washington Water Trails Association Executive Director — see
+ * NOTICE.md at the repo root.
+ */
+
+import { JSDOM, VirtualConsole } from 'jsdom';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const silentConsole = new VirtualConsole();
+silentConsole.on('error', () => {
+  /* drop CSS @import warnings */
+});
+
+const REPO_ROOT = process.cwd();
+const GEOJSON_PATH = join(REPO_ROOT, 'public', 'data', 'ndwt.geojson');
+const OUTPUT_PATH = join(REPO_ROOT, 'public', 'data', 'ndwt-enriched.json');
+
+const REQUEST_DELAY_MS = 250;
+const REQUEST_TIMEOUT_MS = 20_000;
+const USER_AGENT =
+  'ndwt-ol-chakra phase-8 scraper (one-shot data enrichment; ' +
+  'authorized by WWTA - github.com/ivanoats/ndwt-ol-chakra)';
+
+interface RawFeature {
+  readonly properties: Record<string, string | undefined>;
+}
+interface RawFeatureCollection {
+  readonly features: readonly RawFeature[];
+}
+
+export interface EnrichedSite {
+  readonly name: string;
+  readonly state?: string;
+  readonly county?: string;
+  readonly campingFee?: string;
+  readonly notes?: string;
+  readonly sourceUrl: string;
+}
+
+const ID_KEYS = ['web-scraper-order', '﻿web-scraper-order'] as const;
+
+const readId = (props: RawFeature['properties']): string | null => {
+  for (const key of ID_KEYS) {
+    const v = props[key];
+    if (v !== undefined && v !== '') return v;
+  }
+  return null;
+};
+
+const collapseWhitespace = (s: string): string => s.replace(/\s+/g, ' ').trim();
+
+const labelOf = (em: Element): string =>
+  collapseWhitespace(em.textContent ?? '').replace(/\s*$/, '');
+
+/**
+ * The ndwt.org template renders every labeled field as
+ * `<td><em>Label</em></td><td><div align="right">value</div></td>`.
+ * We collect every such label/value pair into a map.
+ */
+const extractLabeledFields = (doc: Document): Map<string, string> => {
+  const out = new Map<string, string>();
+  for (const em of doc.querySelectorAll('em')) {
+    const label = labelOf(em);
+    if (label === '') continue;
+    const cell = em.closest('td');
+    const valueCell = cell?.nextElementSibling;
+    if (valueCell === undefined || valueCell === null) continue;
+    const value = collapseWhitespace(valueCell.textContent ?? '');
+    if (value !== '') out.set(label, value);
+  }
+  return out;
+};
+
+/**
+ * Notes live in their own table whose header cell contains
+ * "Notes" inside `<span class="style1">`. The free-text body sits
+ * in the second `<td>` of the next `<tr>`.
+ */
+const extractNotes = (doc: Document): string | undefined => {
+  for (const span of doc.querySelectorAll('span.style1')) {
+    if (collapseWhitespace(span.textContent ?? '') !== 'Notes') continue;
+    const headerRow = span.closest('tr');
+    const bodyRow = headerRow?.nextElementSibling;
+    if (bodyRow === undefined || bodyRow === null) continue;
+    const cells = bodyRow.querySelectorAll('td');
+    const last = cells[cells.length - 1];
+    if (last === undefined) continue;
+    const text = collapseWhitespace(last.textContent ?? '');
+    if (text !== '' && text !== ' ') return text;
+    return undefined;
+  }
+  return undefined;
+};
+
+const parseSitePage = (html: string, sourceUrl: string): EnrichedSite => {
+  const dom = new JSDOM(html, { virtualConsole: silentConsole });
+  const doc = dom.window.document;
+  const h1 = doc.querySelector('h1');
+  const name = collapseWhitespace(h1?.textContent ?? '');
+  if (name === '') {
+    throw new Error(`No <h1> site name in ${sourceUrl}`);
+  }
+  const labels = extractLabeledFields(doc);
+  const notes = extractNotes(doc);
+
+  const out: { -readonly [K in keyof EnrichedSite]?: EnrichedSite[K] } = {
+    name,
+    sourceUrl,
+  };
+  const state = labels.get('State');
+  if (state !== undefined) out.state = state;
+  const county = labels.get('County');
+  if (county !== undefined) out.county = county;
+  const fee = labels.get('Camping Fee');
+  if (fee !== undefined) out.campingFee = fee;
+  if (notes !== undefined) out.notes = notes;
+  return out as EnrichedSite;
+};
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const fetchHtml = async (url: string): Promise<string> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+    }
+    return await res.text();
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const text = await readFile(GEOJSON_PATH, 'utf-8');
+  const body = JSON.parse(text) as RawFeatureCollection;
+
+  const enriched: Record<string, EnrichedSite> = {};
+  let attempted = 0;
+  let succeeded = 0;
+  const failures: Array<{ id: string; url: string; error: string }> = [];
+
+  for (const feature of body.features) {
+    const id = readId(feature.properties);
+    const url = feature.properties['web-scraper-start-url'];
+    if (id === null || url === undefined || url === '') {
+      console.warn(
+        `Skipping feature without id or url: ${JSON.stringify(feature.properties).slice(0, 80)}`
+      );
+      continue;
+    }
+    attempted++;
+    try {
+      const html = await fetchHtml(url);
+      enriched[id] = parseSitePage(html, url);
+      succeeded++;
+      process.stdout.write(
+        `\r[${succeeded}/${body.features.length}] ${enriched[id].name.padEnd(40).slice(0, 40)}`
+      );
+    } catch (cause) {
+      const error = cause instanceof Error ? cause.message : String(cause);
+      failures.push({ id, url, error });
+      console.warn(`\nFailed ${id} (${url}): ${error}`);
+    }
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  process.stdout.write('\n');
+  await writeFile(OUTPUT_PATH, JSON.stringify(enriched, null, 2) + '\n');
+  console.log(
+    `Wrote ${OUTPUT_PATH}: ${succeeded}/${attempted} sites enriched.`
+  );
+  if (failures.length > 0) {
+    console.log(`${failures.length} failures:`);
+    for (const f of failures) console.log(`  ${f.id}\t${f.url}\t${f.error}`);
+    process.exit(1);
+  }
+};
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/scrape-ndwt-sites.ts
+++ b/scripts/scrape-ndwt-sites.ts
@@ -52,6 +52,26 @@ export interface EnrichedSite {
 
 const ID_KEYS = ['web-scraper-order', '﻿web-scraper-order'] as const;
 
+/**
+ * Manual fix-ups for known typos in ndwt.org's source data. The
+ * upstream site is being retired and the typos won't be corrected
+ * there, so we patch them at scrape time.
+ */
+const COUNTY_CORRECTIONS: Readonly<Record<string, string>> = {
+  'Nez Perice': 'Nez Perce',
+};
+
+/**
+ * Bare placeholder values that should be dropped, not displayed.
+ * Anything else (including "Free", "None", "No fee") is meaningful.
+ */
+const PLACEHOLDER_VALUES: ReadonlySet<string> = new Set(['X', 'x']);
+
+const dropIfPlaceholder = (value: string | undefined): string | undefined => {
+  if (value === undefined) return undefined;
+  return PLACEHOLDER_VALUES.has(value) ? undefined : value;
+};
+
 const readId = (props: RawFeature['properties']): string | null => {
   for (const key of ID_KEYS) {
     const v = props[key];
@@ -122,9 +142,11 @@ const parseSitePage = (html: string, sourceUrl: string): EnrichedSite => {
   };
   const state = labels.get('State');
   if (state !== undefined) out.state = state;
-  const county = labels.get('County');
-  if (county !== undefined) out.county = county;
-  const fee = labels.get('Camping Fee');
+  const rawCounty = labels.get('County');
+  if (rawCounty !== undefined) {
+    out.county = COUNTY_CORRECTIONS[rawCounty] ?? rawCounty;
+  }
+  const fee = dropIfPlaceholder(labels.get('Camping Fee'));
   if (fee !== undefined) out.campingFee = fee;
   if (notes !== undefined) out.notes = notes;
   return out as EnrichedSite;
@@ -133,6 +155,14 @@ const parseSitePage = (html: string, sourceUrl: string): EnrichedSite => {
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/**
+ * ndwt.org declares `charset=iso-8859-1` in its `<meta>`. `res.text()`
+ * defaults to UTF-8, which mangles bytes 0x80–0xFF (e.g. the é in
+ * "café" becomes a replacement character). We decode as windows-1252
+ * — a strict superset of ISO-8859-1 that also handles smart quotes,
+ * em-dashes, and the rest of the Western typography legacy ASP sites
+ * tend to leak in.
+ */
 const fetchHtml = async (url: string): Promise<string> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -144,7 +174,8 @@ const fetchHtml = async (url: string): Promise<string> => {
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
     }
-    return await res.text();
+    const buffer = await res.arrayBuffer();
+    return new TextDecoder('windows-1252').decode(buffer);
   } finally {
     clearTimeout(timer);
   }

--- a/scripts/scrape-ndwt-sites.ts
+++ b/scripts/scrape-ndwt-sites.ts
@@ -74,8 +74,8 @@ const dropIfPlaceholder = (value: string | undefined): string | undefined => {
 
 const readId = (props: RawFeature['properties']): string | null => {
   for (const key of ID_KEYS) {
-    const v = props[key];
-    if (v !== undefined && v !== '') return v;
+    const value = props[key];
+    if (value !== undefined && value !== '') return value;
   }
   return null;
 };
@@ -216,18 +216,23 @@ const main = async (): Promise<void> => {
   }
 
   process.stdout.write('\n');
-  await writeFile(OUTPUT_PATH, JSON.stringify(enriched, null, 2) + '\n');
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(enriched, null, 2)}\n`);
   console.log(
     `Wrote ${OUTPUT_PATH}: ${succeeded}/${attempted} sites enriched.`
   );
   if (failures.length > 0) {
     console.log(`${failures.length} failures:`);
     for (const f of failures) console.log(`  ${f.id}\t${f.url}\t${f.error}`);
-    process.exit(1);
+    throw new Error(
+      `${failures.length} of ${attempted} sites failed to scrape; see log above.`
+    );
   }
 };
 
 main().catch((err: unknown) => {
   console.error(err);
-  process.exit(1);
+  // Set exitCode rather than calling process.exit() so the
+  // event loop drains naturally — DeepSource flags the abrupt
+  // exit and the loop is empty here anyway.
+  process.exitCode = 1;
 });

--- a/src/__tests__/MapApp.test.tsx
+++ b/src/__tests__/MapApp.test.tsx
@@ -17,6 +17,7 @@ import MapApp from '../components/MapApp';
 const fakeSites: readonly Site[] = [
   {
     id: siteId('test'),
+    name: 'Test Site',
     riverSegment: '',
     riverName: 'Columbia',
     riverMile: 0,

--- a/src/__tests__/composition-root.test.ts
+++ b/src/__tests__/composition-root.test.ts
@@ -5,6 +5,7 @@ import { coordinates, FacilitySet, type Site, siteId } from '../domain';
 
 const baseSite: Site = {
   id: siteId('a'),
+  name: 'Site A',
   riverSegment: '',
   riverName: 'Columbia',
   riverMile: 0,

--- a/src/adapters/inbound/next/__tests__/load-sites.test.ts
+++ b/src/adapters/inbound/next/__tests__/load-sites.test.ts
@@ -39,13 +39,14 @@ const enoent = (): NodeJS.ErrnoException => {
 };
 
 const stubReads = (geojson: string, enriched: string | Error): void => {
-  mockReadFile.mockImplementation(async (path: string) => {
-    if (path.endsWith('ndwt.geojson')) return geojson;
+  mockReadFile.mockImplementation((path: string): Promise<string> => {
+    if (path.endsWith('ndwt.geojson')) return Promise.resolve(geojson);
     if (path.endsWith('ndwt-enriched.json')) {
-      if (enriched instanceof Error) throw enriched;
-      return enriched;
+      return enriched instanceof Error
+        ? Promise.reject(enriched)
+        : Promise.resolve(enriched);
     }
-    throw new Error(`unexpected read: ${path}`);
+    return Promise.reject(new Error(`unexpected read: ${path}`));
   });
 };
 
@@ -83,7 +84,9 @@ describe('loadSites', () => {
   });
 
   it('falls back to "RiverName River — Mile NN" when the enriched file is missing', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     stubReads(validGeoJson, enoent());
     const sites = await loadSites();
     expect(sites[0]?.name).toBe('Columbia River — Mile 234');
@@ -117,9 +120,9 @@ describe('loadSites', () => {
 
   it('propagates fs errors as-is on the GeoJSON read', async () => {
     const err = new Error('boom');
-    mockReadFile.mockImplementation(async (path: string) => {
-      if (path.endsWith('ndwt.geojson')) throw err;
-      return validEnriched;
+    mockReadFile.mockImplementation((path: string): Promise<string> => {
+      if (path.endsWith('ndwt.geojson')) return Promise.reject(err);
+      return Promise.resolve(validEnriched);
     });
     await expect(loadSites()).rejects.toBe(err);
   });

--- a/src/adapters/inbound/next/__tests__/load-sites.test.ts
+++ b/src/adapters/inbound/next/__tests__/load-sites.test.ts
@@ -15,11 +15,39 @@ const validGeoJson = JSON.stringify({
   features: [
     {
       type: 'Feature',
-      properties: { riverName: 'Columbia', riverMile: '234' },
+      properties: {
+        'web-scraper-order': 'abc-1',
+        riverName: 'Columbia',
+        riverMile: '234',
+      },
       geometry: { type: 'Point', coordinates: [-120.37, 45.695] },
     },
   ],
 });
+
+const validEnriched = JSON.stringify({
+  'abc-1': {
+    name: 'Blalock Canyon',
+    state: 'OR',
+  },
+});
+
+const enoent = (): NodeJS.ErrnoException => {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+};
+
+const stubReads = (geojson: string, enriched: string | Error): void => {
+  mockReadFile.mockImplementation(async (path: string) => {
+    if (path.endsWith('ndwt.geojson')) return geojson;
+    if (path.endsWith('ndwt-enriched.json')) {
+      if (enriched instanceof Error) throw enriched;
+      return enriched;
+    }
+    throw new Error(`unexpected read: ${path}`);
+  });
+};
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -27,7 +55,7 @@ afterEach(() => {
 
 describe('loadSites', () => {
   it('reads GeoJSON from public/data and returns a parsed Site[]', async () => {
-    mockReadFile.mockResolvedValue(validGeoJson);
+    stubReads(validGeoJson, validEnriched);
     const sites = await loadSites();
     expect(sites).toHaveLength(1);
     expect(sites[0]?.riverName).toBe('Columbia');
@@ -35,22 +63,64 @@ describe('loadSites', () => {
   });
 
   it('reads from process.cwd()/public/data/ndwt.geojson', async () => {
-    mockReadFile.mockResolvedValue(validGeoJson);
+    stubReads(validGeoJson, validEnriched);
     await loadSites();
     expect(mockReadFile).toHaveBeenCalledWith(
       expect.stringContaining('public/data/ndwt.geojson'),
       'utf-8'
     );
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.stringContaining('public/data/ndwt-enriched.json'),
+      'utf-8'
+    );
+  });
+
+  it('merges enriched name + state into the parsed Site', async () => {
+    stubReads(validGeoJson, validEnriched);
+    const sites = await loadSites();
+    expect(sites[0]?.name).toBe('Blalock Canyon');
+    expect(sites[0]?.state).toBe('OR');
+  });
+
+  it('falls back to "RiverName River — Mile NN" when the enriched file is missing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubReads(validGeoJson, enoent());
+    const sites = await loadSites();
+    expect(sites[0]?.name).toBe('Columbia River — Mile 234');
+    expect(sites[0]?.state).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No enriched data')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('falls back when the enriched file lacks a record for this id', async () => {
+    stubReads(
+      validGeoJson,
+      JSON.stringify({ 'other-id': { name: 'Some Other Site' } })
+    );
+    const sites = await loadSites();
+    expect(sites[0]?.name).toBe('Columbia River — Mile 234');
   });
 
   it('throws a path-bearing error on JSON parse failure', async () => {
-    mockReadFile.mockResolvedValue('{not json');
+    stubReads('{not json', validEnriched);
     await expect(loadSites()).rejects.toThrow(/Failed to parse GeoJSON at/);
   });
 
-  it('propagates fs errors as-is', async () => {
-    const enoent = new Error('ENOENT');
-    mockReadFile.mockRejectedValue(enoent);
-    await expect(loadSites()).rejects.toBe(enoent);
+  it('wraps enriched-JSON parse errors with a useful path', async () => {
+    stubReads(validGeoJson, '{not json');
+    await expect(loadSites()).rejects.toThrow(
+      /Failed to parse enriched site data at/
+    );
+  });
+
+  it('propagates fs errors as-is on the GeoJSON read', async () => {
+    const err = new Error('boom');
+    mockReadFile.mockImplementation(async (path: string) => {
+      if (path.endsWith('ndwt.geojson')) throw err;
+      return validEnriched;
+    });
+    await expect(loadSites()).rejects.toBe(err);
   });
 });

--- a/src/adapters/inbound/next/load-sites.ts
+++ b/src/adapters/inbound/next/load-sites.ts
@@ -5,28 +5,56 @@ import 'server-only';
 
 import type { Site } from '../../../domain';
 import {
+  type EnrichedSiteIndex,
   parseSitesFromGeoJson,
   type RawFeatureCollection,
 } from '../../outbound/geojson-site-repository';
 
 const GEOJSON_PATH = ['public', 'data', 'ndwt.geojson'] as const;
+const ENRICHED_PATH = ['public', 'data', 'ndwt-enriched.json'] as const;
+
+const readEnriched = async (path: string): Promise<EnrichedSiteIndex> => {
+  try {
+    const text = await readFile(path, 'utf-8');
+    return JSON.parse(text) as EnrichedSiteIndex;
+  } catch (cause) {
+    if (
+      typeof cause === 'object' &&
+      cause !== null &&
+      'code' in cause &&
+      (cause as { code?: string }).code === 'ENOENT'
+    ) {
+      console.warn(
+        `[load-sites] No enriched data at ${path}; site names will fall back to "RiverName River — Mile NN".`
+      );
+      return {};
+    }
+    throw new Error(`Failed to parse enriched site data at ${path}`, {
+      cause,
+    });
+  }
+};
 
 /**
  * Build-time site loader for App Router server components. Reads the
  * GeoJSON straight off disk via fs/promises (so it's pre-rendered
- * into the static page bundle, no runtime fetch) and runs it through
- * the same parser the client uses for the fetch path. JSON.parse
- * errors are wrapped so a corrupted file fails the build with a
- * useful path.
+ * into the static page bundle, no runtime fetch) and merges in the
+ * scraped name / state / county / camping fee / notes data from
+ * `public/data/ndwt-enriched.json`. JSON.parse errors are wrapped
+ * so a corrupted file fails the build with a useful path.
  */
 export async function loadSites(): Promise<readonly Site[]> {
-  const path = join(process.cwd(), ...GEOJSON_PATH);
-  const text = await readFile(path, 'utf-8');
+  const geojsonPath = join(process.cwd(), ...GEOJSON_PATH);
+  const enrichedPath = join(process.cwd(), ...ENRICHED_PATH);
+  const [text, enriched] = await Promise.all([
+    readFile(geojsonPath, 'utf-8'),
+    readEnriched(enrichedPath),
+  ]);
   let body: RawFeatureCollection;
   try {
     body = JSON.parse(text) as RawFeatureCollection;
   } catch (cause) {
-    throw new Error(`Failed to parse GeoJSON at ${path}`, { cause });
+    throw new Error(`Failed to parse GeoJSON at ${geojsonPath}`, { cause });
   }
-  return parseSitesFromGeoJson(body);
+  return parseSitesFromGeoJson(body, enriched);
 }

--- a/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
@@ -40,6 +40,7 @@ describe('GeoJsonSiteRepository.list()', () => {
     for (const site of sites) {
       expect(typeof site.id).toBe('string');
       expect(site.id.length).toBeGreaterThan(0);
+      expect(site.name.length).toBeGreaterThan(0);
       expect(site.coordinates.longitude).toBeGreaterThan(-180);
       expect(site.coordinates.longitude).toBeLessThan(180);
       expect(site.coordinates.latitude).toBeGreaterThan(-90);
@@ -132,5 +133,53 @@ describe('toSite mapper', () => {
     const site = __test.toSite(feature, 42);
     expect(site.id).toBe('site-42');
     expect(site.riverMile).toBe(0);
+  });
+
+  it('uses the river-and-mile fallback name when no enriched record exists', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {
+        'web-scraper-order': '1639846015-81',
+        riverName: 'Columbia',
+        riverMile: '234',
+      },
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [-120.37, 45.695] as [number, number],
+      },
+    };
+    const site = __test.toSite(feature, 0);
+    expect(site.name).toBe('Columbia River — Mile 234');
+    expect(site.state).toBeUndefined();
+    expect(site.notes).toBeUndefined();
+  });
+
+  it('prefers the enriched record name and merges in optional fields', () => {
+    const feature = {
+      type: 'Feature' as const,
+      properties: {
+        'web-scraper-order': '1639845856-12',
+        riverName: 'Clearwater',
+        riverMile: '34',
+      },
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [-116.45002, 46.49144] as [number, number],
+      },
+    };
+    const enriched = {
+      '1639845856-12': {
+        name: "Harper's Bend",
+        state: 'ID',
+        county: 'Nez Perce',
+        notes: 'Popular site for fishing.',
+      },
+    };
+    const site = __test.toSite(feature, 0, enriched);
+    expect(site.name).toBe("Harper's Bend");
+    expect(site.state).toBe('ID');
+    expect(site.county).toBe('Nez Perce');
+    expect(site.notes).toBe('Popular site for fishing.');
+    expect(site.campingFee).toBeUndefined();
   });
 });

--- a/src/adapters/outbound/__tests__/in-memory-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/in-memory-site-repository.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { coordinates, FacilitySet, type Site, siteId } from '../../../domain';
 import { InMemorySiteRepository } from '../in-memory-site-repository';
 
-const makeSite = (id: string, name = 'Columbia'): Site => ({
+const makeSite = (id: string, riverName = 'Columbia'): Site => ({
   id: siteId(id),
+  name: `${riverName} River — Mile 0`,
   riverSegment: '',
-  riverName: name,
+  riverName,
   riverMile: 0,
   bank: '',
   coordinates: coordinates(0, 0),

--- a/src/adapters/outbound/__tests__/site-to-gpx.test.ts
+++ b/src/adapters/outbound/__tests__/site-to-gpx.test.ts
@@ -76,14 +76,22 @@ describe('siteToGpx', () => {
 });
 
 describe('gpxFilename', () => {
-  it('slugifies the canonical site name', () => {
-    expect(gpxFilename(baseSite)).toBe('blalock-canyon.gpx');
+  it('slugifies the canonical site name and appends the river mile', () => {
+    expect(gpxFilename(baseSite)).toBe('blalock-canyon-mile-234.gpx');
     expect(gpxFilename({ ...baseSite, name: "Harper's Bend" })).toBe(
-      'harper-s-bend.gpx'
+      'harper-s-bend-mile-234.gpx'
     );
   });
 
+  it('encodes decimal miles with a dash so the filename stays portable', () => {
+    expect(
+      gpxFilename({ ...baseSite, name: 'Hood Park', riverMile: 2.5 })
+    ).toBe('hood-park-mile-2-5.gpx');
+  });
+
   it('falls back to "waypoint" when name has no slug-friendly chars', () => {
-    expect(gpxFilename({ ...baseSite, name: '???' })).toBe('waypoint.gpx');
+    expect(gpxFilename({ ...baseSite, name: '???', riverMile: 0 })).toBe(
+      'waypoint-mile-0.gpx'
+    );
   });
 });

--- a/src/adapters/outbound/__tests__/site-to-gpx.test.ts
+++ b/src/adapters/outbound/__tests__/site-to-gpx.test.ts
@@ -5,6 +5,7 @@ import { gpxFilename, siteToGpx } from '../site-to-gpx';
 
 const baseSite: Site = {
   id: siteId('x'),
+  name: 'Blalock Canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,
@@ -25,14 +26,13 @@ describe('siteToGpx', () => {
     expect(gpx).toContain('lon="-120.37"');
   });
 
-  it('uses the river-and-mile string as the waypoint name', () => {
-    expect(siteToGpx(baseSite)).toContain(
-      '<name>Columbia River — Mile 234</name>'
-    );
+  it('uses the canonical site name as the waypoint name', () => {
+    expect(siteToGpx(baseSite)).toContain('<name>Blalock Canyon</name>');
   });
 
-  it('packs segment, bank, season, contact, and facilities into desc', () => {
+  it('puts the river-and-mile context, segment, bank, season, contact, and facilities in desc', () => {
     const gpx = siteToGpx(baseSite);
+    expect(gpx).toContain('Columbia River — Mile 234');
     expect(gpx).toContain('Lake Umatilla');
     expect(gpx).toContain('Bank: OR');
     expect(gpx).toContain('Season: year round');
@@ -40,13 +40,23 @@ describe('siteToGpx', () => {
     expect(gpx).toContain('Facilities: Restrooms, Boat ramp');
   });
 
+  it('includes camping fee and notes when present', () => {
+    const gpx = siteToGpx({
+      ...baseSite,
+      campingFee: '$10/night',
+      notes: 'Popular salmon fishing.',
+    });
+    expect(gpx).toContain('Camping fee: $10/night');
+    expect(gpx).toContain('Notes: Popular salmon fishing.');
+  });
+
   it('escapes XML special characters in name and description', () => {
     const gpx = siteToGpx({
       ...baseSite,
-      riverName: 'Snake & Co',
+      name: 'Snake & Co',
       contact: 'Fish <Wildlife>',
     });
-    expect(gpx).toContain('Snake &amp; Co River');
+    expect(gpx).toContain('<name>Snake &amp; Co</name>');
     expect(gpx).toContain('Contact: Fish &lt;Wildlife&gt;');
   });
 
@@ -66,13 +76,14 @@ describe('siteToGpx', () => {
 });
 
 describe('gpxFilename', () => {
-  it('builds a slugified filename from river + mile', () => {
-    expect(gpxFilename(baseSite)).toBe('columbia-mile-234.gpx');
+  it('slugifies the canonical site name', () => {
+    expect(gpxFilename(baseSite)).toBe('blalock-canyon.gpx');
+    expect(gpxFilename({ ...baseSite, name: "Harper's Bend" })).toBe(
+      'harper-s-bend.gpx'
+    );
   });
 
-  it('falls back to "waypoint" when riverName has no slug-friendly chars', () => {
-    expect(gpxFilename({ ...baseSite, riverName: '???', riverMile: 0 })).toBe(
-      'waypoint-mile-0.gpx'
-    );
+  it('falls back to "waypoint" when name has no slug-friendly chars', () => {
+    expect(gpxFilename({ ...baseSite, name: '???' })).toBe('waypoint.gpx');
   });
 });

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -30,6 +30,17 @@ export interface RawFeatureCollection {
 const ID_KEY_CANDIDATES = ['web-scraper-order', '﻿web-scraper-order'] as const;
 const SOURCE_URL_KEYS = ['web-scraper-start-url'] as const;
 
+export interface EnrichedSiteRecord {
+  readonly name: string;
+  readonly state?: string;
+  readonly county?: string;
+  readonly campingFee?: string;
+  readonly notes?: string;
+  readonly sourceUrl?: string;
+}
+
+export type EnrichedSiteIndex = Readonly<Record<string, EnrichedSiteRecord>>;
+
 const readProp = (
   props: RawProps,
   ...keys: readonly string[]
@@ -49,24 +60,40 @@ const facilityFlags = (props: RawProps): Partial<Record<Facility, boolean>> => {
   return flags;
 };
 
-const toSite = (feature: RawFeature, index: number): Site => {
+const fallbackName = (riverName: string, riverMile: number): string =>
+  `${riverName} River — Mile ${riverMile}`;
+
+const toSite = (
+  feature: RawFeature,
+  index: number,
+  enriched?: EnrichedSiteIndex
+): Site => {
   const props = feature.properties;
   const [lng, lat] = feature.geometry.coordinates;
   const idRaw = readProp(props, ...ID_KEY_CANDIDATES) ?? `site-${index}`;
   const mile = Number(readProp(props, 'riverMile') ?? '');
+  const riverName = readProp(props, 'riverName') ?? '';
+  const riverMile = Number.isFinite(mile) ? mile : 0;
+  const enrichedRecord = enriched?.[idRaw];
+  const name = enrichedRecord?.name ?? fallbackName(riverName, riverMile);
 
   return {
     id: siteId(idRaw),
+    name,
     riverSegment: readProp(props, 'riverSegment') ?? '',
-    riverName: readProp(props, 'riverName') ?? '',
-    riverMile: Number.isFinite(mile) ? mile : 0,
+    riverName,
+    riverMile,
     bank: readProp(props, 'bank') ?? '',
     coordinates: coordinates(lng, lat),
+    state: enrichedRecord?.state,
+    county: enrichedRecord?.county,
     season: readProp(props, 'season'),
     camping: readProp(props, 'camping'),
+    campingFee: enrichedRecord?.campingFee,
     contact: readProp(props, 'contact'),
     phone: readProp(props, 'phone'),
     website: readProp(props, 'website'),
+    notes: enrichedRecord?.notes,
     facilities: FacilitySet.fromFlags(facilityFlags(props)),
     sourceUrl: readProp(props, ...SOURCE_URL_KEYS),
   };
@@ -76,11 +103,18 @@ const toSite = (feature: RawFeature, index: number): Site => {
  * Pure mapper from a parsed GeoJSON FeatureCollection to a Site[].
  * Used by both the runtime fetch path (this file's class) and the
  * build-time fs path (src/adapters/inbound/next/load-sites.ts).
+ *
+ * The optional `enriched` lookup (keyed by the raw web-scraper-order
+ * id) supplies the canonical site name plus state, county, camping
+ * fee, and notes — fields that aren't in the GeoJSON. When a
+ * feature has no enriched record, the parser falls back to a
+ * "RiverName River — Mile NN" placeholder for `name`.
  */
 export const parseSitesFromGeoJson = (
-  body: RawFeatureCollection
+  body: RawFeatureCollection,
+  enriched?: EnrichedSiteIndex
 ): readonly Site[] =>
-  body.features.map((feature, index) => toSite(feature, index));
+  body.features.map((feature, index) => toSite(feature, index, enriched));
 
 export class GeoJsonSiteRepository implements SiteRepository {
   private cache: readonly Site[] | null = null;

--- a/src/adapters/outbound/site-to-gpx.ts
+++ b/src/adapters/outbound/site-to-gpx.ts
@@ -20,17 +20,18 @@ const escapeXml = (raw: string): string =>
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&apos;');
 
-const waypointName = (site: Site): string =>
-  `${site.riverName} River — Mile ${site.riverMile}`;
+const waypointName = (site: Site): string => site.name;
 
 const waypointDescription = (site: Site): string => {
-  const parts: string[] = [];
+  const parts: string[] = [`${site.riverName} River — Mile ${site.riverMile}`];
   if (site.riverSegment !== '') parts.push(site.riverSegment);
   if (site.bank !== '') parts.push(`Bank: ${site.bank}`);
   if (site.season !== undefined && site.season !== '')
     parts.push(`Season: ${site.season}`);
   if (site.camping !== undefined && site.camping !== '')
     parts.push(`Camping: ${site.camping}`);
+  if (site.campingFee !== undefined && site.campingFee !== '')
+    parts.push(`Camping fee: ${site.campingFee}`);
   if (site.contact !== undefined && site.contact !== '')
     parts.push(`Contact: ${site.contact}`);
   if (site.phone !== undefined && site.phone !== '')
@@ -39,6 +40,8 @@ const waypointDescription = (site: Site): string => {
     (facility) => FACILITY_LABELS[facility]
   );
   if (facilities.length > 0) parts.push(`Facilities: ${facilities.join(', ')}`);
+  if (site.notes !== undefined && site.notes !== '')
+    parts.push(`Notes: ${site.notes}`);
   return parts.join('\n');
 };
 
@@ -68,10 +71,10 @@ export const gpxFilename = (site: Site): string => {
   // to single dashes, so the only place a dash can lead or trail is
   // a single character — slice it off without a regex (avoids
   // Sonar's S5852 ReDoS heuristic on anchored quantifiers).
-  const collapsed = site.riverName.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+  const collapsed = site.name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
   const start = collapsed.startsWith('-') ? 1 : 0;
   const end = collapsed.length - (collapsed.endsWith('-') ? 1 : 0);
   const trimmed = collapsed.slice(start, end);
   const namePart = trimmed === '' ? 'waypoint' : trimmed;
-  return `${namePart}-mile-${site.riverMile}.gpx`;
+  return `${namePart}.gpx`;
 };

--- a/src/adapters/outbound/site-to-gpx.ts
+++ b/src/adapters/outbound/site-to-gpx.ts
@@ -76,5 +76,12 @@ export const gpxFilename = (site: Site): string => {
   const end = collapsed.length - (collapsed.endsWith('-') ? 1 : 0);
   const trimmed = collapsed.slice(start, end);
   const namePart = trimmed === '' ? 'waypoint' : trimmed;
-  return `${namePart}.gpx`;
+  // Append river mile for collision avoidance — three site names
+  // appear twice in the dataset (Hood Park, Fishhook Park,
+  // Granite Point). River mile disambiguates two of them; the
+  // remaining Granite Point pair sits at the same mile and is
+  // only resolved when Phase 9's slug logic adds a final id-based
+  // tiebreaker. Decimal miles (e.g. 2.5) become "2-5".
+  const milePart = `${site.riverMile}`.replaceAll('.', '-');
+  return `${namePart}-mile-${milePart}.gpx`;
 };

--- a/src/components/__tests__/map-handlers.test.ts
+++ b/src/components/__tests__/map-handlers.test.ts
@@ -27,6 +27,7 @@ const fakeMap = (overrides: Partial<FakeMap> = {}): FakeMap => ({
 
 const baseSite: Site = {
   id: siteId('feat-1'),
+  name: 'Blalock Canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -15,13 +15,12 @@ import { Text } from '../ui/text';
 
 import FacilityBadges from './FacilityBadges';
 
-const formatTitle = (site: Site): string =>
-  `${site.riverName} River — Mile ${site.riverMile}`;
-
-const formatSubheading = (site: Site): string =>
-  [site.riverSegment, site.bank]
+const formatSubheading = (site: Site): string => {
+  const riverPart = `${site.riverName} River · Mile ${site.riverMile}`;
+  return [riverPart, site.riverSegment, site.bank]
     .filter((part): part is string => part !== undefined && part !== '')
     .join(' · ');
+};
 
 const formatCoordinates = ({
   latitude,
@@ -100,10 +99,17 @@ const WebsiteRow = ({ url }: WebsiteRowProps) => {
   );
 };
 
+const formatLocation = (site: Site): string | undefined => {
+  const parts = [site.county, site.state].filter(
+    (part): part is string => part !== undefined && part !== ''
+  );
+  return parts.length === 0 ? undefined : parts.join(', ');
+};
+
 const PanelBody = ({ site }: PanelBodyProps) => (
   <>
     <DrawerHeader>
-      <Heading size="md">{formatTitle(site)}</Heading>
+      <Heading size="md">{site.name}</Heading>
       <Text as="p" css={{ fontSize: 'sm', color: 'fg.muted', marginTop: '1' }}>
         {formatSubheading(site)}
       </Text>
@@ -111,15 +117,18 @@ const PanelBody = ({ site }: PanelBodyProps) => (
     <DrawerBody>
       <Stack gap="4" css={{ marginTop: '2' }}>
         <FacilityBadges facilities={site.facilities} />
+        <Detail label="Location" value={formatLocation(site)} />
         <Detail
           label="Coordinates"
           value={formatCoordinates(site.coordinates)}
         />
         <Detail label="Season" value={site.season} />
         <Detail label="Camping" value={site.camping} />
+        <Detail label="Camping fee" value={site.campingFee} />
         <Detail label="Contact" value={site.contact} />
         <Detail label="Phone" value={site.phone} />
         <WebsiteRow url={site.website} />
+        <Detail label="Notes" value={site.notes} />
         <DownloadGpxButton site={site} />
       </Stack>
     </DrawerBody>

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -8,16 +8,21 @@ import SiteInfoPanel from '../SiteInfoPanel';
 
 const baseSite: Site = {
   id: siteId('test-1'),
+  name: 'Blalock Canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,
   bank: 'OR',
   coordinates: coordinates(-120.37, 45.695),
+  state: 'OR',
+  county: 'Gilliam',
   season: 'year round',
   camping: 'None',
+  campingFee: '$10/night',
   contact: 'US Army Corps of Engineers',
   phone: '(555) 555-5555',
   website: 'https://example.org/site',
+  notes: 'Popular salmon fishing in autumn.',
   facilities: FacilitySet.fromFlags({ boatRamp: true, restrooms: true }),
 };
 
@@ -51,16 +56,40 @@ describe('<SiteInfoPanel />', () => {
     select(baseSite);
 
     expect(
-      await screen.findByRole('heading', {
-        name: /Columbia River — Mile 234/u,
-      })
+      await screen.findByRole('heading', { name: /Blalock Canyon/u })
     ).toBeInTheDocument();
-    expect(screen.getByText('Lake Umatilla · OR')).toBeInTheDocument();
+    expect(
+      screen.getByText('Columbia River · Mile 234 · Lake Umatilla · OR')
+    ).toBeInTheDocument();
     expect(screen.getByText('US Army Corps of Engineers')).toBeInTheDocument();
     expect(screen.getByText('(555) 555-5555')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: 'https://example.org/site' })
     ).toHaveAttribute('href', 'https://example.org/site');
+  });
+
+  it('renders the new state/county/campingFee/notes rows when present', () => {
+    renderPanel();
+    select(baseSite);
+    expect(screen.getByText('Gilliam, OR')).toBeInTheDocument();
+    expect(screen.getByText('$10/night')).toBeInTheDocument();
+    expect(
+      screen.getByText('Popular salmon fishing in autumn.')
+    ).toBeInTheDocument();
+  });
+
+  it('omits state/county/campingFee/notes rows when absent', () => {
+    renderPanel();
+    select({
+      ...baseSite,
+      state: undefined,
+      county: undefined,
+      campingFee: undefined,
+      notes: undefined,
+    });
+    expect(screen.queryByText('Location')).not.toBeInTheDocument();
+    expect(screen.queryByText('Camping fee')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notes')).not.toBeInTheDocument();
   });
 
   it('renders facility badges from the site', () => {
@@ -76,11 +105,13 @@ describe('<SiteInfoPanel />', () => {
     expect(screen.queryByText(/example\.org/)).not.toBeInTheDocument();
   });
 
-  it('omits empty subheading parts (no leading separator)', () => {
+  it('omits empty subheading parts (no leading or doubled separator)', () => {
     renderPanel();
     select({ ...baseSite, riverSegment: '' });
-    expect(screen.getByText('OR')).toBeInTheDocument();
-    expect(screen.queryByText(/^· /)).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Columbia River · Mile 234 · OR')
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/· ·/)).not.toBeInTheDocument();
   });
 
   it('renders the formatted lat/long coordinates', () => {
@@ -118,7 +149,7 @@ describe('<SiteInfoPanel />', () => {
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
     expect(clicks).toHaveLength(1);
-    expect(clicks[0]?.download).toBe('columbia-mile-234.gpx');
+    expect(clicks[0]?.download).toBe('blalock-canyon.gpx');
     expect(clicks[0]?.href).toContain('blob:test-url');
 
     HTMLAnchorElement.prototype.click = originalClick;

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -149,7 +149,7 @@ describe('<SiteInfoPanel />', () => {
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-url');
     expect(clicks).toHaveLength(1);
-    expect(clicks[0]?.download).toBe('blalock-canyon.gpx');
+    expect(clicks[0]?.download).toBe('blalock-canyon-mile-234.gpx');
     expect(clicks[0]?.href).toContain('blob:test-url');
 
     HTMLAnchorElement.prototype.click = originalClick;

--- a/src/domain/site.ts
+++ b/src/domain/site.ts
@@ -7,16 +7,21 @@ export const siteId = (raw: string): SiteId => raw as SiteId;
 
 export interface Site {
   readonly id: SiteId;
+  readonly name: string;
   readonly riverSegment: string;
   readonly riverName: string;
   readonly riverMile: number;
   readonly bank: string;
   readonly coordinates: Coordinates;
+  readonly state?: string;
+  readonly county?: string;
   readonly season?: string;
   readonly camping?: string;
+  readonly campingFee?: string;
   readonly contact?: string;
   readonly phone?: string;
   readonly website?: string;
+  readonly notes?: string;
   readonly facilities: FacilitySet;
   readonly sourceUrl?: string;
 }

--- a/src/store/__tests__/selected-site.test.ts
+++ b/src/store/__tests__/selected-site.test.ts
@@ -5,6 +5,7 @@ import { useSelectedSite } from '../selected-site';
 
 const fakeSite = (id: string): Site => ({
   id: siteId(id),
+  name: 'Blalock Canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,


### PR DESCRIPTION
## Summary

Closes the **data-parity gap** from
[`docs/gap-analysis.md`](./docs/gap-analysis.md) by enriching the
GeoJSON dataset with content scraped from ndwt.org.

After this PR every site shows a real name in the panel header
("Blalock Canyon" instead of "Columbia River — Mile 234"), plus
state, county, camping fee, and notes when ndwt.org has them.

This is the first phase of the new
[`docs/plans/feature-parity.md`](./docs/plans/feature-parity.md)
plan (phases 8–14), which picks up where
[`modernization.md`](./docs/plans/modernization.md) ended.

## What changed

- **Scraper** (`scripts/scrape-ndwt-sites.ts`, `npm run scrape:sites`)
  — one-shot, walks every `web-scraper-start-url` from
  `public/data/ndwt.geojson`, parses the legacy ASP detail tables
  with jsdom, and writes a keyed record to
  `public/data/ndwt-enriched.json`. Re-run only when ndwt.org
  changes; not part of the build.
- **Domain** — `Site.name` (required), `Site.state`, `Site.county`,
  `Site.campingFee`, `Site.notes` added.
- **Loader** (`src/adapters/inbound/next/load-sites.ts`) reads both
  files in parallel and merges. Falls back to
  `"RiverName River — Mile NN"` for `name` when no enriched record
  exists, with a stderr warning at build time.
- **Panel** — header shows the canonical name; the
  river/segment/bank context moved to the subheading. New rows
  for **Location** (county + state), **Camping fee**, **Notes**
  render conditionally.
- **GPX** — waypoint name and download filename derive from
  `site.name`; the river-and-mile context is now in the
  description.
- **NOTICE.md** records the WWTA Executive Director's permission
  for content reuse.
- **Plan** — `docs/plans/feature-parity.md` introduces phases 8–14;
  `modernization.md` updated to point at the successor.

## Coverage of the source data

- 159/159 sites have names ✓
- 138 with state, 125 with county
- 29 with camping fee, 80 with notes (sparse in source)
- 3 name collisions flagged for Phase 9 slug logic
  (Hood Park, Fishhook Park, Granite Point)

## Test plan

- [x] `npm run lint` — clean (no errors; pre-existing max-len
      warnings only)
- [x] `npm run lint:md` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 70/70 pass, coverage 91%
- [x] `npm run build` — produces `out/` with names baked into the
      static export (verified `Blalock Canyon`, `Harper's Bend`,
      `Hood Park` present in `out/index.html`)
- [x] `npx playwright test --workers=1` — 9/9 pass
- [ ] Bot triage round (Gemini, Copilot, DeepSource, SonarCloud)
      after CI is green
- [ ] Spot-check three sites in browser preview against ndwt.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)