### PR TITLE
feat: phase 10 — site index / browse-by-list

### DIFF
--- a/app/sites/page.tsx
+++ b/app/sites/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
   description:
     'Browse every launch site, campground, and day-use area on the ' +
     '367-mile Northwest Discovery Water Trail. Filter by name, river, ' +
-    'or facility.',
+    'or facilities.',
 };
 
 const pageStyle = css({

--- a/app/sites/page.tsx
+++ b/app/sites/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+import { css } from 'styled-system/css';
+
+import { loadSites } from '@/adapters/inbound/next/load-sites';
+import SiteIndex from '@/components/sites/SiteIndex';
+
+export const metadata: Metadata = {
+  title: 'Sites — Northwest Discovery Water Trail',
+  description:
+    'Browse every launch site, campground, and day-use area on the ' +
+    '367-mile Northwest Discovery Water Trail. Filter by name, river, ' +
+    'or facility.',
+};
+
+const pageStyle = css({
+  maxWidth: '5xl',
+  marginX: 'auto',
+  paddingX: { base: '4', md: '6' },
+  paddingY: { base: '6', md: '10' },
+  color: 'fg.default',
+});
+
+export default async function SitesIndexPage() {
+  const sites = await loadSites();
+  return (
+    <main className={pageStyle}>
+      <SiteIndex sites={sites} />
+    </main>
+  );
+}

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -6,7 +6,7 @@
 | ----- | ----------------------------------------------------- | ------------- |
 | 8     | Data enrichment — names, notes, fees, state/county    | Done (PR #39) |
 | 9     | Per-site canonical URLs (`/sites/<slug>`)             | In review     |
-| 10    | Site index / browse-by-list                           | Planned       |
+| 10    | Site index / browse-by-list                           | In review     |
 | 11    | Water Safety + River Navigation + Leave No Trace      | Planned       |
 | 12    | Natural World + Past & Present                        | Planned       |
 | 13    | About expansion + Get Involved + Photo Gallery        | Planned       |

--- a/e2e/sites-index.spec.ts
+++ b/e2e/sites-index.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Site index — /sites/ (Phase 10)', () => {
+  test('renders an h1 + result count + link list', async ({ page }) => {
+    await page.goto('/sites/');
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Sites' })
+    ).toBeVisible();
+
+    const count = page.getByTestId('site-index-count');
+    await expect(count).toContainText(/\d+ of \d+ sites/u);
+
+    const results = page.getByTestId('site-index-results');
+    // 159 sites in the dataset → result list has at least 100 rows.
+    await expect(results.locator('li')).toHaveCount(159);
+  });
+
+  test('typing into the name filter narrows results to a single match', async ({
+    page,
+  }) => {
+    await page.goto('/sites/');
+
+    const query = page.getByTestId('site-index-query');
+    await query.fill('blalock');
+
+    const results = page.getByTestId('site-index-results');
+    await expect(results.locator('li')).toHaveCount(1);
+
+    const link = page.getByTestId('site-index-row-blalock-canyon');
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(/\/sites\/blalock-canyon\/?$/u);
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Blalock Canyon' })
+    ).toBeVisible();
+  });
+
+  test('the river dropdown filters by river name', async ({ page }) => {
+    await page.goto('/sites/');
+    const before = await page
+      .getByTestId('site-index-results')
+      .locator('li')
+      .count();
+
+    await page
+      .getByTestId('site-index-river')
+      .selectOption({ label: 'Clearwater' });
+
+    const after = await page
+      .getByTestId('site-index-results')
+      .locator('li')
+      .count();
+    expect(after).toBeLessThan(before);
+    expect(after).toBeGreaterThan(0);
+  });
+
+  test('Header has a "Sites" link going to /sites/', async ({ page }) => {
+    await page.goto('/');
+    const sitesLink = page.getByRole('link', { name: 'Sites' });
+    await expect(sitesLink).toBeVisible();
+    await sitesLink.click();
+    await expect(page).toHaveURL(/\/sites\/?$/u);
+  });
+});

