### PR TITLE
docs(architecture): refresh diagrams + fix overview render bug

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,8 +35,20 @@ Architecture Decision Records explain the load-bearing choices:
 - [`plans/modernization.md`](./plans/modernization.md) — the
   7-phase Vite → Next.js + PandaCSS rewrite that produced the
   current shape.
+- [`plans/feature-parity.md`](./plans/feature-parity.md) — the
+  follow-on phases (8+) bringing editorial content, sites
+  detail pages, and the multi-section MDX subtree to parity
+  with the legacy ndwt.org site.
+- [`plans/photo-candidates.md`](./plans/photo-candidates.md) —
+  the photo-discovery scraper (Wikimedia Commons + WWTA blog +
+  planned Flickr / Mapillary) and the curation workflow that
+  feeds per-site detail pages.
 
 ## Other
 
 - [`gap-analysis.md`](./gap-analysis.md) — capability and copy
   comparison vs. the original ndwt.org site.
+- [`gap-analysis-wwta.md`](./gap-analysis-wwta.md) — capability
+  comparison vs. wwta.org, including the boundary line for
+  what this site owns vs. what stays on the WWTA WordPress
+  install (membership, donate, shop, events).

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -11,8 +11,10 @@ graph TB
     Layout["layout.tsx<br/>html/body shell"]
     Providers["providers.tsx<br/>'use client'<br/>next-themes"]
     HomePage["page.tsx<br/>server: Hero + MapApp"]
-    AboutPage["about/page.tsx<br/>article"]
-    TripPage["trip-planning/page.tsx<br/>article"]
+    SitesIndexRoute["sites/page.tsx<br/>SiteIndex grid"]
+    SiteDetailRoute["sites/[slug]/page.tsx<br/>SiteDetails"]
+    AboutRoutes["about/* pages<br/>history · partners · contact<br/>· photo-gallery"]
+    EditorialRoutes["editorial route trees<br/>water-safety · river-navigation<br/>· leave-no-trace · natural-world<br/>· past-and-present · trip-planning<br/>· get-involved"]
     Globals["globals.css<br/>cascade layers + #map"]
   end
 
@@ -34,16 +36,27 @@ graph TB
     Drawer["drawer.tsx<br/>Ark UI Dialog<br/>modal=false"]
   end
 
-  subgraph Map_["src/components/"]
+  subgraph Map_["src/components/ (map)"]
     MapApp["MapApp.tsx<br/>'use client'<br/>composition + dynamic map"]
-    MapTSX["map.tsx<br/>OL Map instance"]
+    MapTSX["map.tsx<br/>OL Map instance<br/>5 tile layers + vectors"]
+    LayerSwitcher_["LayerSwitcher.tsx<br/>base-map + overlay toggles"]
     Handlers["map-handlers.ts<br/>pure click + pointermove"]
     Theme["ThemeToggleButton.tsx"]
   end
 
   subgraph Panels_["src/components/panels/"]
     Panel["SiteInfoPanel.tsx<br/>drawer wrapper"]
+    SiteDetails_["SiteDetails.tsx<br/>shared body for panel + page"]
     Facilities["FacilityBadges.tsx"]
+  end
+
+  subgraph Sites_["src/components/sites/"]
+    SiteIndex["SiteIndex.tsx<br/>filterable grid of all sites"]
+  end
+
+  subgraph Editorial_["src/components/editorial/"]
+    Article["ArticleLayout.tsx<br/>MDX article shell"]
+    SectionIndex["SectionIndex.tsx<br/>per-section landing"]
   end
 
   subgraph App_["src/application/"]
@@ -56,6 +69,7 @@ graph TB
     Site["site.ts"]
     Coords["coordinates.ts"]
     Fac["facility.ts"]
+    Slug["slug.ts<br/>name → unique slug"]
     Idx["index.ts (barrel)"]
   end
 
@@ -67,6 +81,10 @@ graph TB
     Gpx["outbound/<br/>site-to-gpx.ts"]
   end
 
