### PR TITLE
feat: phase 13 — about expansion + get involved

### DIFF
--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+
+import ArticleLayout from '@/components/editorial/ArticleLayout';
+import { Heading } from '@/components/ui/heading';
+import { Link } from '@/components/ui/link';
+import { Text } from '@/components/ui/text';
+
+export const metadata: Metadata = {
+  title: 'Contact — About — Northwest Discovery Water Trail',
+  description:
+    'Get in touch with the Washington Water Trails Association about ' +
+    'the Northwest Discovery Water Trail.',
+};
+
+export default function ContactPage() {
+  return (
+    <ArticleLayout
+      breadcrumbs={[
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about/' },
+        { label: 'Contact' },
+      ]}
+    >
+      <Heading as="h1" size="2xl">
+        Contact
+      </Heading>
+      <Text as="p" css={{ marginTop: '4' }}>
+        For comments, questions, or information about the Northwest Discovery
+        Water Trail, contact the Washington Water Trails Association — the
+        trail&rsquo;s managing organization.
+      </Text>
+      <Text as="p" css={{ marginTop: '4' }}>
+        Email:{' '}
+        <Link href="mailto:info@wwta.org" external>
+          info@wwta.org
+        </Link>
+      </Text>
+      <Text as="p" css={{ marginTop: '4' }}>
+        For information about Water Trail development and planning, the WWTA
+        office can be reached at <strong>(206) 545-9161</strong> or via{' '}
+        <Link href="https://www.wwta.org" external>
+          wwta.org
+        </Link>
+        .
+      </Text>
+      <Text as="p" css={{ marginTop: '4' }}>
+        For issues with this site (the map / data / per-site pages), please open
+        an issue at{' '}
+        <Link href="https://github.com/ivanoats/ndwt-ol-chakra/issues" external>
+          github.com/ivanoats/ndwt-ol-chakra
+        </Link>
+        .
+      </Text>
+    </ArticleLayout>
+  );
+}

