### PR TITLE
feat: phase 9 — per-site canonical URLs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,3 +32,17 @@ body {
   flex: 1;
   width: 100%;
 }
+
+/* Print: hide site chrome so a printed site page is just the
+   article content. The /sites/<slug> page leans on this so a
+   trip-day handout doesn't waste ink on the header / footer. */
+@media print {
+  header,
+  footer {
+    display: none !important;
+  }
+  body {
+    background: white;
+    color: black;
+  }
+}

--- a/app/sites/[slug]/page.tsx
+++ b/app/sites/[slug]/page.tsx
@@ -26,9 +26,9 @@ export async function generateMetadata({
   const sites = await loadSites();
   const site = sites.find((s) => s.slug === slug);
   if (site === undefined) return {};
-  const desc =
-    `${site.riverName} River, mile ${site.riverMile}` +
-    (site.riverSegment !== '' ? ` — ${site.riverSegment}` : '');
+  const segmentSuffix =
+    site.riverSegment !== '' ? ` — ${site.riverSegment}` : '';
+  const desc = `${site.riverName} River, mile ${site.riverMile}${segmentSuffix}`;
   return {
     title: `${site.name} — Northwest Discovery Water Trail`,
     description: desc,

--- a/app/sites/[slug]/page.tsx
+++ b/app/sites/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { css } from 'styled-system/css';
+
+import { loadSites } from '@/adapters/inbound/next/load-sites';
+import { SiteBody, SiteHeading } from '@/components/panels/SiteDetails';
+import { Link } from '@/components/ui/link';
+
+interface RouteParams {
+  readonly slug: string;
+}
+
+interface PageProps {
+  readonly params: Promise<RouteParams>;
+}
+
+export async function generateStaticParams(): Promise<RouteParams[]> {
+  const sites = await loadSites();
+  return sites.map((site) => ({ slug: site.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const sites = await loadSites();
+  const site = sites.find((s) => s.slug === slug);
+  if (site === undefined) return {};
+  const desc =
+    `${site.riverName} River, mile ${site.riverMile}` +
+    (site.riverSegment !== '' ? ` — ${site.riverSegment}` : '');
+  return {
+    title: `${site.name} — Northwest Discovery Water Trail`,
+    description: desc,
+    openGraph: {
+      title: site.name,
+      description: desc,
+      type: 'article',
+    },
+  };
+}
+
+const pageStyle = css({
+  maxWidth: '3xl',
+  marginX: 'auto',
+  paddingX: { base: '4', md: '6' },
+  paddingY: { base: '6', md: '10' },
+  color: 'fg.default',
+  // Print: drop layout chrome via globals.css (the Header / Footer
+  // hide themselves under @media print). The page itself just needs
+  // a clean width and no shadows/colors that waste ink.
+  '@media print': {
+    maxWidth: 'none',
+    paddingY: '0',
+  },
+});
+
+const breadcrumbStyle = css({
+  fontSize: 'sm',
+  color: 'fg.muted',
+  marginBottom: '4',
+  '@media print': { display: 'none' },
+});
+
+const mapLinkStyle = css({
+  display: 'inline-block',
+  marginTop: '6',
+  '@media print': { display: 'none' },
+});
+
+export default async function SitePage({ params }: PageProps) {
+  const { slug } = await params;
+  const sites = await loadSites();
+  const site = sites.find((s) => s.slug === slug);
+  if (site === undefined) notFound();
+
+  return (
+    <article className={pageStyle}>
+      <p className={breadcrumbStyle}>
+        <Link href="/">Map</Link> / Sites / {site.name}
+      </p>
+      <SiteHeading site={site} headingLevel="h1" size="2xl" />
+      <SiteBody site={site} />
+      <p className={mapLinkStyle}>
+        <Link href={`/?site=${site.slug}`}>← View on map</Link>
+      </p>
+    </article>
+  );
+}

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -5,7 +5,7 @@
 | Phase | Description                                           | State         |
 | ----- | ----------------------------------------------------- | ------------- |
 | 8     | Data enrichment — names, notes, fees, state/county    | Done (PR #39) |
-| 9     | Per-site canonical URLs (`/sites/<slug>`)             | Planned       |
+| 9     | Per-site canonical URLs (`/sites/<slug>`)             | In review     |
 | 10    | Site index / browse-by-list                           | Planned       |
 | 11    | Water Safety + River Navigation + Leave No Trace      | Planned       |
 | 12    | Natural World + Past & Present                        | Planned       |

--- a/e2e/site-pages.spec.ts
+++ b/e2e/site-pages.spec.ts
@@ -17,7 +17,7 @@ test.describe('Per-site canonical URLs (Phase 9)', () => {
     ).toBeVisible();
 
     // Subheading carries the river/mile context.
-    await expect(page.getByText(/Columbia River · Mile 234/)).toBeVisible();
+    await expect(page.getByText(/Columbia River · Mile 234/u)).toBeVisible();
 
     // GPX download is part of the same SiteDetails component that
     // the drawer uses.
@@ -25,7 +25,7 @@ test.describe('Per-site canonical URLs (Phase 9)', () => {
 
     // "View on map" link points back at the home page with the
     // shareable query param.
-    const mapLink = page.getByRole('link', { name: /View on map/ });
+    const mapLink = page.getByRole('link', { name: /View on map/u });
     await expect(mapLink).toBeVisible();
     await expect(mapLink).toHaveAttribute('href', `/?site=${SAMPLE_SLUG}`);
   });
@@ -33,7 +33,7 @@ test.describe('Per-site canonical URLs (Phase 9)', () => {
   test('per-page metadata uses the canonical site name', async ({ page }) => {
     await page.goto(`/sites/${SAMPLE_SLUG}`);
     await expect(page).toHaveTitle(
-      /Blalock Canyon — Northwest Discovery Water Trail/
+      /Blalock Canyon — Northwest Discovery Water Trail/u
     );
   });
 

--- a/e2e/site-pages.spec.ts
+++ b/e2e/site-pages.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+// Pick a stable site that has a real name in the enriched dataset.
+// Blalock Canyon (Columbia mile 234) is the canonical example used
+// throughout the unit tests, so it's the safest choice for e2e.
+const SAMPLE_SLUG = 'blalock-canyon';
+const SAMPLE_NAME = 'Blalock Canyon';
+
+test.describe('Per-site canonical URLs (Phase 9)', () => {
+  test('GET /sites/<slug> renders the dedicated page with site name', async ({
+    page,
+  }) => {
+    await page.goto(`/sites/${SAMPLE_SLUG}`);
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: SAMPLE_NAME })
+    ).toBeVisible();
+
+    // Subheading carries the river/mile context.
+    await expect(page.getByText(/Columbia River · Mile 234/)).toBeVisible();
+
+    // GPX download is part of the same SiteDetails component that
+    // the drawer uses.
+    await expect(page.getByTestId('download-gpx-button')).toBeVisible();
+
+    // "View on map" link points back at the home page with the
+    // shareable query param.
+    const mapLink = page.getByRole('link', { name: /View on map/ });
+    await expect(mapLink).toBeVisible();
+    await expect(mapLink).toHaveAttribute('href', `/?site=${SAMPLE_SLUG}`);
+  });
+
+  test('per-page metadata uses the canonical site name', async ({ page }) => {
+    await page.goto(`/sites/${SAMPLE_SLUG}`);
+    await expect(page).toHaveTitle(
+      /Blalock Canyon — Northwest Discovery Water Trail/
+    );
+  });
+
+  test('deep-link /?site=<slug> opens the panel with that site selected', async ({
+    page,
+  }) => {
+    await page.goto(`/?site=${SAMPLE_SLUG}`);
+
+    const panel = page.getByTestId('site-info-panel');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByRole('heading')).toContainText(SAMPLE_NAME);
+  });
+
+  test('print media query hides header / footer chrome', async ({ page }) => {
+    await page.goto(`/sites/${SAMPLE_SLUG}`);
+    await page.emulateMedia({ media: 'print' });
+
+    // header and footer are display:none under @media print.
+    const header = page.locator('header').first();
+    const footer = page.locator('footer').first();
+    await expect(header).toBeHidden();
+    await expect(footer).toBeHidden();
+
+    // The article body is still visible.
+    await expect(
+      page.getByRole('heading', { level: 1, name: SAMPLE_NAME })
+    ).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "panda codegen --silent && next build",
     "panda": "panda codegen",
     "start": "next start",
-    "preview": "serve out --listen 4173 --no-clipboard --single",
+    "preview": "serve out --listen 4173 --no-clipboard",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install --with-deps chromium",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,11 @@ export default defineConfig({
   webServer: {
     // Static export: build to ./out, then serve it. Mirrors what
     // Netlify ships at deploy_url, so e2e exercises the same bytes.
-    command: `npm run preview -- --listen ${PORT} --no-clipboard --single`,
+    // No `--single` (SPA fallback): every route under
+    // app/ generates a real index.html via static export, so we
+    // want unknown paths to surface as 404s, not silently fall
+    // back to the home page.
+    command: `npm run preview -- --listen ${PORT} --no-clipboard`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/src/__tests__/MapApp.test.tsx
+++ b/src/__tests__/MapApp.test.tsx
@@ -18,6 +18,7 @@ const fakeSites: readonly Site[] = [
   {
     id: siteId('test'),
     name: 'Test Site',
+    slug: 'test-site',
     riverSegment: '',
     riverName: 'Columbia',
     riverMile: 0,

--- a/src/__tests__/composition-root.test.ts
+++ b/src/__tests__/composition-root.test.ts
@@ -6,6 +6,7 @@ import { coordinates, FacilitySet, type Site, siteId } from '../domain';
 const baseSite: Site = {
   id: siteId('a'),
   name: 'Site A',
+  slug: 'site-a',
   riverSegment: '',
   riverName: 'Columbia',
   riverMile: 0,

--- a/src/adapters/inbound/next/__tests__/load-sites.test.ts
+++ b/src/adapters/inbound/next/__tests__/load-sites.test.ts
@@ -8,7 +8,7 @@ vi.mock('node:fs/promises', () => ({
   default: { readFile: mockReadFile },
 }));
 
-import { loadSites } from '../load-sites';
+import { __resetLoadSitesCacheForTesting, loadSites } from '../load-sites';
 
 const validGeoJson = JSON.stringify({
   type: 'FeatureCollection',
@@ -29,6 +29,7 @@ const validGeoJson = JSON.stringify({
 
 beforeEach(() => {
   mockReadFile.mockReset();
+  __resetLoadSitesCacheForTesting();
 });
 
 afterEach(() => {

--- a/src/adapters/inbound/next/load-sites.ts
+++ b/src/adapters/inbound/next/load-sites.ts
@@ -11,20 +11,14 @@ import {
 
 const GEOJSON_PATH = ['public', 'data', 'ndwt.geojson'] as const;
 
-/**
- * Build-time site loader for App Router server components. Reads
- * the merged GeoJSON straight off disk via fs/promises (so it's
- * pre-rendered into the static page bundle, no runtime fetch) and
- * runs it through the same parser the client uses for the fetch
- * path. JSON.parse errors are wrapped so a corrupted file fails the
- * build with a useful path.
- *
- * Site name + state/county/campingFee/notes used to live in a
- * sidecar `ndwt-enriched.json`; they were merged into the GeoJSON
- * properties to keep the loader and the published `/data/` asset
- * symmetric. See `public/data/README.md` for the schema.
- */
-export async function loadSites(): Promise<readonly Site[]> {
+// Module-level dedupe across all build-time callers. App Router
+// invokes this loader from `generateStaticParams`, `generateMetadata`
+// (159 times), and the page renderer (159 times) — without a cache
+// that's ~320 fs reads + JSON.parse passes for one `next build`.
+// Caching the parsed Site[] keeps the build under a second instead.
+let cache: Promise<readonly Site[]> | null = null;
+
+const loadAndParse = async (): Promise<readonly Site[]> => {
   const path = join(process.cwd(), ...GEOJSON_PATH);
   const text = await readFile(path, 'utf-8');
   let body: RawFeatureCollection;
@@ -34,4 +28,34 @@ export async function loadSites(): Promise<readonly Site[]> {
     throw new Error(`Failed to parse GeoJSON at ${path}`, { cause });
   }
   return parseSitesFromGeoJson(body);
+};
+
+/**
+ * Build-time site loader for App Router server components. Reads
+ * the merged GeoJSON straight off disk via fs/promises (so it's
+ * pre-rendered into the static page bundle, no runtime fetch) and
+ * runs it through the same parser the client uses for the fetch
+ * path. JSON.parse errors are wrapped so a corrupted file fails the
+ * build with a useful path.
+ *
+ * Memoized at module scope: per-page `generateStaticParams`,
+ * `generateMetadata`, and render passes share one parsed result
+ * across the entire `next build` instead of re-reading the GeoJSON
+ * for every site.
+ *
+ * Site name + state/county/campingFee/notes used to live in a
+ * sidecar `ndwt-enriched.json`; they were merged into the GeoJSON
+ * properties to keep the loader and the published `/data/` asset
+ * symmetric. See `public/data/README.md` for the schema.
+ */
+export function loadSites(): Promise<readonly Site[]> {
+  cache ??= loadAndParse();
+  return cache;
 }
+
+// Test-only escape hatch for clearing the module-level cache
+// between vitest cases. Not exported from any barrel; consumers
+// outside __tests__ should not reach for it.
+export const __resetLoadSitesCacheForTesting = (): void => {
+  cache = null;
+};

--- a/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/geojson-site-repository.test.ts
@@ -37,10 +37,14 @@ describe('GeoJsonSiteRepository.list()', () => {
     expect(sites.length).toBeGreaterThan(100);
     expect(sites.length).toBeLessThan(300);
 
+    const slugs = new Set<string>();
     for (const site of sites) {
       expect(typeof site.id).toBe('string');
       expect(site.id.length).toBeGreaterThan(0);
       expect(site.name.length).toBeGreaterThan(0);
+      expect(site.slug.length).toBeGreaterThan(0);
+      expect(slugs.has(site.slug)).toBe(false);
+      slugs.add(site.slug);
       expect(site.coordinates.longitude).toBeGreaterThan(-180);
       expect(site.coordinates.longitude).toBeLessThan(180);
       expect(site.coordinates.latitude).toBeGreaterThan(-90);
@@ -95,7 +99,7 @@ describe('GeoJsonSiteRepository.list()', () => {
   });
 });
 
-describe('toSite mapper', () => {
+describe('toDraft mapper', () => {
   it('handles missing optional fields without throwing', () => {
     const feature = {
       type: 'Feature' as const,
@@ -112,7 +116,7 @@ describe('toSite mapper', () => {
         coordinates: [-120.37, 45.695] as [number, number],
       },
     };
-    const site = __test.toSite(feature, 0);
+    const site = __test.toDraft(feature, 0);
     expect(site.coordinates).toEqual({ longitude: -120.37, latitude: 45.695 });
     expect(site.facilities).not.toContain('restrooms');
     expect(site.facilities).toContain('boatRamp');
@@ -130,7 +134,7 @@ describe('toSite mapper', () => {
         coordinates: [0, 0] as [number, number],
       },
     };
-    const site = __test.toSite(feature, 42);
+    const site = __test.toDraft(feature, 42);
     expect(site.id).toBe('site-42');
     expect(site.riverMile).toBe(0);
   });
@@ -152,7 +156,7 @@ describe('toSite mapper', () => {
         coordinates: [-116.45002, 46.49144] as [number, number],
       },
     };
-    const site = __test.toSite(feature, 0);
+    const site = __test.toDraft(feature, 0);
     expect(site.name).toBe("Harper's Bend");
     expect(site.state).toBe('ID');
     expect(site.county).toBe('Nez Perce');
@@ -173,7 +177,7 @@ describe('toSite mapper', () => {
         coordinates: [-120.37, 45.695] as [number, number],
       },
     };
-    const site = __test.toSite(feature, 0);
+    const site = __test.toDraft(feature, 0);
     expect(site.name).toBe('Columbia River — Mile 234');
   });
 });

--- a/src/adapters/outbound/__tests__/in-memory-site-repository.test.ts
+++ b/src/adapters/outbound/__tests__/in-memory-site-repository.test.ts
@@ -6,6 +6,7 @@ import { InMemorySiteRepository } from '../in-memory-site-repository';
 const makeSite = (id: string, riverName = 'Columbia'): Site => ({
   id: siteId(id),
   name: `${riverName} River — Mile 0`,
+  slug: `${riverName.toLowerCase()}-river-mile-0`,
   riverSegment: '',
   riverName,
   riverMile: 0,

--- a/src/adapters/outbound/__tests__/site-to-gpx.test.ts
+++ b/src/adapters/outbound/__tests__/site-to-gpx.test.ts
@@ -6,6 +6,7 @@ import { gpxFilename, siteToGpx } from '../site-to-gpx';
 const baseSite: Site = {
   id: siteId('x'),
   name: 'Blalock Canyon',
+  slug: 'blalock-canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -1,5 +1,6 @@
 import type { SiteRepository } from '../../application/ports/site-repository';
 import {
+  assignSlugs,
   coordinates,
   FACILITIES,
   type Facility,
@@ -8,6 +9,8 @@ import {
   type SiteId,
   siteId,
 } from '../../domain';
+
+type DraftSite = Omit<Site, 'slug'>;
 
 interface RawProps {
   readonly [key: string]: string | undefined;
@@ -52,7 +55,7 @@ const facilityFlags = (props: RawProps): Partial<Record<Facility, boolean>> => {
 const fallbackName = (riverName: string, riverMile: number): string =>
   `${riverName} River — Mile ${riverMile}`;
 
-const toSite = (feature: RawFeature, index: number): Site => {
+const toDraft = (feature: RawFeature, index: number): DraftSite => {
   const props = feature.properties;
   const [lng, lat] = feature.geometry.coordinates;
   const idRaw = readProp(props, ...ID_KEY_CANDIDATES) ?? `site-${index}`;
@@ -94,11 +97,20 @@ const toSite = (feature: RawFeature, index: number): Site => {
  * that were merged in from ndwt.org during Phase 8. If `name` is
  * somehow missing, the parser falls back to "RiverName River — Mile
  * NN" so the build doesn't crash on a broken record.
+ *
+ * Slug is assigned in a second pass via `assignSlugs` so it can see
+ * the whole dataset and resolve name collisions.
  */
 export const parseSitesFromGeoJson = (
   body: RawFeatureCollection
-): readonly Site[] =>
-  body.features.map((feature, index) => toSite(feature, index));
+): readonly Site[] => {
+  const drafts = body.features.map((feature, index) => toDraft(feature, index));
+  const slugs = assignSlugs(drafts);
+  return drafts.map((draft) => ({
+    ...draft,
+    slug: slugs.get(draft.id) ?? draft.id,
+  }));
+};
 
 export class GeoJsonSiteRepository implements SiteRepository {
   private cache: readonly Site[] | null = null;
@@ -137,4 +149,4 @@ export class GeoJsonSiteRepository implements SiteRepository {
   }
 }
 
-export const __test = { toSite };
+export const __test = { toDraft };

--- a/src/adapters/outbound/geojson-site-repository.ts
+++ b/src/adapters/outbound/geojson-site-repository.ts
@@ -106,10 +106,16 @@ export const parseSitesFromGeoJson = (
 ): readonly Site[] => {
   const drafts = body.features.map((feature, index) => toDraft(feature, index));
   const slugs = assignSlugs(drafts);
-  return drafts.map((draft) => ({
-    ...draft,
-    slug: slugs.get(draft.id) ?? draft.id,
-  }));
+  return drafts.map((draft) => {
+    const slug = slugs.get(draft.id);
+    if (slug === undefined) {
+      // assignSlugs assigns one slug per input id by construction
+      // — a miss here means the slug module has a bug. Fail the
+      // build loudly rather than ship a non-canonical URL.
+      throw new Error(`assignSlugs returned no slug for site id ${draft.id}`);
+    }
+    return { ...draft, slug };
+  });
 };
 
 export class GeoJsonSiteRepository implements SiteRepository {

--- a/src/components/MapApp.tsx
+++ b/src/components/MapApp.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { css } from 'styled-system/css';
 
 import { createComposition } from '../composition-root';
 import type { Site } from '../domain';
+import { useSelectedSite } from '../store/selected-site';
 
 import SiteInfoPanel from './panels/SiteInfoPanel';
 import ThemeToggleButton from './ThemeToggleButton';
@@ -19,8 +20,53 @@ interface MapAppProps {
   readonly sites: readonly Site[];
 }
 
+const SITE_QUERY_KEY = 'site';
+
+/**
+ * Two-way URL sync for the selected site.
+ *
+ * - On mount, read `?site=<slug>` and select the matching site so a
+ *   shared link opens the panel deterministically.
+ * - On every selectedSite change, mirror the state into the URL via
+ *   `history.replaceState` (no Next router round-trip → no re-render,
+ *   no scroll jump). Selecting a marker pushes `?site=<slug>`;
+ *   closing the drawer strips it.
+ */
+const useSiteUrlSync = (sites: readonly Site[]) => {
+  const selectedSite = useSelectedSite((s) => s.selectedSite);
+
+  // Initial-load deep-link: runs once after mount.
+  useEffect(() => {
+    const slug = new URLSearchParams(window.location.search).get(
+      SITE_QUERY_KEY
+    );
+    if (slug === null || slug === '') return;
+    const site = sites.find((s) => s.slug === slug);
+    if (site !== undefined) useSelectedSite.getState().select(site);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deep-link is one-shot
+  }, []);
+
+  // Mirror selection back into the URL.
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (selectedSite === null) {
+      url.searchParams.delete(SITE_QUERY_KEY);
+    } else {
+      url.searchParams.set(SITE_QUERY_KEY, selectedSite.slug);
+    }
+    const next = `${url.pathname}${url.search}${url.hash}`;
+    if (
+      next !==
+      `${window.location.pathname}${window.location.search}${window.location.hash}`
+    ) {
+      window.history.replaceState(null, '', next);
+    }
+  }, [selectedSite]);
+};
+
 export default function MapApp({ sites }: MapAppProps) {
   const composition = useMemo(() => createComposition(sites), [sites]);
+  useSiteUrlSync(sites);
 
   return (
     // The root layout's <main> is a flex column; this container

--- a/src/components/__tests__/map-handlers.test.ts
+++ b/src/components/__tests__/map-handlers.test.ts
@@ -28,6 +28,7 @@ const fakeMap = (overrides: Partial<FakeMap> = {}): FakeMap => ({
 const baseSite: Site = {
   id: siteId('feat-1'),
   name: 'Blalock Canyon',
+  slug: 'blalock-canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,

--- a/src/components/panels/SiteDetails.tsx
+++ b/src/components/panels/SiteDetails.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { css } from 'styled-system/css';
+
+import { gpxFilename, siteToGpx } from '../../adapters/outbound/site-to-gpx';
+import type { Site } from '../../domain';
+import { Box } from '../ui/box';
+import { Button } from '../ui/button';
+import { Heading } from '../ui/heading';
+import { Link } from '../ui/link';
+import { Stack } from '../ui/stack';
+import { Text } from '../ui/text';
+
+import FacilityBadges from './FacilityBadges';
+
+const formatSubheading = (site: Site): string => {
+  const riverPart = `${site.riverName} River · Mile ${site.riverMile}`;
+  return [riverPart, site.riverSegment, site.bank]
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' · ');
+};
+
+const formatCoordinates = ({
+  latitude,
+  longitude,
+}: Site['coordinates']): string =>
+  `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+
+const formatLocation = (site: Site): string | undefined => {
+  const parts = [site.county, site.state].filter(
+    (part): part is string => part !== undefined && part !== ''
+  );
+  return parts.length === 0 ? undefined : parts.join(', ');
+};
+
+const labelStyle = css({
+  fontSize: 'sm',
+  color: 'fg.muted',
+  textTransform: 'uppercase',
+  letterSpacing: 'wider',
+  margin: 0,
+});
+
+const valueStyle = css({ margin: 0, color: 'fg.default' });
+
+interface DetailProps {
+  readonly label: string;
+  readonly value: string | undefined;
+}
+
+const Detail = ({ label, value }: DetailProps) => {
+  if (value === undefined || value === '') return null;
+  return (
+    <Box>
+      <p className={labelStyle}>{label}</p>
+      <p className={valueStyle}>{value}</p>
+    </Box>
+  );
+};
+
+interface WebsiteRowProps {
+  readonly url: string | undefined;
+}
+
+const WebsiteRow = ({ url }: WebsiteRowProps) => {
+  if (url === undefined || url === '') return null;
+  return (
+    <Box>
+      <p className={labelStyle}>Website</p>
+      <Link href={url} external>
+        {url}
+      </Link>
+    </Box>
+  );
+};
+
+const downloadGpx = (site: Site): void => {
+  const blob = new Blob([siteToGpx(site)], {
+    type: 'application/gpx+xml',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = gpxFilename(site);
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+interface SitePartProps {
+  readonly site: Site;
+  readonly headingLevel?: 'h1' | 'h2' | 'h3';
+  readonly size?: 'md' | 'lg' | 'xl' | '2xl';
+}
+
+/**
+ * Site name + river/segment/bank subheading. The heading element
+ * and visual size are configurable so the dedicated
+ * `/sites/<slug>` page can render an `<h1>` at page-title size
+ * while the in-map drawer renders an `<h2>` at panel size.
+ */
+export const SiteHeading = ({
+  site,
+  headingLevel = 'h2',
+  size = 'md',
+}: SitePartProps) => (
+  <>
+    <Heading as={headingLevel} size={size}>
+      {site.name}
+    </Heading>
+    <Text as="p" css={{ fontSize: 'sm', color: 'fg.muted', marginTop: '1' }}>
+      {formatSubheading(site)}
+    </Text>
+  </>
+);
+
+/**
+ * Facilities, conditional detail rows, and the GPX download
+ * button. Layout-neutral — the caller owns the surrounding
+ * scrollable area.
+ */
+export const SiteBody = ({ site }: { readonly site: Site }) => (
+  <Stack gap="4" css={{ marginTop: '2' }}>
+    <FacilityBadges facilities={site.facilities} />
+    <Detail label="Location" value={formatLocation(site)} />
+    <Detail label="Coordinates" value={formatCoordinates(site.coordinates)} />
+    <Detail label="Season" value={site.season} />
+    <Detail label="Camping" value={site.camping} />
+    <Detail label="Camping fee" value={site.campingFee} />
+    <Detail label="Contact" value={site.contact} />
+    <Detail label="Phone" value={site.phone} />
+    <WebsiteRow url={site.website} />
+    <Detail label="Notes" value={site.notes} />
+    <Box css={{ paddingTop: '2' }}>
+      <Button
+        size="sm"
+        onClick={() => downloadGpx(site)}
+        data-testid="download-gpx-button"
+      >
+        Download GPX waypoint
+      </Button>
+    </Box>
+  </Stack>
+);

--- a/src/components/panels/SiteInfoPanel.tsx
+++ b/src/components/panels/SiteInfoPanel.tsx
@@ -1,139 +1,9 @@
 'use client';
 
-import { css } from 'styled-system/css';
-
-import { gpxFilename, siteToGpx } from '../../adapters/outbound/site-to-gpx';
-import type { Site } from '../../domain';
 import { useSelectedSite } from '../../store/selected-site';
-import { Box } from '../ui/box';
-import { Button } from '../ui/button';
 import { Drawer, DrawerBody, DrawerHeader } from '../ui/drawer';
-import { Heading } from '../ui/heading';
-import { Link } from '../ui/link';
-import { Stack } from '../ui/stack';
-import { Text } from '../ui/text';
 
-import FacilityBadges from './FacilityBadges';
-
-const formatSubheading = (site: Site): string => {
-  const riverPart = `${site.riverName} River · Mile ${site.riverMile}`;
-  return [riverPart, site.riverSegment, site.bank]
-    .filter((part): part is string => part !== undefined && part !== '')
-    .join(' · ');
-};
-
-const formatCoordinates = ({
-  latitude,
-  longitude,
-}: Site['coordinates']): string =>
-  `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
-
-interface DetailProps {
-  readonly label: string;
-  readonly value: string | undefined;
-}
-
-const labelStyle = css({
-  fontSize: 'sm',
-  color: 'fg.muted',
-  textTransform: 'uppercase',
-  letterSpacing: 'wider',
-  margin: 0,
-});
-
-const valueStyle = css({ margin: 0, color: 'fg.default' });
-
-const Detail = ({ label, value }: DetailProps) => {
-  if (value === undefined || value === '') return null;
-  return (
-    <Box>
-      <p className={labelStyle}>{label}</p>
-      <p className={valueStyle}>{value}</p>
-    </Box>
-  );
-};
-
-const downloadGpx = (site: Site): void => {
-  const blob = new Blob([siteToGpx(site)], {
-    type: 'application/gpx+xml',
-  });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = gpxFilename(site);
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
-};
-
-interface PanelBodyProps {
-  readonly site: Site;
-}
-
-const DownloadGpxButton = ({ site }: PanelBodyProps) => (
-  <Box css={{ paddingTop: '2' }}>
-    <Button
-      size="sm"
-      onClick={() => downloadGpx(site)}
-      data-testid="download-gpx-button"
-    >
-      Download GPX waypoint
-    </Button>
-  </Box>
-);
-
-interface WebsiteRowProps {
-  readonly url: string | undefined;
-}
-
-const WebsiteRow = ({ url }: WebsiteRowProps) => {
-  if (url === undefined || url === '') return null;
-  return (
-    <Box>
-      <p className={labelStyle}>Website</p>
-      <Link href={url} external>
-        {url}
-      </Link>
-    </Box>
-  );
-};
-
-const formatLocation = (site: Site): string | undefined => {
-  const parts = [site.county, site.state].filter(
-    (part): part is string => part !== undefined && part !== ''
-  );
-  return parts.length === 0 ? undefined : parts.join(', ');
-};
-
-const PanelBody = ({ site }: PanelBodyProps) => (
-  <>
-    <DrawerHeader>
-      <Heading size="md">{site.name}</Heading>
-      <Text as="p" css={{ fontSize: 'sm', color: 'fg.muted', marginTop: '1' }}>
-        {formatSubheading(site)}
-      </Text>
-    </DrawerHeader>
-    <DrawerBody>
-      <Stack gap="4" css={{ marginTop: '2' }}>
-        <FacilityBadges facilities={site.facilities} />
-        <Detail label="Location" value={formatLocation(site)} />
-        <Detail
-          label="Coordinates"
-          value={formatCoordinates(site.coordinates)}
-        />
-        <Detail label="Season" value={site.season} />
-        <Detail label="Camping" value={site.camping} />
-        <Detail label="Camping fee" value={site.campingFee} />
-        <Detail label="Contact" value={site.contact} />
-        <Detail label="Phone" value={site.phone} />
-        <WebsiteRow url={site.website} />
-        <Detail label="Notes" value={site.notes} />
-        <DownloadGpxButton site={site} />
-      </Stack>
-    </DrawerBody>
-  </>
-);
+import { SiteBody, SiteHeading } from './SiteDetails';
 
 export default function SiteInfoPanel() {
   const selectedSite = useSelectedSite((state) => state.selectedSite);
@@ -145,7 +15,16 @@ export default function SiteInfoPanel() {
   // disappears with the dialog itself.
   return (
     <Drawer open={selectedSite !== null} onClose={close}>
-      {selectedSite === null ? null : <PanelBody site={selectedSite} />}
+      {selectedSite === null ? null : (
+        <>
+          <DrawerHeader>
+            <SiteHeading site={selectedSite} headingLevel="h2" />
+          </DrawerHeader>
+          <DrawerBody>
+            <SiteBody site={selectedSite} />
+          </DrawerBody>
+        </>
+      )}
     </Drawer>
   );
 }

--- a/src/components/panels/__tests__/SiteInfoPanel.test.tsx
+++ b/src/components/panels/__tests__/SiteInfoPanel.test.tsx
@@ -9,6 +9,7 @@ import SiteInfoPanel from '../SiteInfoPanel';
 const baseSite: Site = {
   id: siteId('test-1'),
   name: 'Blalock Canyon',
+  slug: 'blalock-canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,

--- a/src/domain/__tests__/slug.test.ts
+++ b/src/domain/__tests__/slug.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { __test, assignSlugs, type SluggableSite } from '../slug';
+
+describe('baseSlug', () => {
+  const { baseSlug } = __test;
+
+  it('kebab-cases an ASCII name', () => {
+    expect(baseSlug('Blalock Canyon')).toBe('blalock-canyon');
+  });
+
+  it('collapses runs of non-alphanumerics into single dashes', () => {
+    expect(baseSlug("Harper's Bend")).toBe('harper-s-bend');
+    expect(baseSlug('Big   Flat')).toBe('big-flat');
+    expect(baseSlug('Bonneville(Oregon )')).toBe('bonneville-oregon');
+  });
+
+  it('strips leading/trailing dashes', () => {
+    expect(baseSlug('  Site  ')).toBe('site');
+    expect(baseSlug('???')).toBe('site');
+  });
+});
+
+describe('assignSlugs collision strategy', () => {
+  it('uses the bare name slug when unique', () => {
+    const sites: SluggableSite[] = [
+      { id: 'a', name: 'Blalock Canyon', riverMile: 234 },
+      { id: 'b', name: "Harper's Bend", riverMile: 34 },
+    ];
+    const slugs = assignSlugs(sites);
+    expect(slugs.get('a')).toBe('blalock-canyon');
+    expect(slugs.get('b')).toBe('harper-s-bend');
+  });
+
+  it('disambiguates with river mile when names collide on different miles', () => {
+    const sites: SluggableSite[] = [
+      { id: 'a', name: 'Hood Park', riverMile: 2 },
+      { id: 'b', name: 'Hood Park', riverMile: 2.5 },
+    ];
+    const slugs = assignSlugs(sites);
+    expect(slugs.get('a')).toBe('hood-park-mile-2');
+    expect(slugs.get('b')).toBe('hood-park-mile-2-5');
+  });
+
+  it('falls back to id when names AND miles collide', () => {
+    const sites: SluggableSite[] = [
+      { id: '188', name: 'Granite Point', riverMile: 113 },
+      { id: '182', name: 'Granite Point', riverMile: 113 },
+    ];
+    const slugs = assignSlugs(sites);
+    expect(slugs.get('188')).toBe('granite-point-mile-113-188');
+    expect(slugs.get('182')).toBe('granite-point-mile-113-182');
+  });
+
+  it('handles a mix of unique and colliding names in one batch', () => {
+    const sites: SluggableSite[] = [
+      { id: '1', name: 'Blalock Canyon', riverMile: 234 },
+      { id: '2', name: 'Hood Park', riverMile: 2 },
+      { id: '3', name: 'Hood Park', riverMile: 2.5 },
+      { id: '4', name: 'Granite Point', riverMile: 113 },
+      { id: '5', name: 'Granite Point', riverMile: 113 },
+    ];
+    const slugs = assignSlugs(sites);
+    expect(slugs.get('1')).toBe('blalock-canyon');
+    expect(slugs.get('2')).toBe('hood-park-mile-2');
+    expect(slugs.get('3')).toBe('hood-park-mile-2-5');
+    expect(slugs.get('4')).toBe('granite-point-mile-113-4');
+    expect(slugs.get('5')).toBe('granite-point-mile-113-5');
+  });
+
+  it('produces unique slugs across the dataset (no two sites share a slug)', () => {
+    const sites: SluggableSite[] = [
+      { id: '1', name: 'Hood Park', riverMile: 2 },
+      { id: '2', name: 'Hood Park', riverMile: 2 }, // exact duplicate
+      { id: '3', name: 'Hood Park', riverMile: 2 }, // 3-way collision
+    ];
+    const slugs = assignSlugs(sites);
+    const unique = new Set(slugs.values());
+    expect(unique.size).toBe(3);
+  });
+});

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -4,3 +4,4 @@ export type { Facility } from './facility';
 export { FACILITIES, FacilitySet, hasFacility } from './facility';
 export type { Site, SiteId } from './site';
 export { siteId } from './site';
+export { assignSlugs, type SluggableSite } from './slug';

--- a/src/domain/site.ts
+++ b/src/domain/site.ts
@@ -8,6 +8,7 @@ export const siteId = (raw: string): SiteId => raw as SiteId;
 export interface Site {
   readonly id: SiteId;
   readonly name: string;
+  readonly slug: string;
   readonly riverSegment: string;
   readonly riverName: string;
   readonly riverMile: number;

--- a/src/domain/slug.ts
+++ b/src/domain/slug.ts
@@ -56,9 +56,11 @@ export const assignSlugs = (
 
   for (const [base, bucket] of buckets) {
     if (bucket.length === 1) {
-      // Bucket guaranteed non-empty by Pass 1; non-null assertion
-      // satisfies tsconfig's `noUncheckedIndexedAccess`.
-      out.set(bucket[0]!.id, base);
+      // Single-iteration `for...of` reads the lone element without
+      // an indexed access — sidesteps `noUncheckedIndexedAccess`'s
+      // pessimism without a non-null assertion (DeepSource JS-0339)
+      // or a dead-branch undefined check.
+      for (const site of bucket) out.set(site.id, base);
       continue;
     }
 
@@ -75,7 +77,7 @@ export const assignSlugs = (
 
     for (const [mileSlug, inner] of byMileSlug) {
       if (inner.length === 1) {
-        out.set(inner[0]!.id, mileSlug);
+        for (const site of inner) out.set(site.id, mileSlug);
       } else {
         // Pass 3: still colliding — append the legacy id. By
         // construction these ids are unique.

--- a/src/domain/slug.ts
+++ b/src/domain/slug.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure slug derivation for per-site canonical URLs.
+ *
+ * Strategy is collision-aware in three tiers:
+ *   1. `slugify(name)` if unique across the dataset.
+ *   2. `slugify(name)-mile-{N}` (decimals as `2-5`) when names collide
+ *      but river miles differ.
+ *   3. `slugify(name)-{id}` as a final tiebreaker for true source
+ *      duplicates (the legacy `web-scraper-order` value, which is
+ *      unique by construction).
+ *
+ * Slug computation is a batch operation — it needs to see every site
+ * to detect collisions. `assignSlugs` returns a Map keyed by id.
+ */
+
+export interface SluggableSite {
+  readonly id: string;
+  readonly name: string;
+  readonly riverMile: number;
+}
+
+const baseSlug = (name: string): string => {
+  // Lowercase, runs of non-alphanumerics collapsed to single dashes,
+  // strip leading/trailing dash without anchored regex (avoids
+  // Sonar S5852).
+  const collapsed = name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+  const start = collapsed.startsWith('-') ? 1 : 0;
+  const end = collapsed.length - (collapsed.endsWith('-') ? 1 : 0);
+  const trimmed = collapsed.slice(start, end);
+  return trimmed === '' ? 'site' : trimmed;
+};
+
+const withMile = (slug: string, mile: number): string =>
+  `${slug}-mile-${`${mile}`.replaceAll('.', '-')}`;
+
+const withId = (slug: string, id: string): string => `${slug}-${id}`;
+
+/**
+ * Compute the canonical slug for every site in `sites`. Returns a
+ * Map<id, slug>. Pure: no I/O, no globals, deterministic for a given
+ * input order.
+ */
+export const assignSlugs = (
+  sites: readonly SluggableSite[]
+): ReadonlyMap<string, string> => {
+  // Pass 1: bucket by base slug.
+  const buckets = new Map<string, SluggableSite[]>();
+  for (const site of sites) {
+    const key = baseSlug(site.name);
+    const bucket = buckets.get(key);
+    if (bucket === undefined) buckets.set(key, [site]);
+    else bucket.push(site);
+  }
+
+  const out = new Map<string, string>();
+
+  for (const [base, bucket] of buckets) {
+    if (bucket.length === 1) {
+      const only = bucket[0];
+      if (only !== undefined) out.set(only.id, base);
+      continue;
+    }
+
+    // Pass 2: try `name-mile-N`. Group within the bucket by the
+    // mile-suffixed slug; if every entry lands on a unique slug,
+    // we're done.
+    const byMileSlug = new Map<string, SluggableSite[]>();
+    for (const site of bucket) {
+      const key = withMile(base, site.riverMile);
+      const inner = byMileSlug.get(key);
+      if (inner === undefined) byMileSlug.set(key, [site]);
+      else inner.push(site);
+    }
+
+    for (const [mileSlug, inner] of byMileSlug) {
+      if (inner.length === 1) {
+        const only = inner[0];
+        if (only !== undefined) out.set(only.id, mileSlug);
+      } else {
+        // Pass 3: still colliding — append the legacy id. By
+        // construction these ids are unique.
+        for (const site of inner) {
+          out.set(site.id, withId(mileSlug, site.id));
+        }
+      }
+    }
+  }
+
+  return out;
+};
+
+export const __test = { baseSlug, withMile, withId };

--- a/src/domain/slug.ts
+++ b/src/domain/slug.ts
@@ -56,8 +56,9 @@ export const assignSlugs = (
 
   for (const [base, bucket] of buckets) {
     if (bucket.length === 1) {
-      const only = bucket[0];
-      if (only !== undefined) out.set(only.id, base);
+      // Bucket guaranteed non-empty by Pass 1; non-null assertion
+      // satisfies tsconfig's `noUncheckedIndexedAccess`.
+      out.set(bucket[0]!.id, base);
       continue;
     }
 
@@ -74,8 +75,7 @@ export const assignSlugs = (
 
     for (const [mileSlug, inner] of byMileSlug) {
       if (inner.length === 1) {
-        const only = inner[0];
-        if (only !== undefined) out.set(only.id, mileSlug);
+        out.set(inner[0]!.id, mileSlug);
       } else {
         // Pass 3: still colliding — append the legacy id. By
         // construction these ids are unique.

--- a/src/store/__tests__/selected-site.test.ts
+++ b/src/store/__tests__/selected-site.test.ts
@@ -6,6 +6,7 @@ import { useSelectedSite } from '../selected-site';
 const fakeSite = (id: string): Site => ({
   id: siteId(id),
   name: 'Blalock Canyon',
+  slug: 'blalock-canyon',
   riverSegment: 'Lake Umatilla',
   riverName: 'Columbia',
   riverMile: 234,


### PR DESCRIPTION
## Summary

Closes the per-site URL gap from
[`docs/gap-analysis.md`](./docs/gap-analysis.md). Every site now
has a shareable, bookmarkable, indexable, printable page at
`/sites/<slug>`. The map's selection state mirrors into
`?site=<slug>` on the home page, so a marker click is shareable
without a full navigation.

Phase 9 of [`docs/plans/feature-parity.md`](./docs/plans/feature-parity.md).

## What changed

- **Slug derivation** (`src/domain/slug.ts`) — pure 3-tier
  collision strategy:
  1. `slugify(name)` when unique.
  2. `slugify(name)-mile-N` (decimals encoded `2-5`) when names
     collide on different miles.
  3. `slugify(name)-{site.id}` when names AND miles collide
     (Granite Point pair — the only true source-data dupe).
- **`Site.slug`** added as a required field. Parser does a
  2-pass: `toDraft` → `assignSlugs` across the whole set →
  finalize.
- **`SiteDetails.tsx`** extracted from `SiteInfoPanel` as two
  reusable pieces (`SiteHeading` + `SiteBody`) so the drawer and
  the new dedicated page share the same content with different
  chrome.
- **`app/sites/[slug]/page.tsx`** — server component using
  `generateStaticParams` to enumerate all 159 sites; per-site
  `generateMetadata` for OpenGraph; "View on map" link back to
  `/?site=<slug>`; print-friendly CSS via `@media print` in
  `globals.css` that hides header/footer chrome.
- **`useSiteUrlSync`** in `MapApp` — deep-link `?site=<slug>` on
  mount; mirror `selectedSite` changes into the URL via
  `history.replaceState` (no Next router round-trip, no re-render).
- **Dropped `--single` SPA fallback** from `npm run preview` and
  the Playwright webServer command. Every route emits a real
  `index.html` under `output: 'export'`; fallback was masking the
  new dynamic-segment pages during e2e and would mask 404s in
  production preview.

## Test plan

- [x] `npm run lint` — clean (no errors)
- [x] `npm run lint:md` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 75/75 (5 new in `slug.test.ts`)
- [x] `npm run build` — produces 159 `/sites/<slug>/index.html`
      files; sample slug `blalock-canyon` confirmed end-to-end
- [x] `npx playwright test --workers=1` — 13/13 (4 new in
      `site-pages.spec.ts`: dedicated page renders, per-page
      metadata, deep-link opens panel, print hides chrome)
- [ ] Bot triage round (Gemini, Copilot, DeepSource, SonarCloud)
      after CI is green
- [ ] Manual browser sweep: click a marker → URL gets
      `?site=...`; close drawer → URL clears; copy/paste
      `/?site=blalock-canyon` to a new tab → drawer opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)