+  subgraph Content_["content/ (MDX)"]
+    Mdx["*.mdx files<br/>safety · navigation · history…"]
+  end
+
   Comp["composition-root.ts<br/>createComposition factory"]
   Store["store/selected-site.ts<br/>Zustand"]
 
@@ -74,12 +92,21 @@ graph TB
   Layout --> Header
   Layout --> Footer
   Layout --> Globals
+
   HomePage --> Hero
   HomePage --> MapApp
   HomePage --> LoadSites
 
-  AboutPage --> Link
-  TripPage --> Link
+  SitesIndexRoute --> SiteIndex
+  SitesIndexRoute --> LoadSites
+  SiteDetailRoute --> SiteDetails_
+  SiteDetailRoute --> LoadSites
+
+  AboutRoutes --> Article
+  AboutRoutes --> Mdx
+  EditorialRoutes --> Article
+  EditorialRoutes --> SectionIndex
+  EditorialRoutes --> Mdx
 
   MapApp --> MapTSX
   MapApp --> Panel
@@ -87,22 +114,32 @@ graph TB
   MapApp --> Comp
 
   MapTSX --> Handlers
+  MapTSX --> LayerSwitcher_
   Handlers --> Store
 
   Panel --> Drawer
-  Panel --> Heading
-  Panel --> Stack
-  Panel --> Box
-  Panel --> Link
-  Panel --> Button
-  Panel --> Facilities
+  Panel --> SiteDetails_
+  SiteDetails_ --> Heading
+  SiteDetails_ --> Stack
+  SiteDetails_ --> Box
+  SiteDetails_ --> Link
+  SiteDetails_ --> Button
+  SiteDetails_ --> Facilities
   Panel --> Store
-  Panel --> Gpx
+  SiteDetails_ --> Gpx
 
   Facilities --> Stack
   Facilities --> Badge
 
   Theme --> IconButton
+
+  SiteIndex --> Link
+  SiteIndex --> Stack
+  SiteIndex --> Slug
+
+  Article --> Heading
+  Article --> Stack
+  SectionIndex --> Link
 
   Comp --> InMem
   Comp --> ListUC
@@ -116,6 +153,7 @@ graph TB
   Geo --> Parser
   Site --> Coords
   Site --> Fac
+  Slug --> Site
   Idx --> Site
 
   classDef route fill:#dbeafe,stroke:#2563eb;
@@ -124,13 +162,15 @@ graph TB
   classDef app fill:#fef3c7,stroke:#d97706;
   classDef adapter fill:#fef3c7,stroke:#d97706;
   classDef glue fill:#fee2e2,stroke:#dc2626;
+  classDef content fill:#fae8ff,stroke:#a21caf;
 
-  class Layout,Providers,HomePage,AboutPage,TripPage,Globals route
-  class Header,Hero,Footer,Box,Stack,Text,Heading,Badge,Link,Button,IconButton,Drawer,Panel,Facilities,MapApp,MapTSX,Theme ui
-  class Site,Coords,Fac,Idx domain
+  class Layout,Providers,HomePage,SitesIndexRoute,SiteDetailRoute,AboutRoutes,EditorialRoutes,Globals route
+  class Header,Hero,Footer,Box,Stack,Text,Heading,Badge,Link,Button,IconButton,Drawer,Panel,SiteDetails_,Facilities,MapApp,MapTSX,LayerSwitcher_,Theme,SiteIndex,Article,SectionIndex ui
+  class Site,Coords,Fac,Slug,Idx domain
   class Port,ListUC,GetUC app
   class LoadSites,InMem,Geo,Parser,Gpx adapter
   class Comp,Store,Handlers glue