--- a/e2e/sites-index.spec.ts
+++ b/e2e/sites-index.spec.ts
@@ -11,9 +11,17 @@ test.describe('Site index — /sites/ (Phase 10)', () => {
     const count = page.getByTestId('site-index-count');
     await expect(count).toContainText(/\d+ of \d+ sites/u);
 
+    // Derive the expected row count from the rendered count text
+    // rather than hard-coding the dataset size — the test stays
+    // green when ndwt-enriched data grows or shrinks.
+    const countText = await count.textContent();
+    const totalMatch = countText?.match(/\d+ of (\d+) sites/u);
+    expect(totalMatch).not.toBeNull();
+    const totalSites = Number(totalMatch?.[1] ?? '0');
+    expect(totalSites).toBeGreaterThan(100);
+
     const results = page.getByTestId('site-index-results');
-    // 159 sites in the dataset → result list has at least 100 rows.
-    await expect(results.locator('li')).toHaveCount(159);
+    await expect(results.locator('li')).toHaveCount(totalSites);
   });
 
   test('typing into the name filter narrows results to a single match', async ({

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { css } from 'styled-system/css';
 
 const NAV_ITEMS = [
   { href: '/', label: 'Map' },
+  { href: '/sites/', label: 'Sites' },
   { href: '/about/', label: 'About' },
   { href: '/trip-planning/', label: 'Trip Planning' },
 ] as const;

--- a/src/components/sites/SiteIndex.tsx
+++ b/src/components/sites/SiteIndex.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { css } from 'styled-system/css';
+
+import {
+  collectRivers,
+  FACILITIES,
+  type Facility,
+  filterSites,
+  type Site,
+  type SiteFilter,
+  type SiteSortMode,
+  sortSites,
+} from '../../domain';
+import FacilityBadges from '../panels/FacilityBadges';
+import { Box } from '../ui/box';
+import { Heading } from '../ui/heading';
+import { Link } from '../ui/link';
+import { Stack } from '../ui/stack';
+import { Text } from '../ui/text';
+
+const FACILITY_LABELS: Record<Facility, string> = {
+  restrooms: 'Restrooms',
+  potableWater: 'Potable water',
+  marineDumpStation: 'Marine dump station',
+  dayUseOnly: 'Day use only',
+  picnicShelters: 'Picnic shelters',
+  boatRamp: 'Boat ramp',
+  handCarried: 'Hand-carried launch',
+  marina: 'Marina',
+  adaAccess: 'ADA access',
+};
+
+interface SiteIndexProps {
+  readonly sites: readonly Site[];
+}
+
+const formatRowSubtitle = (site: Site): string =>
+  [
+    `${site.riverName} River · Mile ${site.riverMile}`,
+    site.riverSegment,
+    site.bank,
+  ]
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' · ');
+
+const controlsStyle = css({
+  display: 'grid',
+  gap: '4',
+  gridTemplateColumns: { base: '1fr', md: '1fr 1fr auto' },
+  alignItems: 'end',
+  marginBottom: '4',
+});
+
+const controlLabelStyle = css({
+  display: 'block',
+  fontSize: 'sm',
+  color: 'fg.muted',
+  marginBottom: '1',
+  textTransform: 'uppercase',
+  letterSpacing: 'wider',
+});
+
+const inputStyle = css({
+  width: '100%',
+  paddingX: '3',
+  paddingY: '2',
+  fontSize: 'md',
+  borderRadius: 'md',
+  borderWidth: '1px',
+  borderColor: 'gray.7',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  _focus: {
+    outline: 'none',
+    borderColor: 'colorPalette.9',
+    colorPalette: 'green',
+  },
+});
+
+const facilityToggleListStyle = css({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '2',
+  marginBottom: '6',
+});
+
+const facilityToggleStyle = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '1',
+  paddingX: '3',
+  paddingY: '1',
+  fontSize: 'sm',
+  borderRadius: 'full',
+  borderWidth: '1px',
+  borderColor: 'gray.7',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  cursor: 'pointer',
+  _hover: { backgroundColor: 'gray.3' },
+  '&[aria-pressed="true"]': {
+    backgroundColor: 'colorPalette.9',
+    borderColor: 'colorPalette.9',
+    color: 'colorPalette.contrast',
+    colorPalette: 'green',
+  },
+});
+
+const resultsListStyle = css({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2',
+});
+
+const resultRowStyle = css({
+  display: 'block',
+  paddingX: '4',
+  paddingY: '3',
+  borderRadius: 'md',
+  borderWidth: '1px',
+  borderColor: 'gray.6',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  textDecoration: 'none',
+  _hover: {
+    borderColor: 'colorPalette.9',
+    colorPalette: 'green',
+  },
+});
+
+const resultCountStyle = css({
+  fontSize: 'sm',
+  color: 'fg.muted',
+  marginBottom: '3',
+});
+
+export default function SiteIndex({ sites }: SiteIndexProps) {
+  const [query, setQuery] = useState('');
+  const [river, setRiver] = useState<string | null>(null);
+  const [facilities, setFacilities] = useState<ReadonlySet<Facility>>(
+    new Set<Facility>()
+  );
+  const [sortMode, setSortMode] = useState<SiteSortMode>('river-mile');
+
+  const rivers = useMemo(() => collectRivers(sites), [sites]);
+
+  const filter: SiteFilter = { query, river, facilities };
+  const visible = useMemo(
+    () => sortSites(filterSites(sites, filter), sortMode),
+    // filter is rebuilt every render but its parts are stable refs
+    // so depending on each piece individually keeps the memo honest.
+    [sites, query, river, facilities, sortMode]
+  );
+
+  const toggleFacility = (facility: Facility) => {
+    setFacilities((prev) => {
+      const next = new Set(prev);
+      if (next.has(facility)) next.delete(facility);
+      else next.add(facility);
+      return next;
+    });
+  };
+
+  return (
+    <Stack gap="4">
+      <Heading as="h1" size="2xl">
+        Sites
+      </Heading>
+      <Text as="p" css={{ color: 'fg.muted' }}>
+        {sites.length} access sites along the Northwest Discovery Water Trail.
+        Filter by name, river, or facilities.
+      </Text>
+
+      <Box className={controlsStyle}>
+        <label>
+          <span className={controlLabelStyle}>Name</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="e.g. Blalock"
+            className={inputStyle}
+            data-testid="site-index-query"
+          />
+        </label>
+        <label>
+          <span className={controlLabelStyle}>River</span>
+          <select
+            value={river ?? ''}
+            onChange={(event) =>
+              setRiver(event.target.value === '' ? null : event.target.value)
+            }
+            className={inputStyle}
+            data-testid="site-index-river"
+          >
+            <option value="">All rivers</option>
+            {rivers.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span className={controlLabelStyle}>Sort</span>
+          <select
+            value={sortMode}
+            onChange={(event) =>
+              setSortMode(event.target.value as SiteSortMode)
+            }
+            className={inputStyle}
+            data-testid="site-index-sort"
+          >
+            <option value="river-mile">By river + mile</option>
+            <option value="alpha">A → Z</option>
+          </select>
+        </label>
+      </Box>
+
+      <fieldset
+        className={css({ border: 'none', padding: 0, margin: 0 })}
+        aria-label="Filter by facility"
+      >
+        <ul className={facilityToggleListStyle}>
+          {FACILITIES.map((facility) => {
+            const pressed = facilities.has(facility);
+            return (
+              <li key={facility}>
+                <button
+                  type="button"
+                  aria-pressed={pressed}
+                  onClick={() => toggleFacility(facility)}
+                  className={facilityToggleStyle}
+                  data-testid={`site-index-facility-${facility}`}
+                >
+                  {FACILITY_LABELS[facility]}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </fieldset>
+
+      <p
+        className={resultCountStyle}
+        aria-live="polite"
+        data-testid="site-index-count"
+      >
+        {visible.length} of {sites.length} sites
+      </p>
+
+      <ol
+        className={resultsListStyle}
+        aria-label="Filtered sites"
+        data-testid="site-index-results"
+      >
+        {visible.map((site) => (
+          <li key={site.id}>
+            <Link
+              href={`/sites/${site.slug}`}
+              className={resultRowStyle}
+              data-testid={`site-index-row-${site.slug}`}
+            >
+              <Text
+                as="span"
+                css={{ fontWeight: 'semibold', display: 'block' }}
+              >
+                {site.name}
+              </Text>
+              <Text
+                as="span"
+                css={{
+                  fontSize: 'sm',
+                  color: 'fg.muted',
+                  display: 'block',
+                  marginTop: '1',
+                }}
+              >
+                {formatRowSubtitle(site)}
+              </Text>
+              {site.facilities.length === 0 ? null : (
+                <Box css={{ marginTop: '2' }}>
+                  <FacilityBadges facilities={site.facilities} />
+                </Box>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ol>
+    </Stack>
+  );
+}

--- a/src/components/sites/SiteIndex.tsx
+++ b/src/components/sites/SiteIndex.tsx
@@ -142,6 +142,126 @@ const resultCountStyle = css({
   marginBottom: '3',
 });
 
+interface FilterControlsProps {
+  readonly query: string;
+  readonly onQueryChange: (next: string) => void;
+  readonly river: string | null;
+  readonly onRiverChange: (next: string | null) => void;
+  readonly sortMode: SiteSortMode;
+  readonly onSortChange: (next: SiteSortMode) => void;
+  readonly rivers: readonly string[];
+}
+
+const FilterControls = ({
+  query,
+  onQueryChange,
+  river,
+  onRiverChange,
+  sortMode,
+  onSortChange,
+  rivers,
+}: FilterControlsProps) => (
+  <Box className={controlsStyle}>
+    <label>
+      <span className={controlLabelStyle}>Name</span>
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        placeholder="e.g. Blalock"
+        className={inputStyle}
+        data-testid="site-index-query"
+      />
+    </label>
+    <label>
+      <span className={controlLabelStyle}>River</span>
+      <select
+        value={river ?? ''}
+        onChange={(event) =>
+          onRiverChange(event.target.value === '' ? null : event.target.value)
+        }
+        className={inputStyle}
+        data-testid="site-index-river"
+      >
+        <option value="">All rivers</option>
+        {rivers.map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+    </label>
+    <label>
+      <span className={controlLabelStyle}>Sort</span>
+      <select
+        value={sortMode}
+        onChange={(event) => onSortChange(event.target.value as SiteSortMode)}
+        className={inputStyle}
+        data-testid="site-index-sort"
+      >
+        <option value="river-mile">By river + mile</option>
+        <option value="alpha">A → Z</option>
+      </select>
+    </label>
+  </Box>
+);
+
+interface FacilityTogglesProps {
+  readonly facilities: ReadonlySet<Facility>;
+  readonly onToggle: (facility: Facility) => void;
+}
+
+const FacilityToggles = ({ facilities, onToggle }: FacilityTogglesProps) => (
+  <fieldset
+    className={css({ border: 'none', padding: 0, margin: 0 })}
+    aria-label="Filter by facility"
+  >
+    <ul className={facilityToggleListStyle}>
+      {FACILITIES.map((facility) => (
+        <li key={facility}>
+          <button
+            type="button"
+            aria-pressed={facilities.has(facility)}
+            onClick={() => onToggle(facility)}
+            className={facilityToggleStyle}
+            data-testid={`site-index-facility-${facility}`}
+          >
+            {FACILITY_LABELS[facility]}
+          </button>
+        </li>
+      ))}
+    </ul>
+  </fieldset>
+);
+
+const SiteRow = ({ site }: { readonly site: Site }) => (
+  <Link
+    href={`/sites/${site.slug}`}
+    className={resultRowStyle}
+    data-testid={`site-index-row-${site.slug}`}
+  >
+    <Text as="span" css={{ fontWeight: 'semibold', display: 'block' }}>
+      {site.name}
+    </Text>
+    <Text
+      as="span"
+      css={{
+        fontSize: 'sm',
+        color: 'fg.muted',
+        display: 'block',
+        marginTop: '1',
+      }}
+    >
+      {formatRowSubtitle(site)}
+    </Text>
+    {site.facilities.length === 0 ? null : (
+      <Box css={{ marginTop: '2' }}>
+        <FacilityBadges facilities={site.facilities} />
+      </Box>
+    )}
+  </Link>
+);
+
 export default function SiteIndex({ sites }: SiteIndexProps) {
   const [query, setQuery] = useState('');
   const [river, setRiver] = useState<string | null>(null);
@@ -179,75 +299,17 @@ export default function SiteIndex({ sites }: SiteIndexProps) {
         Filter by name, river, or facilities.
       </Text>
 
-      <Box className={controlsStyle}>
-        <label>
-          <span className={controlLabelStyle}>Name</span>
-          <input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="e.g. Blalock"
-            className={inputStyle}
-            data-testid="site-index-query"
-          />
-        </label>
-        <label>
-          <span className={controlLabelStyle}>River</span>
-          <select
-            value={river ?? ''}
-            onChange={(event) =>
-              setRiver(event.target.value === '' ? null : event.target.value)
-            }
-            className={inputStyle}
-            data-testid="site-index-river"
-          >
-            <option value="">All rivers</option>
-            {rivers.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          <span className={controlLabelStyle}>Sort</span>
-          <select
-            value={sortMode}
-            onChange={(event) =>
-              setSortMode(event.target.value as SiteSortMode)
-            }
-            className={inputStyle}
-            data-testid="site-index-sort"
-          >
-            <option value="river-mile">By river + mile</option>
-            <option value="alpha">A → Z</option>
-          </select>
-        </label>
-      </Box>
+      <FilterControls
+        query={query}
+        onQueryChange={setQuery}
+        river={river}
+        onRiverChange={setRiver}
+        sortMode={sortMode}
+        onSortChange={setSortMode}
+        rivers={rivers}
+      />
 
-      <fieldset
-        className={css({ border: 'none', padding: 0, margin: 0 })}
-        aria-label="Filter by facility"
-      >
-        <ul className={facilityToggleListStyle}>
-          {FACILITIES.map((facility) => {
-            const pressed = facilities.has(facility);
-            return (
-              <li key={facility}>
-                <button
-                  type="button"
-                  aria-pressed={pressed}
-                  onClick={() => toggleFacility(facility)}
-                  className={facilityToggleStyle}
-                  data-testid={`site-index-facility-${facility}`}
-                >
-                  {FACILITY_LABELS[facility]}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </fieldset>
+      <FacilityToggles facilities={facilities} onToggle={toggleFacility} />
 
       <p
         className={resultCountStyle}
@@ -264,34 +326,7 @@ export default function SiteIndex({ sites }: SiteIndexProps) {
       >
         {visible.map((site) => (
           <li key={site.id}>
-            <Link
-              href={`/sites/${site.slug}`}
-              className={resultRowStyle}
-              data-testid={`site-index-row-${site.slug}`}
-            >
-              <Text
-                as="span"
-                css={{ fontWeight: 'semibold', display: 'block' }}
-              >
-                {site.name}
-              </Text>
-              <Text
-                as="span"
-                css={{
-                  fontSize: 'sm',
-                  color: 'fg.muted',
-                  display: 'block',
-                  marginTop: '1',
-                }}
-              >
-                {formatRowSubtitle(site)}
-              </Text>
-              {site.facilities.length === 0 ? null : (
-                <Box css={{ marginTop: '2' }}>
-                  <FacilityBadges facilities={site.facilities} />
-                </Box>
-              )}
-            </Link>
+            <SiteRow site={site} />
           </li>
         ))}
       </ol>

--- a/src/components/sites/__tests__/SiteIndex.test.tsx
+++ b/src/components/sites/__tests__/SiteIndex.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import { coordinates } from '../../../domain/coordinates';
+import { FacilitySet } from '../../../domain/facility';
+import { type Site, siteId } from '../../../domain/site';
+import SiteIndex from '../SiteIndex';
+
+const make = (
+  partial: Partial<Site> & Pick<Site, 'name' | 'riverName' | 'riverMile'>
+): Site => ({
+  id: siteId(partial.name.toLowerCase().replaceAll(' ', '-')),
+  slug: partial.name.toLowerCase().replaceAll(' ', '-'),
+  riverSegment: '',
+  bank: '',
+  coordinates: coordinates(0, 0),
+  facilities: FacilitySet.empty(),
+  ...partial,
+});
+
+const fixtures: readonly Site[] = [
+  make({ name: 'Blalock Canyon', riverName: 'Columbia', riverMile: 234 }),
+  make({
+    name: 'Hood Park',
+    riverName: 'Snake',
+    riverMile: 2,
+    facilities: FacilitySet.fromFlags({ boatRamp: true, restrooms: true }),
+  }),
+  make({
+    name: 'Hells Gate State Park',
+    riverName: 'Snake',
+    riverMile: 142,
+    facilities: FacilitySet.fromFlags({ boatRamp: true, marina: true }),
+  }),
+  make({ name: 'Canoe Camp', riverName: 'Clearwater', riverMile: 1 }),
+];
+
+const renderIndex = () => render(<SiteIndex sites={fixtures} />);
+
+describe('<SiteIndex />', () => {
+  it('renders all sites and a result count by default', () => {
+    renderIndex();
+    expect(screen.getByTestId('site-index-count')).toHaveTextContent(
+      '4 of 4 sites'
+    );
+    const results = screen.getByTestId('site-index-results');
+    expect(within(results).getAllByRole('listitem')).toHaveLength(4);
+  });
+
+  it('narrows results when the user types into the name filter', () => {
+    renderIndex();
+    fireEvent.change(screen.getByTestId('site-index-query'), {
+      target: { value: 'blal' },
+    });
+    expect(screen.getByTestId('site-index-count')).toHaveTextContent(
+      '1 of 4 sites'
+    );
+    expect(screen.getByTestId('site-index-row-blalock-canyon')).toBeVisible();
+  });
+
+  it('filters by river when the dropdown changes', () => {
+    renderIndex();
+    fireEvent.change(screen.getByTestId('site-index-river'), {
+      target: { value: 'Snake' },
+    });
+    expect(screen.getByTestId('site-index-count')).toHaveTextContent(
+      '2 of 4 sites'
+    );
+    expect(screen.getByTestId('site-index-row-hood-park')).toBeVisible();
+    expect(
+      screen.queryByTestId('site-index-row-blalock-canyon')
+    ).not.toBeInTheDocument();
+  });
+
+  it('AND-combines facility toggles with the other filters', () => {
+    renderIndex();
+    fireEvent.click(screen.getByTestId('site-index-facility-marina'));
+    expect(screen.getByTestId('site-index-count')).toHaveTextContent(
+      '1 of 4 sites'
+    );
+    expect(
+      screen.getByTestId('site-index-row-hells-gate-state-park')
+    ).toBeVisible();
+  });
+
+  it('toggles a facility off when its button is clicked twice', () => {
+    renderIndex();
+    const button = screen.getByTestId('site-index-facility-marina');
+    fireEvent.click(button); // on
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(button); // off
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('site-index-count')).toHaveTextContent(
+      '4 of 4 sites'
+    );
+  });
+
+  it('switches sort order to alphabetical', () => {
+    renderIndex();
+    fireEvent.change(screen.getByTestId('site-index-sort'), {
+      target: { value: 'alpha' },
+    });
+    // First row's link text is the alphabetically-first site name
+    // across the fixtures (Blalock Canyon). Reach the first link
+    // via getAllByRole + index — `rows[0]!` would trip
+    // DeepSource's no-non-null-assertion rule.
+    const links = within(screen.getByTestId('site-index-results')).getAllByRole(
+      'link'
+    );
+    expect(links).toHaveLength(4);
+    expect(links[0]).toHaveTextContent('Blalock Canyon');
+  });
+
+  it('points each result row at /sites/<slug>', () => {
+    renderIndex();
+    expect(screen.getByTestId('site-index-row-blalock-canyon')).toHaveAttribute(
+      'href',
+      '/sites/blalock-canyon'
+    );
+  });
+});

--- a/src/domain/__tests__/site-filter.test.ts
+++ b/src/domain/__tests__/site-filter.test.ts
@@ -5,8 +5,8 @@ import { type Facility, FacilitySet } from '../facility';
 import { type Site, siteId } from '../site';
 import {
   collectRivers,
-  emptyFilter,
   filterSites,
+  makeEmptyFilter,
   sortSites,
 } from '../site-filter';
 
@@ -46,18 +46,24 @@ const fixtures: readonly Site[] = [
 ];
 
 describe('filterSites', () => {
-  it('returns the input unchanged for the empty filter', () => {
-    expect(filterSites(fixtures, emptyFilter)).toEqual(fixtures);
+  it('returns all sites for the empty filter', () => {
+    expect(filterSites(fixtures, makeEmptyFilter())).toEqual(fixtures);
   });
 
   it('matches names case-insensitively as a substring', () => {
-    const result = filterSites(fixtures, { ...emptyFilter, query: 'BLAL' });
+    const result = filterSites(fixtures, {
+      ...makeEmptyFilter(),
+      query: 'BLAL',
+    });
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('Blalock Canyon');
   });
 
   it('narrows by river', () => {
-    const result = filterSites(fixtures, { ...emptyFilter, river: 'Snake' });
+    const result = filterSites(fixtures, {
+      ...makeEmptyFilter(),
+      river: 'Snake',
+    });
     expect(result.map((s) => s.name)).toEqual([
       'Hood Park',
       'Hells Gate State Park',
@@ -66,7 +72,7 @@ describe('filterSites', () => {
 
   it('AND-combines facility filters (every facility must be present)', () => {
     const facilities = new Set<Facility>(['boatRamp', 'marina']);
-    const result = filterSites(fixtures, { ...emptyFilter, facilities });
+    const result = filterSites(fixtures, { ...makeEmptyFilter(), facilities });
     expect(result.map((s) => s.name)).toEqual(['Hells Gate State Park']);
   });
 

--- a/src/domain/__tests__/site-filter.test.ts
+++ b/src/domain/__tests__/site-filter.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { coordinates } from '../coordinates';
+import { type Facility, FacilitySet } from '../facility';
+import { type Site, siteId } from '../site';
+import {
+  collectRivers,
+  emptyFilter,
+  filterSites,
+  sortSites,
+} from '../site-filter';
+
+const make = (
+  partial: Partial<Site> & Pick<Site, 'name' | 'riverName' | 'riverMile'>
+): Site => ({
+  id: siteId(partial.name.toLowerCase().replaceAll(' ', '-')),
+  slug: partial.name.toLowerCase().replaceAll(' ', '-'),
+  riverSegment: '',
+  bank: '',
+  coordinates: coordinates(0, 0),
+  facilities: FacilitySet.empty(),
+  ...partial,
+});
+
+const fixtures: readonly Site[] = [
+  make({ name: 'Blalock Canyon', riverName: 'Columbia', riverMile: 234 }),
+  make({
+    name: 'Hood Park',
+    riverName: 'Snake',
+    riverMile: 2,
+    facilities: FacilitySet.fromFlags({ boatRamp: true, restrooms: true }),
+  }),
+  make({
+    name: 'Hells Gate State Park',
+    riverName: 'Snake',
+    riverMile: 142,
+    facilities: FacilitySet.fromFlags({ boatRamp: true, marina: true }),
+  }),
+  make({ name: 'Canoe Camp', riverName: 'Clearwater', riverMile: 1 }),
+  make({
+    name: 'Avery Park',
+    riverName: 'Columbia',
+    riverMile: 220,
+    facilities: FacilitySet.fromFlags({ restrooms: true }),
+  }),
+];
+
+describe('filterSites', () => {
+  it('returns the input unchanged for the empty filter', () => {
+    expect(filterSites(fixtures, emptyFilter)).toEqual(fixtures);
+  });
+
+  it('matches names case-insensitively as a substring', () => {
+    const result = filterSites(fixtures, { ...emptyFilter, query: 'BLAL' });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('Blalock Canyon');
+  });
+
+  it('narrows by river', () => {
+    const result = filterSites(fixtures, { ...emptyFilter, river: 'Snake' });
+    expect(result.map((s) => s.name)).toEqual([
+      'Hood Park',
+      'Hells Gate State Park',
+    ]);
+  });
+
+  it('AND-combines facility filters (every facility must be present)', () => {
+    const facilities = new Set<Facility>(['boatRamp', 'marina']);
+    const result = filterSites(fixtures, { ...emptyFilter, facilities });
+    expect(result.map((s) => s.name)).toEqual(['Hells Gate State Park']);
+  });
+
+  it('combines query + river + facilities', () => {
+    const facilities = new Set<Facility>(['restrooms']);
+    const result = filterSites(fixtures, {
+      query: 'park',
+      river: 'Columbia',
+      facilities,
+    });
+    expect(result.map((s) => s.name)).toEqual(['Avery Park']);
+  });
+});
+
+describe('sortSites', () => {
+  it('default river-mile groups by river name then ascending mile', () => {
+    const result = sortSites(fixtures, 'river-mile');
+    expect(result.map((s) => s.name)).toEqual([
+      'Canoe Camp', // Clearwater 1
+      'Avery Park', // Columbia 220
+      'Blalock Canyon', // Columbia 234
+      'Hood Park', // Snake 2
+      'Hells Gate State Park', // Snake 142
+    ]);
+  });
+
+  it('alpha sorts by name', () => {
+    const result = sortSites(fixtures, 'alpha');
+    expect(result.map((s) => s.name)).toEqual([
+      'Avery Park',
+      'Blalock Canyon',
+      'Canoe Camp',
+      'Hells Gate State Park',
+      'Hood Park',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = fixtures.map((s) => s.name);
+    sortSites(fixtures, 'alpha');
+    expect(fixtures.map((s) => s.name)).toEqual(before);
+  });
+});
+
+describe('collectRivers', () => {
+  it('returns distinct river names sorted alphabetically', () => {
+    expect(collectRivers(fixtures)).toEqual([
+      'Clearwater',
+      'Columbia',
+      'Snake',
+    ]);
+  });
+
+  it('drops empty river names', () => {
+    const withBlank = [
+      ...fixtures,
+      make({ name: 'No River', riverName: '', riverMile: 0 }),
+    ];
+    expect(collectRivers(withBlank)).toEqual([
+      'Clearwater',
+      'Columbia',
+      'Snake',
+    ]);
+  });
+});

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -6,8 +6,8 @@ export type { Site, SiteId } from './site';
 export { siteId } from './site';
 export {
   collectRivers,
-  emptyFilter,
   filterSites,
+  makeEmptyFilter,
   type SiteFilter,
   type SiteSortMode,
   sortSites,

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -4,4 +4,12 @@ export type { Facility } from './facility';
 export { FACILITIES, FacilitySet, hasFacility } from './facility';
 export type { Site, SiteId } from './site';
 export { siteId } from './site';
+export {
+  collectRivers,
+  emptyFilter,
+  filterSites,
+  type SiteFilter,
+  type SiteSortMode,
+  sortSites,
+} from './site-filter';
 export { assignSlugs, type SluggableSite } from './slug';

--- a/src/domain/site-filter.ts
+++ b/src/domain/site-filter.ts
@@ -18,11 +18,16 @@ export interface SiteFilter {
   readonly facilities: ReadonlySet<Facility>;
 }
 
-export const emptyFilter: SiteFilter = {
+/**
+ * Returns a fresh "match everything" filter. Factory rather than a
+ * shared constant so callers (especially tests) can't accidentally
+ * mutate the `facilities` Set into each other's state.
+ */
+export const makeEmptyFilter = (): SiteFilter => ({
   query: '',
   river: null,
   facilities: new Set<Facility>(),
-};
+});
 
 const matchesQuery = (site: Site, query: string): boolean => {
   if (query === '') return true;

--- a/src/domain/site-filter.ts
+++ b/src/domain/site-filter.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure filter + sort helpers for the `/sites/` index page.
+ *
+ * Kept in the domain layer because they're framework-agnostic and
+ * easy to unit test against fixtures. The UI layer (`SiteIndex`)
+ * owns the input state via `useState` and pipes it through these
+ * functions on every render.
+ */
+
+import type { Facility } from './facility';
+import type { Site } from './site';
+
+export type SiteSortMode = 'river-mile' | 'alpha';
+
+export interface SiteFilter {
+  readonly query: string;
+  readonly river: string | null;
+  readonly facilities: ReadonlySet<Facility>;
+}
+
+export const emptyFilter: SiteFilter = {
+  query: '',
+  river: null,
+  facilities: new Set<Facility>(),
+};
+
+const matchesQuery = (site: Site, query: string): boolean => {
+  if (query === '') return true;
+  return site.name.toLowerCase().includes(query.toLowerCase());
+};
+
+const matchesRiver = (site: Site, river: string | null): boolean =>
+  river === null || site.riverName === river;
+
+const matchesFacilities = (
+  site: Site,
+  facilities: ReadonlySet<Facility>
+): boolean => {
+  if (facilities.size === 0) return true;
+  for (const facility of facilities) {
+    if (!site.facilities.includes(facility)) return false;
+  }
+  return true;
+};
+
+export const filterSites = (
+  sites: readonly Site[],
+  filter: SiteFilter
+): readonly Site[] =>
+  sites.filter(
+    (site) =>
+      matchesQuery(site, filter.query) &&
+      matchesRiver(site, filter.river) &&
+      matchesFacilities(site, filter.facilities)
+  );
+
+const compareByRiverMile = (a: Site, b: Site): number => {
+  const byRiver = a.riverName.localeCompare(b.riverName);
+  if (byRiver !== 0) return byRiver;
+  return a.riverMile - b.riverMile;
+};
+
+const compareByName = (a: Site, b: Site): number =>
+  a.name.localeCompare(b.name);
+
+export const sortSites = (
+  sites: readonly Site[],
+  mode: SiteSortMode
+): readonly Site[] => {
+  const cmp = mode === 'alpha' ? compareByName : compareByRiverMile;
+  return [...sites].sort(cmp);
+};
+
+/** Distinct river names present in the dataset, sorted alphabetically. */
+export const collectRivers = (sites: readonly Site[]): readonly string[] => {
+  const seen = new Set<string>();
+  for (const site of sites) {
+    if (site.riverName !== '') seen.add(site.riverName);
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
+};


### PR DESCRIPTION
## Summary

Closes the "I know the name but can't find it on the map" gap
from [`docs/gap-analysis.md`](./docs/gap-analysis.md). Adds
`/sites/` as a sortable, filterable list of every site, with a
**Sites** entry in the Header nav. Coexists with the per-site
detail pages introduced in Phase 9.

Phase 10 of [`docs/plans/feature-parity.md`](./docs/plans/feature-parity.md).

## What changed

- **`src/domain/site-filter.ts`** — pure `filterSites`,
  `sortSites`, `collectRivers`. Filter combines (case-insensitive)
  name substring + river match + facility set (AND-combined).
  Sort modes: `river-mile` (default; river-name then ascending
  mile) or `alpha`.
- **`src/components/sites/SiteIndex.tsx`** — `'use client'`
  component owning `useState` for query / river / facility set /
  sort mode. Renders a 3-column controls grid, a facility toggle
  row using `aria-pressed` buttons, an `aria-live` result count,
  and an `<ol>` of `<Link>` rows to `/sites/<slug>`.
- **`app/sites/page.tsx`** — server component, `loadSites()` +
  per-page metadata. Sits alongside `/sites/[slug]/page.tsx` from
  Phase 9.
- **`Header.tsx`** — `Sites` link added to `NAV_ITEMS`. Active
  state covers both `/sites/` and `/sites/<slug>` via the
  existing `startsWith` logic.

## Test plan

- [x] `npm run lint` — clean (no errors)
- [x] `npm run lint:md` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 95/95 (10 new in `site-filter.test.ts`)
- [x] `npm run build` — produces `out/sites/index.html` plus the
      159 `out/sites/<slug>/index.html` from Phase 9
- [x] `npx playwright test --workers=1` — 17/17 (4 new in
      `sites-index.spec.ts`: list renders 159, name-filter
      narrows + click lands on detail, river filter narrows
      further, Header link navigates)
- [ ] Bot triage round (Gemini, Copilot, DeepSource, SonarCloud)
      after CI is green
- [ ] Manual sweep: type "blalock", confirm one result; toggle
      "Boat ramp" facility, confirm narrowing; switch sort to
      A → Z, confirm reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)