--- a/app/about/contact/page.tsx
+++ b/app/about/contact/page.tsx
@@ -30,14 +30,12 @@ export default function ContactPage() {
         trail&rsquo;s managing organization.
       </Text>
       <Text as="p" css={{ marginTop: '4' }}>
-        Email:{' '}
-        <Link href="mailto:info@wwta.org" external>
-          info@wwta.org
-        </Link>
+        Email: <Link href="mailto:info@wwta.org">info@wwta.org</Link>
       </Text>
       <Text as="p" css={{ marginTop: '4' }}>
         For information about Water Trail development and planning, the WWTA
-        office can be reached at <strong>(206) 545-9161</strong> or via{' '}
+        office can be reached at{' '}
+        <Link href="tel:+12065459161">(206) 545-9161</Link> or via{' '}
         <Link href="https://www.wwta.org" external>
           wwta.org
         </Link>

--- a/app/about/history/page.tsx
+++ b/app/about/history/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+
+import ArticleLayout from '@/components/editorial/ArticleLayout';
+
+import History from '../../../content/about/history.mdx';
+
+export const metadata: Metadata = {
+  title: 'History — About — Northwest Discovery Water Trail',
+  description:
+    'The 2005 designation events that established the Northwest ' +
+    'Discovery Water Trail — Bonneville Ribbon Cutting, the Mosier ' +
+    'Fall Festival, and the Clearwater Cleanup.',
+};
+
+export default function HistoryPage() {
+  return (
+    <ArticleLayout
+      breadcrumbs={[
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about/' },
+        { label: 'History' },
+      ]}
+    >
+      <History />
+    </ArticleLayout>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -80,6 +80,31 @@ export default function AboutPage() {
         </Link>{' '}
         under the MIT license. Issues and pull requests welcome.
       </p>
+
+      <h2 className={subheadingStyle}>Read more</h2>
+      <ul
+        className={css({
+          marginTop: '3',
+          paddingLeft: '6',
+          listStyle: 'disc',
+          '& li': { marginBottom: '2' },
+        })}
+      >
+        <li>
+          <Link href="/about/partners/">Partners</Link> — funder, manager, and
+          original partner organizations
+        </li>
+        <li>
+          <Link href="/about/history/">History</Link> — 2005 designation events
+        </li>
+        <li>
+          <Link href="/about/photo-gallery/">Photo Gallery</Link> — photos of
+          the trail
+        </li>
+        <li>
+          <Link href="/about/contact/">Contact</Link> — get in touch with WWTA
+        </li>
+      </ul>
     </article>
   );
 }

--- a/app/about/partners/page.tsx
+++ b/app/about/partners/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+
+import ArticleLayout from '@/components/editorial/ArticleLayout';
+
+import Partners from '../../../content/about/partners.mdx';
+
+export const metadata: Metadata = {
+  title: 'Partners — About — Northwest Discovery Water Trail',
+  description:
+    'Partner organizations that developed and maintain the Northwest ' +
+    'Discovery Water Trail, including the National Park Service ' +
+    'funder, WWTA manager, and the Columbia River treaty tribes.',
+};
+
+export default function PartnersPage() {
+  return (
+    <ArticleLayout
+      breadcrumbs={[
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about/' },
+        { label: 'Partners' },
+      ]}
+    >
+      <Partners />
+    </ArticleLayout>
+  );
+}

--- a/app/about/photo-gallery/page.tsx
+++ b/app/about/photo-gallery/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next';
+
+import ArticleLayout from '@/components/editorial/ArticleLayout';
+import { Heading } from '@/components/ui/heading';
+import { Link } from '@/components/ui/link';
+import { Text } from '@/components/ui/text';
+
+export const metadata: Metadata = {
+  title: 'Photo Gallery — About — Northwest Discovery Water Trail',
+  description:
+    'Photos of the Northwest Discovery Water Trail are hosted by the ' +
+    'Washington Water Trails Association.',
+};
+
+// TODO(phase-13): confirm exact WWTA photo-gallery URL with the
+// Executive Director before merge. The placeholder below points
+// at the WWTA root; if the gallery has its own slug (e.g.
+// /photos/), update.
+const GALLERY_URL = 'https://www.wwta.org/';
+
+export default function PhotoGalleryPage() {
+  return (
+    <ArticleLayout
+      breadcrumbs={[
+        { label: 'Home', href: '/' },
+        { label: 'About', href: '/about/' },
+        { label: 'Photo Gallery' },
+      ]}
+    >
+      <Heading as="h1" size="2xl">
+        Photo Gallery
+      </Heading>
+      <Text as="p" css={{ marginTop: '4' }}>
+        Photos of the Northwest Discovery Water Trail are maintained by the
+        Washington Water Trails Association.
+      </Text>
+      <Text as="p" css={{ marginTop: '4' }}>
+        <Link href={GALLERY_URL} external>
+          View the WWTA photo gallery →
+        </Link>
+      </Text>
+      <Text as="p" css={{ marginTop: '6', fontSize: 'sm', color: 'fg.muted' }}>
+        Want to contribute a photo? Email a high-resolution image and any
+        photographer credit to{' '}
+        <Link href="mailto:info@wwta.org" external>
+          info@wwta.org
+        </Link>
+        .
+      </Text>
+    </ArticleLayout>
+  );
+}

--- a/app/about/photo-gallery/page.tsx
+++ b/app/about/photo-gallery/page.tsx
@@ -42,10 +42,7 @@ export default function PhotoGalleryPage() {
       <Text as="p" css={{ marginTop: '6', fontSize: 'sm', color: 'fg.muted' }}>
         Want to contribute a photo? Email a high-resolution image and any
         photographer credit to{' '}
-        <Link href="mailto:info@wwta.org" external>
-          info@wwta.org
-        </Link>
-        .
+        <Link href="mailto:info@wwta.org">info@wwta.org</Link>.
       </Text>
     </ArticleLayout>
   );

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from 'next';
+import { css } from 'styled-system/css';
+
+import ArticleLayout from '@/components/editorial/ArticleLayout';
+import { Box } from '@/components/ui/box';
+import { Heading } from '@/components/ui/heading';
+import { Link } from '@/components/ui/link';
+import { Text } from '@/components/ui/text';
+
+export const metadata: Metadata = {
+  title: 'Get Involved — Northwest Discovery Water Trail',
+  description:
+    'Volunteer, donate, or share a trip report from the Northwest ' +
+    'Discovery Water Trail through the Washington Water Trails ' +
+    'Association.',
+};
+
+// TODO(phase-13): confirm exact WWTA URLs with the Executive
+// Director before merge. The placeholders below point at the
+// WWTA root; if any of these have dedicated slugs
+// (e.g. /volunteer/, /donate/, /trips/), tighten them up.
+const VOLUNTEER_URL = 'https://www.wwta.org/';
+const DONATE_URL = 'https://www.wwta.org/';
+const TRIP_REPORTS_URL = 'https://www.wwta.org/';
+
+const cardStyle = css({
+  display: 'block',
+  paddingX: '5',
+  paddingY: '4',
+  borderRadius: 'md',
+  borderWidth: '1px',
+  borderColor: 'gray.6',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  textDecoration: 'none',
+  marginBottom: '3',
+  _hover: {
+    borderColor: 'colorPalette.9',
+    colorPalette: 'green',
+  },
+});
+
+const cardLabelStyle = css({
+  display: 'block',
+  fontWeight: 'semibold',
+  fontSize: 'lg',
+});
+
+const cardSummaryStyle = css({
+  display: 'block',
+  fontSize: 'sm',
+  color: 'fg.muted',
+  marginTop: '1',
+});
+
+interface CtaProps {
+  readonly title: string;
+  readonly summary: string;
+  readonly href: string;
+}
+
+const Cta = ({ title, summary, href }: CtaProps) => (
+  <Link href={href} className={cardStyle} external>
+    <span className={cardLabelStyle}>{title} →</span>
+    <span className={cardSummaryStyle}>{summary}</span>
+  </Link>
+);
+
+export default function GetInvolvedPage() {
+  return (
+    <ArticleLayout
+      breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Get Involved' }]}
+    >
+      <Heading as="h1" size="2xl">
+        Get Involved
+      </Heading>
+      <Text as="p" css={{ marginTop: '4' }}>
+        The Northwest Discovery Water Trail is managed by the Washington Water
+        Trails Association. Volunteer opportunities, donations, and trip reports
+        are coordinated through WWTA directly:
+      </Text>
+
+      <Box css={{ marginTop: '6' }}>
+        <Cta
+          title="Volunteer"
+          summary="Help maintain the Water Trail with the Washington Water Trails Association."
+          href={VOLUNTEER_URL}
+        />
+        <Cta
+          title="Donate"
+          summary="Support trail development and maintenance through WWTA."
+          href={DONATE_URL}
+        />
+        <Cta
+          title="Share a trip report"
+          summary="Tell WWTA about your Water Trail expedition — photos, conditions, route notes welcome."
+          href={TRIP_REPORTS_URL}
+        />
+      </Box>
+
+      <Text as="p" css={{ marginTop: '6', fontSize: 'sm', color: 'fg.muted' }}>
+        For other questions, see <Link href="/about/contact/">Contact</Link> or
+        visit{' '}
+        <Link href="https://www.wwta.org" external>
+          wwta.org
+        </Link>
+        .
+      </Text>
+    </ArticleLayout>
+  );
+}

--- a/content/about/history.mdx
+++ b/content/about/history.mdx
@@ -1,0 +1,58 @@
+# History
+
+The Northwest Discovery Water Trail was established as a 367-mile
+recreational corridor on the Clearwater, Snake, and Columbia
+rivers — running from Canoe Camp on the Clearwater in Idaho
+down to Bonneville Dam in the Columbia River Gorge.
+
+## Designation events (2005)
+
+### Bonneville Ribbon Cutting — August 26, 2005
+
+Bonneville Dam links the Northwest Discovery and Lower Columbia
+River Water Trails, together offering over 500 miles of river
+travel. During the Taste of Lewis and Clark festival held at the
+dam, visitors and dignitaries — including Washington Congressman
+Brian Baird and Washington State Parks Director Rex Derr —
+boarded the _Columbia Gorge Sternwheeler_ for a ribbon-cutting
+ceremony in the lock. As the crowded sternwheeler approached the
+lock, two volunteers hoisted a ribbon strung from lockwall to
+lockwall over the jack-staff flag pole and onto the deck of the
+moving boat, where water-trail partners and guests cut the ribbon
+and celebrated the opening and connection of the two water
+trails.
+
+### Mosier Fall Festival — September 3, 2005
+
+At Mosier's Labor Day weekend community picnic, the Washington
+Water Trails Association installed the first Northwest Discovery
+Water Trail marker on the Columbia River at the newly-established
+Rock Creek launch site. Mosier is a small Oregon town but a big
+destination for windsurfers and a prime stop on the Northwest
+Discovery Water Trail, where travelers can restock supplies or
+enjoy the town's shops and restaurants.
+
+### Clearwater Cleanup — September 24, 2005
+
+The free-flowing waters of the Clearwater River rush travelers
+through a deep canyon. For years, agencies and community members
+worked to rid the Clearwater of junked cars and abandoned
+appliances that marred the beauty of the river. The Nez Perce
+Tribe and eight other partnering businesses and agencies teamed
+up to remove the last remnants of riverside junk from the Nez
+Perce Reservation near Lapwai, Idaho. Volunteers attached large
+pieces of contorted, rusted cars to a boom crane, which then
+lifted automobile parts from the riverbank into a container bound
+for the recycling center.
+
+## Funding and management
+
+The Water Trail was funded by the National Park Service through
+the Lewis and Clark Challenge Cost Share Program and is managed
+today by the [Washington Water Trails Association](https://www.wwta.org).
+A full list of original partner organizations is on the
+[Partners](/about/partners/) page.
+
+---
+
+_Originally published on [ndwt.org](http://www.ndwt.org/ndwt/about/history.asp); reused with permission from the Washington Water Trails Association — see [project NOTICE](https://github.com/ivanoats/ndwt-ol-chakra/blob/main/NOTICE.md)._

--- a/content/about/partners.mdx
+++ b/content/about/partners.mdx
@@ -1,0 +1,76 @@
+# Partners
+
+The Northwest Discovery Water Trail was developed and is
+maintained through the work of dozens of partner organizations
+across federal, state, county, and private sectors.
+
+## Funder
+
+- **National Park Service** — through the Lewis and Clark
+  Challenge Cost Share Program
+
+## Manager
+
+- [**Washington Water Trails Association**](https://www.wwta.org)
+  (WWTA) — the Water Trail's current managing organization
+
+## Original partner organizations
+
+The 2005 designation of the Water Trail was made possible by
+contributions from the following partners:
+
+- Benton County
+- Bureau of Land Management
+- Citizen Advocates
+- Clearwater County Sheriff's Department
+- Clearwater Management Council
+- Columbia Gorge Windsurfing Association
+- Columbia Kayak Adventures
+- Columbia River Exhibition of History, Science & Technology
+- Columbia River Pilots
+- Columbia Riverkeeper
+- Desert Kayak and Canoe Club
+- Fort Vancouver Regional Library
+- Friends of the Columbia Gorge
+- Hood River Valley Parks & Recreation
+- Ice Age Floods Institute
+- Idaho Department of Parks and Recreation
+- Idaho Governor's Lewis and Clark Trail Committee
+- Lower Columbia River Estuary Partnership
+- Mosier Alliance
+- National Park Service
+- Northern Wasco County Parks and Recreation District
+- Oregon Parks & Recreation Department
+- Oregon State Marine Board
+- ROW Adventures
+- Tapteal Greenway Association
+- Tidewater Barge Lines
+- Tri-Cities Visitor and Convention Bureau
+- Umatilla County Lewis & Clark Bicentennial Committee
+- U.S. Army Corps of Engineers
+- U.S. Coast Guard
+- U.S. Fish and Wildlife Service
+- U.S. Forest Service
+- Vancouver Lewis and Clark Committee
+- Washington State Parks and Recreation Commission
+- Washington Water Trails Association
+
+## Tribal partners
+
+The corridor crosses traditional homelands of many tribal
+nations. The four Columbia River treaty tribes — coordinated
+through the [Columbia River Inter-Tribal Fish Commission](https://critfc.org/) —
+are essential partners in stewardship of the corridor's
+fisheries:
+
+- Confederated Tribes of the Umatilla Indian Reservation
+- Confederated Tribes of the Warm Springs Reservation of Oregon
+- Confederated Tribes and Bands of the Yakama Nation
+- Nez Perce Tribe
+
+See [Tribal Communities](/past-and-present/tribal-communities/)
+for more.
+
+---
+
+_Partner list originally published on [ndwt.org](http://www.ndwt.org/ndwt/about/partners.asp); reused with permission from the Washington Water Trails Association — see [project NOTICE](https://github.com/ivanoats/ndwt-ol-chakra/blob/main/NOTICE.md)._

--- a/docs/plans/feature-parity.md
+++ b/docs/plans/feature-parity.md
@@ -9,7 +9,7 @@
 | 10    | Site index / browse-by-list                           | In review     |
 | 11    | Water Safety + River Navigation + Leave No Trace      | In review     |
 | 12    | Natural World + Past & Present                        | In review     |
-| 13    | About expansion + Get Involved + Photo Gallery        | Planned       |
+| 13    | About expansion + Get Involved + Photo Gallery        | In review     |
 | 14    | Cutover — redirects, sitemap, SEO, custom-domain swap | Planned       |
 
 This plan picks up where

--- a/e2e/about-and-get-involved.spec.ts
+++ b/e2e/about-and-get-involved.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+const ROUTES: ReadonlyArray<{
+  readonly path: string;
+  readonly heading: RegExp;
+}> = [
+  { path: '/about/partners/', heading: /^Partners$/u },
+  { path: '/about/history/', heading: /^History$/u },
+  { path: '/about/contact/', heading: /^Contact$/u },
+  { path: '/about/photo-gallery/', heading: /^Photo Gallery$/u },
+  { path: '/get-involved/', heading: /^Get Involved$/u },
+];
+
+test.describe('About sub-pages + Get Involved (Phase 13)', () => {
+  for (const { path, heading } of ROUTES) {
+    test(`${path} renders an h1`, async ({ page }) => {
+      await page.goto(path);
+      await expect(
+        page.getByRole('heading', { level: 1, name: heading })
+      ).toBeVisible();
+    });
+  }
+
+  test('Contact page surfaces the WWTA mailto', async ({ page }) => {
+    await page.goto('/about/contact/');
+    await expect(
+      page.getByRole('link', { name: 'info@wwta.org' })
+    ).toHaveAttribute('href', 'mailto:info@wwta.org');
+  });
+
+  test('Get Involved CTAs all point at WWTA', async ({ page }) => {
+    await page.goto('/get-involved/');
+    const ctas = page.getByRole('link', {
+      name: /(Volunteer|Donate|Share a trip report) →/u,
+    });
+    await expect(ctas).toHaveCount(3);
+    for (const cta of await ctas.all()) {
+      const href = await cta.getAttribute('href');
+      expect(href).toMatch(/wwta\.org/u);
+    }
+  });
+
+  test('About index page links to all four sub-pages', async ({ page }) => {
+    await page.goto('/about/');
+    await expect(page.getByRole('link', { name: 'Partners' })).toHaveAttribute(
+      'href',
+      '/about/partners/'
+    );
+    await expect(page.getByRole('link', { name: 'History' })).toHaveAttribute(
+      'href',
+      '/about/history/'
+    );
+    await expect(
+      page.getByRole('link', { name: 'Photo Gallery' })
+    ).toHaveAttribute('href', '/about/photo-gallery/');
+    await expect(page.getByRole('link', { name: 'Contact' })).toHaveAttribute(
+      'href',
+      '/about/contact/'
+    );
+  });
+
+  test('Header has Get Involved nav link', async ({ page }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('link', { name: 'Get Involved' })
+    ).toBeVisible();
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,6 +19,7 @@ export const NAV_ITEMS = [
   { href: '/natural-world/', label: 'Natural World' },
   { href: '/past-and-present/', label: 'Past & Present' },
   { href: '/trip-planning/', label: 'Trip Planning' },
+  { href: '/get-involved/', label: 'Get Involved' },
   { href: '/about/', label: 'About' },
 ] as const;
 


### PR DESCRIPTION
## Summary

Closes the meta-page gap from
[`docs/gap-analysis.md`](./docs/gap-analysis.md). Five new
routes (Partners, History, Contact, Photo Gallery, Get Involved),
two new MDX files, a Header nav addition, and a small update to
the existing `/about/` index so the new sub-pages are
discoverable.

Phase 13 of [`docs/plans/feature-parity.md`](./docs/plans/feature-parity.md).

**Stacked on `phase-12-cultural-natural` (PR #44, merged).**
GitHub will retarget to `main` once the chain catches up.

## ⚠ URL placeholders flagged for confirmation before merge

Per the Phase 13 plan's Q&A, several outbound URLs need explicit
confirmation from the WWTA Executive Director:

| Page | Variable | Currently | Confirm |
| --- | --- | --- | --- |
| `/about/photo-gallery/` | `GALLERY_URL` | `https://www.wwta.org/` | dedicated NextGen Gallery URL? |
| `/get-involved/` | `VOLUNTEER_URL` | `https://www.wwta.org/` | `/volunteer/`? |
| `/get-involved/` | `DONATE_URL` | `https://www.wwta.org/` | `/donate/`? |
| `/get-involved/` | `TRIP_REPORTS_URL` | `https://www.wwta.org/` | `/trips/`? forum URL? |

`info@wwta.org` (the Contact page mailto) is confirmed and
matches the Phase 13 plan answer.

## What changed

### Routes

- **`app/about/partners/page.tsx`** — imports
  `content/about/partners.mdx`. Lists the NPS funder, WWTA
  manager, 35 original partner organizations from the 2005
  designation, and the four CRITFC member tribes.
- **`app/about/history/page.tsx`** — `content/about/history.mdx`
  covers the three 2005 designation events (Bonneville Ribbon
  Cutting, Mosier Fall Festival, Clearwater Cleanup).
- **`app/about/contact/page.tsx`** — TSX page; `mailto:info@wwta.org`
  (per the Phase 13 Q&A), WWTA phone, and a GitHub-issue link
  for site-specific bugs.
- **`app/about/photo-gallery/page.tsx`** — links out to WWTA's
  photo library rather than building our own gallery (per the
  Phase 13 Q&A — WWTA already runs WordPress + NextGen Gallery
  with usage rights).
- **`app/get-involved/page.tsx`** — three outbound CTAs to
  WWTA: Volunteer, Donate, Share a trip report.

### About index

Existing `/about/` page gains a "Read more" section linking to
the four new sub-pages.

### Header

Added Get Involved between Trip Planning and About — 10 items
inline at xl+; mobile hamburger handles the count.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run lint:md` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 102/102
- [x] `npm run build` — 5 new static HTML files
- [x] `npx playwright test --workers=1` — 49/49 (8 new in
      `about-and-get-involved.spec.ts`)
- [ ] **Confirm 4 placeholder WWTA URLs** above before merge
- [ ] Bot triage round (Gemini, Copilot, DeepSource, SonarCloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)