+  class Mdx content
 ```
 
 ## What lives where
@@ -139,10 +179,22 @@ graph TB
 
 Next.js App Router entry points only. `layout.tsx` sets the
 HTML shell and global chrome (Header / main / Footer / Providers);
-`page.tsx` per route is a thin server component that fetches the
-data it needs and renders a presentation component. The whole
-folder ships as RSC server components except `providers.tsx`
-(client) which hosts `next-themes`.
+each `page.tsx` is a thin server component that fetches the data
+it needs and renders a presentation component. The whole folder
+ships as RSC server components except `providers.tsx` (client)
+which hosts `next-themes`.
+
+Routes:
+
+- `/` — map + Hero (`HomePage`)
+- `/sites/`, `/sites/[slug]/` — index grid + per-site detail
+- `/about/`, `/about/{history,contact,partners,photo-gallery}/`
+  — MDX articles for the curated about subtree
+- `/water-safety/[[...slug]]/`, `/river-navigation/[[...slug]]/`,
+  `/natural-world/[[...slug]]/`, `/past-and-present/[[...slug]]/`
+  — catch-all editorial sections backed by `content/*.mdx`
+- `/leave-no-trace/`, `/trip-planning/`, `/get-involved/` —
+  single-article editorial pages
 
 ### `src/components/layout/`
 
@@ -162,9 +214,23 @@ Panda preset already carries the design tokens.
 
 The site info Drawer and its supporting badges. The Drawer is
 non-modal — clicking outside doesn't dismiss; ESC and the close
-button do.
+button do. `SiteDetails.tsx` is the shared body used by both
+the drawer and the standalone `/sites/[slug]/` page so the two
+surfaces stay visually identical.
 
-### `src/components/map.tsx` + `map-handlers.ts` + `MapApp.tsx`
+### `src/components/sites/`
+
+`SiteIndex.tsx` — the filterable grid of all sites at `/sites/`.
+Filtering is client-side using a search input + facility-flag
+checkboxes; server hands it the full `Site[]` from `loadSites()`.
+
+### `src/components/editorial/`
+
+`ArticleLayout.tsx` is the MDX article shell (h1, lead, meta).
+`SectionIndex.tsx` renders the per-section landing page — a
+list of articles inside one of the catch-all editorial routes.
+
+### `src/components/map.tsx` + `map-handlers.ts` + `MapApp.tsx` + `LayerSwitcher.tsx`
 
 The OpenLayers integration:
 
@@ -172,15 +238,30 @@ The OpenLayers integration:
   composition once per `sites` prop via `useMemo` and dynamic-
   imports the OL component with `ssr: false`.
 - `map.tsx` owns the `ol.Map` instance and its lifecycle (mount
-  on `useEffect`, set the global test handle, clean up).
+  on `useEffect`, set the global test handle, clean up). It
+  registers five tile layers (OSM / USGS / OpenTopoMap base
+  maps + OpenSeaMap / Waymarked Trails overlays) and syncs
+  their visibility from React state.
+- `LayerSwitcher.tsx` is the floating dropdown that drives the
+  base-map and overlay state. Pure presentation — `map.tsx`
+  passes the active selections and toggle callbacks in.
 - `map-handlers.ts` exports curried pure functions
   (`makeHandleClick`, `makeHandlePointerMove`) that don't import
   any UI deps — straightforward to unit test against a fake Map.
 
+### `content/`
+
+MDX source for editorial articles. Pages under
+`app/<section>/[[...slug]]/page.tsx` import the matching MDX
+file at build time, wrap it in `ArticleLayout`, and emit static
+HTML. No MDX runtime ships in the client bundle.
+
 ### `src/domain/`
 
 Pure types only. Adding a non-pure dependency here is a code
-review red flag.
+review red flag. `slug.ts` is included here because it's a pure
+derivation from `Site.name` (with collision tie-breaking by
+river mile then site id) and has no framework deps.
 
 ### `src/application/`
 
@@ -216,7 +297,9 @@ it to its own module would be a clean refactor.
 
 A single Zustand slice for the selected site. The split between
 "domain data" (in the composition) and "ephemeral UI state" (in
-Zustand) is intentional.
+Zustand) is intentional. The map's layer-switcher state lives
+in component-local `useState` inside `map.tsx`, not in Zustand,
+because no other component needs to read it.
 
 ## See also
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -13,8 +13,8 @@ graph TB
     HomePage["page.tsx<br/>server: Hero + MapApp"]
     SitesIndexRoute["sites/page.tsx<br/>SiteIndex grid"]
     SiteDetailRoute["sites/[slug]/page.tsx<br/>SiteDetails"]
-    AboutRoutes["about/* pages<br/>history · partners · contact<br/>· photo-gallery"]
-    EditorialRoutes["editorial route trees<br/>water-safety · river-navigation<br/>· leave-no-trace · natural-world<br/>· past-and-present · trip-planning<br/>· get-involved"]
+    AboutRoutes["about/* pages<br/>about · contact · photo-gallery (TSX)<br/>history · partners (MDX)"]
+    EditorialRoutes["editorial route trees<br/>water-safety · river-navigation<br/>· leave-no-trace · natural-world<br/>· past-and-present (MDX)<br/>trip-planning · get-involved (TSX)"]
     Globals["globals.css<br/>cascade layers + #map"]
   end
 
@@ -103,10 +103,10 @@ graph TB
   SiteDetailRoute --> LoadSites
 
   AboutRoutes --> Article
-  AboutRoutes --> Mdx
   EditorialRoutes --> Article
   EditorialRoutes --> SectionIndex
-  EditorialRoutes --> Mdx
+  Mdx -.MDX-backed subset.-> AboutRoutes
+  Mdx -.MDX-backed subset.-> EditorialRoutes
 
   MapApp --> MapTSX
   MapApp --> Panel
@@ -133,12 +133,14 @@ graph TB
 
   Theme --> IconButton
 
+  SiteIndex --> Heading
+  SiteIndex --> Box
   SiteIndex --> Link
   SiteIndex --> Stack
-  SiteIndex --> Slug
+  SiteIndex --> Text
+  SiteIndex --> Facilities
 
-  Article --> Heading
-  Article --> Stack
+  Article --> Link
   SectionIndex --> Link
 
   Comp --> InMem
@@ -151,9 +153,9 @@ graph TB
 
   LoadSites --> Parser
   Geo --> Parser
+  Parser -.uses.-> Slug
   Site --> Coords
   Site --> Fac
-  Slug --> Site
   Idx --> Site
 
   classDef route fill:#dbeafe,stroke:#2563eb;
@@ -188,13 +190,17 @@ Routes:
 
 - `/` — map + Hero (`HomePage`)
 - `/sites/`, `/sites/[slug]/` — index grid + per-site detail
-- `/about/`, `/about/{history,contact,partners,photo-gallery}/`
-  — MDX articles for the curated about subtree
+- `/about/`, `/about/contact/`, `/about/photo-gallery/` — TSX
+  pages that wrap `ArticleLayout` directly; no MDX import.
+- `/about/history/`, `/about/partners/` — MDX-backed (`content/about/*.mdx`)
+  rendered through `ArticleLayout`.
 - `/water-safety/[[...slug]]/`, `/river-navigation/[[...slug]]/`,
   `/natural-world/[[...slug]]/`, `/past-and-present/[[...slug]]/`
-  — catch-all editorial sections backed by `content/*.mdx`
-- `/leave-no-trace/`, `/trip-planning/`, `/get-involved/` —
-  single-article editorial pages
+  — catch-all editorial sections backed by `content/*.mdx`,
+  with `SectionIndex` rendering the per-section landing pages.
+- `/leave-no-trace/` — single MDX page.
+- `/trip-planning/`, `/get-involved/` — TSX pages that wrap
+  `ArticleLayout` directly; no MDX import.
 
 ### `src/components/layout/`
 
@@ -251,17 +257,29 @@ The OpenLayers integration:
 
 ### `content/`
 
-MDX source for editorial articles. Pages under
-`app/<section>/[[...slug]]/page.tsx` import the matching MDX
-file at build time, wrap it in `ArticleLayout`, and emit static
-HTML. No MDX runtime ships in the client bundle.
+MDX source for the MDX-backed subset of editorial articles
+(`leave-no-trace.mdx`, `about/{history,partners}.mdx`, plus
+the per-section trees under `water-safety/`, `river-navigation/`,
+`natural-world/`, and `past-and-present/`). The matching route
+handlers import the MDX file at build time, wrap it in
+`ArticleLayout`, and emit static HTML. No MDX runtime ships in
+the client bundle. TSX-authored editorial pages (`/about/`,
+`/about/contact/`, `/about/photo-gallery/`, `/trip-planning/`,
+`/get-involved/`) skip `content/` entirely and write their copy
+directly in TSX.
 
 ### `src/domain/`
 
 Pure types only. Adding a non-pure dependency here is a code
 review red flag. `slug.ts` is included here because it's a pure
-derivation from `Site.name` (with collision tie-breaking by
-river mile then site id) and has no framework deps.
+derivation from a site's name (with collision tie-breaking by
+river mile then site id) and has no framework deps. It declares
+its own minimal `SluggableSite` interface rather than importing
+`site.ts`, which keeps it usable from the GeoJSON parser before
+a full `Site` exists. The parser (`parseSitesFromGeoJson`) is
+the only caller — adapters use `assignSlugs` while building the
+site list, then the slug rides along on every `Site` value as a
+plain string field.
 
 ### `src/application/`
 

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -33,7 +33,7 @@ graph TB
   subgraph Domain["Domain (pure)"]
     Site[Site<br/>SiteId branded]
     Coords[Coordinates]
-    Facility[Facility<br/>FacilitySet = readonly Facility[]]
+    Facility["Facility<br/>FacilitySet = readonly Facility[]"]
   end
 
   subgraph Adapters["Adapters"]

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,69 +1,85 @@
 # System overview
 
 C4 Context (level 1) and Container (level 2) views of the
-Northwest Discovery Water Trail map site. Diagrams use
-[MermaidJS](https://mermaid.js.org) and render directly on GitHub.
+Northwest Discovery Water Trail map site. Diagrams are written
+as Mermaid `flowchart`s (the C4 plugin is unstable on GitHub's
+renderer) and render directly on GitHub.
 
 ## Context
 
 The whole product fits in one diagram: a public, browser-based
-map. Source data is a static GeoJSON file we maintain in this
-repository; the deployed site is a static export served by
-Netlify's CDN.
+map plus a small set of editorial articles. Source data is a
+static GeoJSON file we maintain in this repository plus MDX
+content under `content/`; the deployed site is a static export
+served by Netlify's CDN.
 
 ```mermaid
-C4Context
-  title System Context — NW Discovery Water Trail map
+flowchart LR
+  boater(["Boater /<br/>trip planner"])
+  maintainer(["Maintainer"])
 
-  Person(boater, "Boater / trip planner", "Plans a trip on the Snake / Columbia / Clearwater corridor")
-  Person(maintainer, "Maintainer", "Adds features, fixes bugs, edits content")
+  site["NW Discovery Water Trail map<br/>Static Next.js site<br/>159 launch sites + GPX downloads<br/>+ MDX editorial pages"]
 
-  System(site, "NW Discovery Water Trail map", "Static Next.js site<br/>~150 launch sites + GPX downloads")
+  netlify[("Netlify CDN<br/>HTTPS, deploy previews")]
+  github[("GitHub<br/>repo · CI · dependabot")]
+  tiles[("Tile providers<br/>OSM · USGS Topo · OpenTopoMap<br/>OpenSeaMap · Waymarked Trails")]
+  wwta[("Washington Water Trails Assoc.<br/>future data integration")]
 
-  System_Ext(netlify, "Netlify CDN", "Hosts the static export at deploy_url")
-  System_Ext(github, "GitHub", "Source repo, CI, PR reviews, dependabot")
-  System_Ext(osm, "OpenStreetMap tile servers", "Basemap tiles loaded by OL")
-  System_Ext(wwta, "Washington Water Trails Assoc.", "Manages the trail<br/>(future data integration)")
+  boater -->|Browses, opens site panel,<br/>downloads GPX| netlify
+  netlify -->|Serves| site
+  maintainer -->|PRs, reviews| github
+  github -->|Auto-deploys on merge to main| netlify
+  site -.->|Tile fetches in browser| tiles
+  wwta -.->|Trail-data sync<br/>planned, ArcGIS / DB| site
 
-  Rel(boater, site, "Browses map, opens site panel, downloads GPX")
-  Rel(maintainer, github, "PRs, reviews, dependency bumps")
-  Rel(github, netlify, "Auto-deploys on merge to main")
-  Rel(boater, netlify, "HTTPS")
-  Rel(site, osm, "Tile fetches in browser")
-  Rel(wwta, site, "Trail-data sync<br/>(planned, ArcGIS / DB)")
+  classDef person fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef sys fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+  classDef ext fill:#fef3c7,stroke:#d97706,color:#78350f;
+  class boater,maintainer person
+  class site sys
+  class netlify,github,tiles,wwta ext
 ```
 
 ## Container
 
 The container view zooms into the deployable units. Notice that
 **the only dynamic component is the user's browser** — Netlify
-serves pre-rendered HTML and the trail data is baked into each
-page at build time.
+serves pre-rendered HTML and the trail data + editorial articles
+are baked into each page at build time.
 
 ```mermaid
-C4Container
-  title Container — what runs where
+flowchart TB
+  boater(["Boater"])
 
-  Person(boater, "Boater")
+  subgraph deploy["Static deploy on Netlify"]
+    direction TB
+    html["Pre-rendered HTML<br/>Next.js static export<br/>map · sites index · site detail<br/>+ water-safety · river-navigation<br/>+ leave-no-trace · natural-world<br/>+ past-and-present · trip-planning<br/>+ get-involved · about · about/*"]
+    js["Hydration bundle<br/>React 19 + OpenLayers 10<br/>map · layer switcher<br/>panel · GPX download"]
+    css["Atomic CSS<br/>PandaCSS<br/>generated at build time<br/>no runtime CSS-in-JS"]
+    data[("/data/ndwt.geojson<br/>159 sites + facility flags<br/>still served for external GIS")]
+    mdx[("content/*.mdx<br/>editorial articles<br/>safety · navigation · history…")]
+  end
 
-  System_Boundary(deploy, "Static deploy on Netlify") {
-    Container(html, "Pre-rendered HTML", "Next.js static export", "/, /about/, /trip-planning/<br/>Site[] inlined into the page tree")
-    Container(js, "Hydration bundle", "React 19 + OpenLayers 10", "Mounts the map after page load<br/>handles clicks + GPX download")
-    Container(css, "Atomic CSS", "PandaCSS", "Generated at build time<br/>no runtime CSS-in-JS")
-    Container(data, "/data/ndwt.geojson", "Static asset", "147 sites + facility flags<br/>still served for external GIS consumers")
-  }
+  ci(["GitHub Actions CI<br/>lint · typecheck · Vitest<br/>Playwright · SonarCloud · DeepSource"])
+  tiles[("Tile servers<br/>OSM · USGS · OpenTopoMap<br/>OpenSeaMap · Waymarked Trails")]
+  repo[("ivanoats/ndwt-ol-chakra<br/>source of truth")]
 
-  System_Ext(github_actions, "GitHub Actions CI", "Lint / typecheck / Vitest / Playwright / SonarCloud / DeepSource on every PR")
-  System_Ext(osm_tiles, "OSM tile servers", "Fetched on demand by the OL map")
-  System_Ext(repo, "ivanoats/ndwt-ol-chakra", "Source of truth — public/data/ndwt.geojson")
+  boater -->|HTTPS| html
+  html -->|Hydrates| js
+  js -->|Tile requests| tiles
+  html -.->|Baked at build time| data
+  html -.->|Baked at build time| mdx
+  repo -->|Push triggers| ci
+  ci -->|Static export → out/| deploy
 
-  Rel(boater, html, "Loads")
-  Rel(html, js, "Hydrates")
-  Rel(js, osm_tiles, "Tile requests")
-  Rel(repo, github_actions, "Push triggers")
-  Rel(github_actions, deploy, "Static export → out/")
-
-  UpdateRelStyle(html, js, $offsetY="-10")
+  classDef container fill:#f3e8ff,stroke:#9333ea,color:#581c87;
+  classDef store fill:#fef3c7,stroke:#d97706,color:#78350f;
+  classDef ext fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
+  classDef person fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  class boater person
+  class html,js,css container
+  class data,mdx store
+  class ci,tiles,repo ext
 ```
 
 ## Why this shape
@@ -71,12 +87,22 @@ C4Container
 - **Static export** keeps hosting cheap and the deploy preview
   fast. No server runtime, no API routes, no cold starts.
 - **Trail data baked in at build time** kills the runtime fetch
-  hop and gives the map paint at first byte. The `/data/ndwt.geojson`
-  file is still published unchanged so anyone running their own
-  map / trip planner can ingest the dataset directly.
+  hop and gives the map paint at first byte. The
+  `/data/ndwt.geojson` file is still published unchanged so
+  anyone running their own map / trip planner can ingest the
+  dataset directly.
+- **MDX content baked in too** — editorial articles ship as
+  pre-rendered HTML; no MDX runtime in the client bundle.
+- **Multiple tile providers, all client-fetched** — the map UI
+  exposes a layer switcher so users can toggle between the
+  OSM street basemap, USGS topo, and OpenTopoMap, and overlay
+  OpenSeaMap sea marks or Waymarked Trails hiking. All tile
+  fetches are direct from the browser to the provider; the
+  static deploy never proxies them.
 - **OL is the only meaningful client-side dependency** — the
-  hydration bundle stays small because we don't ship a UI runtime
-  (Park UI components compile to plain elements + atomic CSS).
+  hydration bundle stays small because we don't ship a UI
+  runtime (Park UI components compile to plain elements +
+  atomic CSS).
 
 ## See also
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -18,7 +18,7 @@ flowchart LR
   boater(["Boater /<br/>trip planner"])
   maintainer(["Maintainer"])
 
-  site["NW Discovery Water Trail map<br/>Static Next.js site<br/>159 launch sites + GPX downloads<br/>+ MDX editorial pages"]
+  site["NW Discovery Water Trail map<br/>Static Next.js site<br/>159 launch sites + GPX downloads<br/>+ editorial pages (MDX + TSX)"]
 
   netlify[("Netlify CDN<br/>HTTPS, deploy previews")]
   github[("GitHub<br/>repo · CI · dependabot")]


### PR DESCRIPTION
## Summary

- Fix the broken Mermaid render at `docs/architecture/overview.md` by converting both diagrams from the experimental `C4Context`/`C4Container` syntax to plain `flowchart` (the same syntax `hexagonal.md` and `components.md` already use without issues). The C4 plugin crashes GitHub's renderer with `undefined is not an object (evaluating 'e.x')`, especially when descriptions embed `<br/>`.
- Refresh stale facts that have drifted as the app grew: 147/~150 → **159 sites**, OSM-only tiles → **OSM + USGS + OpenTopoMap + OpenSeaMap + Waymarked Trails**, three routes → the full app-router tree including `/sites/[slug]/` and the catch-all editorial sections.
- Add the MDX editorial content layer to both the context and container views.
- Update `components.md` to include `LayerSwitcher`, `SiteIndex`, `SiteDetails`, `editorial/ArticleLayout` + `SectionIndex`, and the new editorial route trees.
- Point `docs/README.md` at `plans/feature-parity.md`, `plans/photo-candidates.md`, and `gap-analysis-wwta.md` that landed since the original index was written.

## Test plan

- [ ] Verify both Mermaid blocks in `overview.md` render on the GitHub PR diff (or in the deployed file view) without the "Unable to render rich display" error.
- [ ] Skim the updated `components.md` diagram for any nodes I missed.
- [ ] `npm run lint:md` (already clean locally).

## Bot review triage

- [ ] Gemini Code Assist
- [ ] GitHub Copilot review
- [ ] DeepSource
- [ ] SonarCloud (will likely be a no-op — only `.md` files touched)

## Notes for reviewer

The pre-existing C4 syntax was always brittle on GitHub. The flowchart rewrite preserves the same logical content (people, system, external dependencies, relationships) but uses node shapes + `classDef` styling instead of the C4 macros, which means it will keep rendering even if Mermaid's C4 support changes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)