### PR TITLE
feat(map): surface tile-load failures with a non-blocking banner (Tier 1 of #64)

### DIFF
--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -210,6 +210,59 @@ test.describe('Northwest Discovery Water Trail map', () => {
       )
       .toBeGreaterThan(0);
   });
+
+  test('shows the basemap-unavailable banner when active layer tiles fail', async ({
+    page,
+  }) => {
+    // Force every OSM tile request to 503 — simulates an upstream
+    // outage of the user's active basemap. The banner should show
+    // up within a few seconds once OL's source has fired enough
+    // tileloaderror events to cross the "down" threshold.
+    await page.route(/tile\.openstreetmap\.org\//, (route) =>
+      route.fulfill({ status: 503, body: 'simulated outage' })
+    );
+
+    await page.goto('/');
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // OSM is the default basemap → its failure triggers the banner.
+    const banner = page.getByTestId('tile-health-banner');
+    await expect(banner).toBeVisible({ timeout: 20_000 });
+    await expect(banner).toContainText(/Basemap unavailable/i);
+    await expect(banner).toContainText(/Street Map/);
+  });
+
+  test('hides the banner once a healthy basemap is selected', async ({
+    page,
+  }) => {
+    await page.route(/tile\.openstreetmap\.org\//, (route) =>
+      route.fulfill({ status: 503, body: 'simulated outage' })
+    );
+
+    await page.goto('/');
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const banner = page.getByTestId('tile-health-banner');
+    await expect(banner).toBeVisible({ timeout: 20_000 });
+
+    // Switch to USGS Topo (different host, no route override). The
+    // banner reads health for the new active layer, which has no
+    // events yet → 'unknown' → banner hides.
+    await page.getByRole('button', { name: 'Toggle layer switcher' }).click();
+    await page.getByRole('button', { name: /USGS Topo/ }).click();
+
+    await expect(banner).toBeHidden({ timeout: 5_000 });
+  });
 });
 
 async function clickFirstMarker(page: Page): Promise<void> {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -26,9 +26,18 @@ sonar.coverage.exclusions=src/components/map.tsx
 # legitimate Playwright pattern, not the anti-pattern S1607
 # targets. The skip reason always includes the upstream status so
 # CI signals are still actionable.
-sonar.issue.ignore.multicriteria=runtime-skip-in-e2e
+#
+# typescript:S6564 ("redundant type alias") misfires on
+# `LayerKey = BaseMapId | OverlayId` because Sonar's TypeScript
+# resolver can't follow the imported aliases and widens the union
+# to `string`. The alias is the central single-source-of-truth for
+# tile-health keys; inlining the literal union would duplicate
+# values defined in LayerSwitcher.
+sonar.issue.ignore.multicriteria=runtime-skip-in-e2e,layerkey-alias
 sonar.issue.ignore.multicriteria.runtime-skip-in-e2e.ruleKey=typescript:S1607
 sonar.issue.ignore.multicriteria.runtime-skip-in-e2e.resourceKey=e2e/**/*.spec.ts
+sonar.issue.ignore.multicriteria.layerkey-alias.ruleKey=typescript:S6564
+sonar.issue.ignore.multicriteria.layerkey-alias.resourceKey=src/store/tile-health.ts
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPath=tsconfig.json

--- a/src/components/LayerSwitcher.tsx
+++ b/src/components/LayerSwitcher.tsx
@@ -14,7 +14,10 @@ interface LayerSwitcherProps {
   readonly onOverlayToggle: (id: OverlayId) => void;
 }
 
-const BASE_MAPS: Array<{ id: BaseMapId; label: string }> = [
+// Exported so other components (e.g. the tile-health banner) can
+// resolve a layer's display label from its id without duplicating the
+// list.
+export const BASE_MAPS: ReadonlyArray<{ id: BaseMapId; label: string }> = [
   { id: 'osm', label: 'Street Map' },
   { id: 'usgs', label: 'USGS Topo' },
   { id: 'opentopomap', label: 'OpenTopoMap' },

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -63,8 +63,8 @@ export default function TileHealthBanner({
   const [now, setNow] = useState<number>(() => Date.now());
 
   useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), TICK_MS);
-    return () => window.clearInterval(id);
+    const id = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(id);
   }, []);
 
   const status = health === undefined ? 'unknown' : classify(health, now);

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -63,8 +63,8 @@ export default function TileHealthBanner({
   const [now, setNow] = useState<number>(() => Date.now());
 
   useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), TICK_MS);
-    return () => clearInterval(id);
+    const id = globalThis.setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => globalThis.clearInterval(id);
   }, []);
 
   const status = health === undefined ? 'unknown' : classify(health, now);
@@ -76,12 +76,12 @@ export default function TileHealthBanner({
       : `${activeLayerLabel} is having trouble loading some tiles.`;
 
   return (
-    // role="status" implies aria-live="polite" — non-interruptive
-    // announcement that doesn't preempt the user's current task.
-    // role="alert" would force assertive interruption, which is the
-    // wrong tone for "your basemap is slow."
-    <div
-      role="status"
+    // <output> has an implicit `role="status"` (and the matching
+    // `aria-live="polite"`), which is better-supported by screen
+    // readers than `<div role="status">`. The non-interruptive
+    // semantics fit "your basemap is slow" — `role="alert"` would
+    // force assertive announcement which is too loud for this.
+    <output
       data-testid="tile-health-banner"
       data-status={status}
       className={bannerClass}
@@ -93,6 +93,6 @@ export default function TileHealthBanner({
         </div>
         <div>{message}</div>
       </div>
-    </div>
+    </output>
   );
 }

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { css } from 'styled-system/css';
+
+import { useTileHealth } from '../store/tile-health';
+
+import { classify } from './tile-health-tracker';
+
+interface TileHealthBannerProps {
+  readonly activeLayer: string;
+  readonly activeLayerLabel: string;
+}
+
+// Top-center banner over the map. Sits high enough to clear the
+// LayerSwitcher (top-left) and OL zoom controls; auto-disappears when
+// the active layer recovers.
+const bannerClass = css({
+  position: 'absolute',
+  top: '4',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 110,
+  maxWidth: 'min(560px, calc(100% - 8rem))',
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '2',
+  padding: '3',
+  borderRadius: 'md',
+  boxShadow: 'md',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  borderWidth: '1px',
+  borderColor: 'colorPalette.7',
+  fontSize: 'sm',
+  lineHeight: 'snug',
+  colorPalette: 'amber',
+});
+
+const iconClass = css({
+  flexShrink: 0,
+  marginTop: '0.5',
+  color: 'colorPalette.9',
+});
+
+const labelClass = css({
+  fontWeight: 'semibold',
+});
+
+// Time-based classification (e.g. "no successful tile in 10s") needs
+// the component to re-render even when no new events arrive. Tick at
+// a coarse interval — 2 s is fine for human-perceived latency and
+// keeps wakeups cheap.
+const TICK_MS = 2000;
+
+export default function TileHealthBanner({
+  activeLayer,
+  activeLayerLabel,
+}: TileHealthBannerProps) {
+  const health = useTileHealth((s) => s.health[activeLayer]);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const status = health === undefined ? 'unknown' : classify(health, now);
+  if (status === 'unknown' || status === 'ok') return null;
+
+  const message =
+    status === 'down'
+      ? `${activeLayerLabel} isn't loading right now. The tile service might be temporarily down — try a different basemap from the layers menu.`
+      : `${activeLayerLabel} is having trouble loading some tiles.`;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      data-testid="tile-health-banner"
+      data-status={status}
+      className={bannerClass}
+    >
+      <AlertTriangle size={20} className={iconClass} aria-hidden="true" />
+      <div>
+        <div className={labelClass}>
+          {status === 'down' ? 'Basemap unavailable' : 'Slow connection'}
+        </div>
+        <div>{message}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -6,10 +6,11 @@ import { css } from 'styled-system/css';
 
 import { useTileHealth } from '../store/tile-health';
 
+import type { BaseMapId } from './LayerSwitcher';
 import { classify } from './tile-health-tracker';
 
 interface TileHealthBannerProps {
-  readonly activeLayer: string;
+  readonly activeLayer: BaseMapId;
   readonly activeLayerLabel: string;
 }
 
@@ -75,9 +76,12 @@ export default function TileHealthBanner({
       : `${activeLayerLabel} is having trouble loading some tiles.`;
 
   return (
+    // role="status" implies aria-live="polite" — non-interruptive
+    // announcement that doesn't preempt the user's current task.
+    // role="alert" would force assertive interruption, which is the
+    // wrong tone for "your basemap is slow."
     <div
-      role="alert"
-      aria-live="polite"
+      role="status"
       data-testid="tile-health-banner"
       data-status={status}
       className={bannerClass}

--- a/src/components/__tests__/TileHealthBanner.test.tsx
+++ b/src/components/__tests__/TileHealthBanner.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { render, screen } from '@testing-library/react';
 
+import type { LayerKey } from '../../store/tile-health';
 import { useTileHealth } from '../../store/tile-health';
 import { DOWN_AFTER_CONSECUTIVE_ERRORS } from '../tile-health-tracker';
 import TileHealthBanner from '../TileHealthBanner';
@@ -9,6 +10,18 @@ import TileHealthBanner from '../TileHealthBanner';
 beforeEach(() => {
   useTileHealth.setState({ health: {} });
 });
+
+const repeatRecord = (
+  layer: LayerKey,
+  kind: 'success' | 'error',
+  count: number
+): void => {
+  const action =
+    kind === 'success'
+      ? useTileHealth.getState().recordSuccess
+      : useTileHealth.getState().recordError;
+  Array.from({ length: count }).forEach(() => action(layer));
+};
 
 describe('<TileHealthBanner />', () => {
   it('renders nothing when no tile events have been recorded for the layer', () => {
@@ -27,9 +40,7 @@ describe('<TileHealthBanner />', () => {
   });
 
   it('shows the "down" banner when the active layer crosses the threshold', () => {
-    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
-      useTileHealth.getState().recordError('osm');
-    }
+    repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
     render(
       <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
     );
@@ -42,9 +53,7 @@ describe('<TileHealthBanner />', () => {
   });
 
   it('uses the activeLayerLabel in the banner copy', () => {
-    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
-      useTileHealth.getState().recordError('aerial');
-    }
+    repeatRecord('aerial', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
     render(
       <TileHealthBanner
         activeLayer="aerial"
@@ -59,9 +68,7 @@ describe('<TileHealthBanner />', () => {
 
   it('only reflects the active layer — a different failing layer is ignored', () => {
     // OSM is failing, but the user is currently on USGS Topo.
-    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
-      useTileHealth.getState().recordError('osm');
-    }
+    repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
     useTileHealth.getState().recordSuccess('usgs');
 
     render(
@@ -73,13 +80,9 @@ describe('<TileHealthBanner />', () => {
   it('shows the degraded banner copy when status is "degraded"', () => {
     // 4 errors + 6 successes = 40% errors, above the 30% degraded
     // threshold but consecutiveErrors=4 stays under the 5-error
-    // "down" threshold.
-    for (let i = 0; i < 6; i++) {
-      useTileHealth.getState().recordSuccess('osm');
-    }
-    for (let i = 0; i < 4; i++) {
-      useTileHealth.getState().recordError('osm');
-    }
+    // "down" threshold; 10 events ≥ MIN_EVENTS_FOR_DEGRADED.
+    repeatRecord('osm', 'success', 6);
+    repeatRecord('osm', 'error', 4);
 
     render(
       <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />

--- a/src/components/__tests__/TileHealthBanner.test.tsx
+++ b/src/components/__tests__/TileHealthBanner.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+
+import { useTileHealth } from '../../store/tile-health';
+import { DOWN_AFTER_CONSECUTIVE_ERRORS } from '../tile-health-tracker';
+import TileHealthBanner from '../TileHealthBanner';
+
+beforeEach(() => {
+  useTileHealth.setState({ health: {} });
+});
+
+describe('<TileHealthBanner />', () => {
+  it('renders nothing when no tile events have been recorded for the layer', () => {
+    render(
+      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+    );
+    expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while the active layer is healthy', () => {
+    useTileHealth.getState().recordSuccess('osm');
+    render(
+      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+    );
+    expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows the "down" banner when the active layer crosses the threshold', () => {
+    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
+      useTileHealth.getState().recordError('osm');
+    }
+    render(
+      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+    );
+
+    const banner = screen.getByTestId('tile-health-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute('data-status', 'down');
+    expect(banner).toHaveTextContent(/Basemap unavailable/);
+    expect(banner).toHaveTextContent(/Street Map/);
+  });
+
+  it('uses the activeLayerLabel in the banner copy', () => {
+    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
+      useTileHealth.getState().recordError('aerial');
+    }
+    render(
+      <TileHealthBanner
+        activeLayer="aerial"
+        activeLayerLabel="Aerial Imagery"
+      />
+    );
+
+    expect(screen.getByTestId('tile-health-banner')).toHaveTextContent(
+      /Aerial Imagery/
+    );
+  });
+
+  it('only reflects the active layer — a different failing layer is ignored', () => {
+    // OSM is failing, but the user is currently on USGS Topo.
+    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
+      useTileHealth.getState().recordError('osm');
+    }
+    useTileHealth.getState().recordSuccess('usgs');
+
+    render(
+      <TileHealthBanner activeLayer="usgs" activeLayerLabel="USGS Topo" />
+    );
+    expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows the degraded banner copy when status is "degraded"', () => {
+    // 4 errors + 6 successes = 40% errors, above the 30% degraded
+    // threshold but consecutiveErrors=4 stays under the 5-error
+    // "down" threshold.
+    for (let i = 0; i < 6; i++) {
+      useTileHealth.getState().recordSuccess('osm');
+    }
+    for (let i = 0; i < 4; i++) {
+      useTileHealth.getState().recordError('osm');
+    }
+
+    render(
+      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+    );
+
+    const banner = screen.getByTestId('tile-health-banner');
+    expect(banner).toHaveAttribute('data-status', 'degraded');
+    expect(banner).toHaveTextContent(/Slow connection/);
+  });
+});

--- a/src/components/__tests__/tile-health-tracker.test.ts
+++ b/src/components/__tests__/tile-health-tracker.test.ts
@@ -7,6 +7,7 @@ import {
   DOWN_NO_SUCCESS_FOR_MS,
   EMPTY_HEALTH,
   type LayerHealth,
+  MIN_EVENTS_FOR_DEGRADED,
   recordEvent,
   WINDOW_SIZE,
 } from '../tile-health-tracker';
@@ -15,16 +16,16 @@ const T0 = 1_700_000_000_000; // arbitrary fixed wall-clock for determinism
 const PAST = (ms: number) => T0 - ms;
 const FUTURE = (ms: number) => T0 + ms;
 
-function feedSuccesses(start: LayerHealth, n: number, at: number): LayerHealth {
-  let s = start;
-  for (let i = 0; i < n; i++) s = recordEvent(s, 'success', at);
-  return s;
-}
-
-function feedErrors(start: LayerHealth, n: number, at: number): LayerHealth {
-  let s = start;
-  for (let i = 0; i < n; i++) s = recordEvent(s, 'error', at);
-  return s;
+function feedEvents(
+  start: LayerHealth,
+  kind: 'success' | 'error',
+  count: number,
+  at: number
+): LayerHealth {
+  return Array.from({ length: count }).reduce<LayerHealth>(
+    (state) => recordEvent(state, kind, at),
+    start
+  );
 }
 
 describe('recordEvent', () => {
@@ -43,7 +44,7 @@ describe('recordEvent', () => {
   });
 
   it('increments consecutiveErrors on errors, resets on success', () => {
-    const after2err = feedErrors(EMPTY_HEALTH, 2, T0);
+    const after2err = feedEvents(EMPTY_HEALTH, 'error', 2, T0);
     expect(after2err.consecutiveErrors).toBe(2);
 
     const afterRecover = recordEvent(after2err, 'success', T0 + 100);
@@ -52,22 +53,22 @@ describe('recordEvent', () => {
   });
 
   it('keeps lastSuccessAt unchanged when an error follows a success', () => {
-    const a = recordEvent(EMPTY_HEALTH, 'success', T0);
-    const b = recordEvent(a, 'error', T0 + 50);
-    expect(b.lastSuccessAt).toBe(T0);
+    const successful = recordEvent(EMPTY_HEALTH, 'success', T0);
+    const thenErrored = recordEvent(successful, 'error', T0 + 50);
+    expect(thenErrored.lastSuccessAt).toBe(T0);
   });
 
   it('caps the events buffer at WINDOW_SIZE', () => {
-    const flooded = feedSuccesses(EMPTY_HEALTH, WINDOW_SIZE + 5, T0);
+    const flooded = feedEvents(EMPTY_HEALTH, 'success', WINDOW_SIZE + 5, T0);
     expect(flooded.events).toHaveLength(WINDOW_SIZE);
   });
 
   it('drops oldest events first when window overflows', () => {
     // Mark the first event distinctly so we can detect its eviction.
-    const first = recordEvent(EMPTY_HEALTH, 'error', T0);
-    const filled = feedSuccesses(first, WINDOW_SIZE, T0 + 1);
+    const seeded = recordEvent(EMPTY_HEALTH, 'error', T0);
+    const filled = feedEvents(seeded, 'success', WINDOW_SIZE, T0 + 1);
     expect(filled.events).toHaveLength(WINDOW_SIZE);
-    expect(filled.events.every((e) => e.kind === 'success')).toBe(true);
+    expect(filled.events.every((event) => event.kind === 'success')).toBe(true);
   });
 
   it('does not mutate the input state', () => {
@@ -84,72 +85,98 @@ describe('classify', () => {
   });
 
   it('reports ok after a single successful tile load', () => {
-    const s = recordEvent(EMPTY_HEALTH, 'success', T0);
-    expect(classify(s, T0)).toBe('ok');
+    const single = recordEvent(EMPTY_HEALTH, 'success', T0);
+    expect(classify(single, T0)).toBe('ok');
   });
 
-  it('reports degraded when error ratio exceeds the threshold', () => {
-    // 4 errors + 6 successes = 40% errors, above the 30% threshold
-    let s = EMPTY_HEALTH;
-    for (let i = 0; i < 6; i++) s = recordEvent(s, 'success', T0 + i);
-    for (let i = 0; i < 4; i++) s = recordEvent(s, 'error', T0 + 6 + i);
+  it('reports degraded when error ratio exceeds the threshold (with enough events)', () => {
+    // 4 errors + 6 successes = 40% errors, above the 30% threshold,
+    // and 10 events ≥ MIN_EVENTS_FOR_DEGRADED.
+    const withSuccesses = feedEvents(EMPTY_HEALTH, 'success', 6, T0);
+    const mixed = feedEvents(withSuccesses, 'error', 4, T0 + 6);
     const ratio =
-      s.events.filter((e) => e.kind === 'error').length / s.events.length;
+      mixed.events.filter((event) => event.kind === 'error').length /
+      mixed.events.length;
     expect(ratio).toBeGreaterThan(DEGRADED_ERROR_RATIO);
-    expect(classify(s, T0 + 100)).toBe('degraded');
+    expect(mixed.events.length).toBeGreaterThanOrEqual(MIN_EVENTS_FOR_DEGRADED);
+    expect(classify(mixed, T0 + 100)).toBe('degraded');
+  });
+
+  it('does not classify as degraded with fewer than MIN_EVENTS_FOR_DEGRADED events', () => {
+    // A single early failure (1/1 = 100% errors) shouldn't trip the
+    // degraded banner — the minimum-events floor exists for this.
+    const oneError = recordEvent(EMPTY_HEALTH, 'error', T0);
+    expect(oneError.events.length).toBeLessThan(MIN_EVENTS_FOR_DEGRADED);
+    expect(classify(oneError, T0 + 100)).not.toBe('degraded');
   });
 
   it('stays ok when error ratio is below the threshold', () => {
     // 2 errors + 8 successes = 20% errors, below 30% threshold
-    let s = EMPTY_HEALTH;
-    for (let i = 0; i < 8; i++) s = recordEvent(s, 'success', T0 + i);
-    for (let i = 0; i < 2; i++) s = recordEvent(s, 'error', T0 + 8 + i);
-    expect(classify(s, T0 + 100)).toBe('ok');
+    const withSuccesses = feedEvents(EMPTY_HEALTH, 'success', 8, T0);
+    const mixed = feedEvents(withSuccesses, 'error', 2, T0 + 8);
+    expect(classify(mixed, T0 + 100)).toBe('ok');
   });
 
   it('reports down on consecutive errors with no recent success', () => {
-    const s = feedErrors(
+    const allErrors = feedEvents(
       EMPTY_HEALTH,
+      'error',
       DOWN_AFTER_CONSECUTIVE_ERRORS,
       PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
     );
-    expect(classify(s, T0)).toBe('down');
+    expect(classify(allErrors, T0)).toBe('down');
   });
 
   it('does not report down if a success arrived within the recovery window', () => {
     // 5 errors but a success was just recorded — recovery resets the
     // consecutiveErrors counter to 0, so it cannot be 'down'.
-    let s = feedErrors(EMPTY_HEALTH, DOWN_AFTER_CONSECUTIVE_ERRORS, T0);
-    s = recordEvent(s, 'success', T0 + 100);
-    expect(classify(s, T0 + 200)).not.toBe('down');
+    const allErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    const recovered = recordEvent(allErrors, 'success', T0 + 100);
+    expect(classify(recovered, T0 + 200)).not.toBe('down');
   });
 
   it('does not report down if consecutive errors are below the threshold', () => {
-    const s = feedErrors(EMPTY_HEALTH, DOWN_AFTER_CONSECUTIVE_ERRORS - 1, T0);
-    expect(classify(s, FUTURE(DOWN_NO_SUCCESS_FOR_MS + 1))).not.toBe('down');
+    const fewErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS - 1,
+      T0
+    );
+    expect(classify(fewErrors, FUTURE(DOWN_NO_SUCCESS_FOR_MS + 1))).not.toBe(
+      'down'
+    );
   });
 
   it('escalates from degraded to down as more consecutive errors accumulate', () => {
-    let s = recordEvent(
+    const oldSuccess = recordEvent(
       EMPTY_HEALTH,
       'success',
       PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
     );
-    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
-      s = recordEvent(s, 'error', T0 + i);
-    }
-    expect(classify(s, T0 + 100)).toBe('down');
+    const sustainedErrors = feedEvents(
+      oldSuccess,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    expect(classify(sustainedErrors, T0 + 100)).toBe('down');
   });
 
   it('recovers to ok once the rolling window fills with successes', () => {
-    const downState = feedErrors(
+    const downState = feedEvents(
       EMPTY_HEALTH,
+      'error',
       DOWN_AFTER_CONSECUTIVE_ERRORS,
       PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
     );
     expect(classify(downState, T0)).toBe('down');
 
-    const recovered = feedSuccesses(downState, WINDOW_SIZE, T0);
+    const recovered = feedEvents(downState, 'success', WINDOW_SIZE, T0);
     expect(classify(recovered, T0 + 1)).toBe('ok');
   });
 });

--- a/src/components/__tests__/tile-health-tracker.test.ts
+++ b/src/components/__tests__/tile-health-tracker.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classify,
+  DEGRADED_ERROR_RATIO,
+  DOWN_AFTER_CONSECUTIVE_ERRORS,
+  DOWN_NO_SUCCESS_FOR_MS,
+  EMPTY_HEALTH,
+  type LayerHealth,
+  recordEvent,
+  WINDOW_SIZE,
+} from '../tile-health-tracker';
+
+const T0 = 1_700_000_000_000; // arbitrary fixed wall-clock for determinism
+const PAST = (ms: number) => T0 - ms;
+const FUTURE = (ms: number) => T0 + ms;
+
+function feedSuccesses(start: LayerHealth, n: number, at: number): LayerHealth {
+  let s = start;
+  for (let i = 0; i < n; i++) s = recordEvent(s, 'success', at);
+  return s;
+}
+
+function feedErrors(start: LayerHealth, n: number, at: number): LayerHealth {
+  let s = start;
+  for (let i = 0; i < n; i++) s = recordEvent(s, 'error', at);
+  return s;
+}
+
+describe('recordEvent', () => {
+  it('starts from EMPTY_HEALTH with no events', () => {
+    expect(EMPTY_HEALTH.events).toHaveLength(0);
+    expect(EMPTY_HEALTH.consecutiveErrors).toBe(0);
+    expect(EMPTY_HEALTH.lastSuccessAt).toBeNull();
+  });
+
+  it('appends a success event and updates lastSuccessAt', () => {
+    const next = recordEvent(EMPTY_HEALTH, 'success', T0);
+    expect(next.events).toHaveLength(1);
+    expect(next.events[0]).toEqual({ kind: 'success', at: T0 });
+    expect(next.lastSuccessAt).toBe(T0);
+    expect(next.consecutiveErrors).toBe(0);
+  });
+
+  it('increments consecutiveErrors on errors, resets on success', () => {
+    const after2err = feedErrors(EMPTY_HEALTH, 2, T0);
+    expect(after2err.consecutiveErrors).toBe(2);
+
+    const afterRecover = recordEvent(after2err, 'success', T0 + 100);
+    expect(afterRecover.consecutiveErrors).toBe(0);
+    expect(afterRecover.lastSuccessAt).toBe(T0 + 100);
+  });
+
+  it('keeps lastSuccessAt unchanged when an error follows a success', () => {
+    const a = recordEvent(EMPTY_HEALTH, 'success', T0);
+    const b = recordEvent(a, 'error', T0 + 50);
+    expect(b.lastSuccessAt).toBe(T0);
+  });
+
+  it('caps the events buffer at WINDOW_SIZE', () => {
+    const flooded = feedSuccesses(EMPTY_HEALTH, WINDOW_SIZE + 5, T0);
+    expect(flooded.events).toHaveLength(WINDOW_SIZE);
+  });
+
+  it('drops oldest events first when window overflows', () => {
+    // Mark the first event distinctly so we can detect its eviction.
+    const first = recordEvent(EMPTY_HEALTH, 'error', T0);
+    const filled = feedSuccesses(first, WINDOW_SIZE, T0 + 1);
+    expect(filled.events).toHaveLength(WINDOW_SIZE);
+    expect(filled.events.every((e) => e.kind === 'success')).toBe(true);
+  });
+
+  it('does not mutate the input state', () => {
+    const before = recordEvent(EMPTY_HEALTH, 'success', T0);
+    const beforeSnapshot = JSON.stringify(before);
+    recordEvent(before, 'error', T0 + 100);
+    expect(JSON.stringify(before)).toBe(beforeSnapshot);
+  });
+});
+
+describe('classify', () => {
+  it('reports unknown when no events recorded yet', () => {
+    expect(classify(EMPTY_HEALTH, T0)).toBe('unknown');
+  });
+
+  it('reports ok after a single successful tile load', () => {
+    const s = recordEvent(EMPTY_HEALTH, 'success', T0);
+    expect(classify(s, T0)).toBe('ok');
+  });
+
+  it('reports degraded when error ratio exceeds the threshold', () => {
+    // 4 errors + 6 successes = 40% errors, above the 30% threshold
+    let s = EMPTY_HEALTH;
+    for (let i = 0; i < 6; i++) s = recordEvent(s, 'success', T0 + i);
+    for (let i = 0; i < 4; i++) s = recordEvent(s, 'error', T0 + 6 + i);
+    const ratio =
+      s.events.filter((e) => e.kind === 'error').length / s.events.length;
+    expect(ratio).toBeGreaterThan(DEGRADED_ERROR_RATIO);
+    expect(classify(s, T0 + 100)).toBe('degraded');
+  });
+
+  it('stays ok when error ratio is below the threshold', () => {
+    // 2 errors + 8 successes = 20% errors, below 30% threshold
+    let s = EMPTY_HEALTH;
+    for (let i = 0; i < 8; i++) s = recordEvent(s, 'success', T0 + i);
+    for (let i = 0; i < 2; i++) s = recordEvent(s, 'error', T0 + 8 + i);
+    expect(classify(s, T0 + 100)).toBe('ok');
+  });
+
+  it('reports down on consecutive errors with no recent success', () => {
+    const s = feedErrors(
+      EMPTY_HEALTH,
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
+    );
+    expect(classify(s, T0)).toBe('down');
+  });
+
+  it('does not report down if a success arrived within the recovery window', () => {
+    // 5 errors but a success was just recorded — recovery resets the
+    // consecutiveErrors counter to 0, so it cannot be 'down'.
+    let s = feedErrors(EMPTY_HEALTH, DOWN_AFTER_CONSECUTIVE_ERRORS, T0);
+    s = recordEvent(s, 'success', T0 + 100);
+    expect(classify(s, T0 + 200)).not.toBe('down');
+  });
+
+  it('does not report down if consecutive errors are below the threshold', () => {
+    const s = feedErrors(EMPTY_HEALTH, DOWN_AFTER_CONSECUTIVE_ERRORS - 1, T0);
+    expect(classify(s, FUTURE(DOWN_NO_SUCCESS_FOR_MS + 1))).not.toBe('down');
+  });
+
+  it('escalates from degraded to down as more consecutive errors accumulate', () => {
+    let s = recordEvent(
+      EMPTY_HEALTH,
+      'success',
+      PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
+    );
+    for (let i = 0; i < DOWN_AFTER_CONSECUTIVE_ERRORS; i++) {
+      s = recordEvent(s, 'error', T0 + i);
+    }
+    expect(classify(s, T0 + 100)).toBe('down');
+  });
+
+  it('recovers to ok once the rolling window fills with successes', () => {
+    const downState = feedErrors(
+      EMPTY_HEALTH,
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      PAST(DOWN_NO_SUCCESS_FOR_MS + 1)
+    );
+    expect(classify(downState, T0)).toBe('down');
+
+    const recovered = feedSuccesses(downState, WINDOW_SIZE, T0);
+    expect(classify(recovered, T0 + 1)).toBe('ok');
+  });
+});

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { Feature, Map, View } from 'ol';
+import type { EventsKey } from 'ol/events';
 import Point from 'ol/geom/Point';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
+import { unByKey } from 'ol/Observable';
 import { fromLonLat } from 'ol/proj';
 import OSM from 'ol/source/OSM';
 import VectorSource from 'ol/source/Vector';
@@ -13,6 +15,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { GetSite } from '../application/use-cases/get-site';
 import type { Site } from '../domain';
+import type { LayerKey } from '../store/tile-health';
 import { useTileHealth } from '../store/tile-health';
 
 import LayerSwitcher, {
@@ -152,14 +155,21 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
     // banner can show when the active basemap is failing. Use the
     // store's getState() — these listeners run outside React's
     // render lifecycle, so we don't need (and can't safely use) a
-    // hook subscription here.
+    // hook subscription here. Capture the EventsKeys so the cleanup
+    // returned by this effect can detach them via unByKey; otherwise
+    // a re-run of the effect (e.g. on `sites` change) would leave
+    // the previous map's sources holding live listeners and double-
+    // count tile events for the rebuilt map.
     const recordSuccess = useTileHealth.getState().recordSuccess;
     const recordError = useTileHealth.getState().recordError;
-    const trackTileEvents = (key: string, layer: TileLayer<OSM | XYZ>) => {
+    const tileEventKeys: EventsKey[] = [];
+    const trackTileEvents = (key: LayerKey, layer: TileLayer<OSM | XYZ>) => {
       const source = layer.getSource();
       if (source === null) return;
-      source.on('tileloadend', () => recordSuccess(key));
-      source.on('tileloaderror', () => recordError(key));
+      tileEventKeys.push(
+        source.on('tileloadend', () => recordSuccess(key)) as EventsKey,
+        source.on('tileloaderror', () => recordError(key)) as EventsKey
+      );
     };
     trackTileEvents('osm', osmLayer);
     trackTileEvents('usgs', usgsLayer);
@@ -198,6 +208,10 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
     (globalThis as GlobalWithMap).__ndwtMap = map;
 
     return () => {
+      // Detach tile-load listeners so the next mount's tracker
+      // doesn't double-count and the old sources can be GC'd once
+      // their in-flight requests settle.
+      for (const k of tileEventKeys) unByKey(k);
       map.setTarget();
       delete (globalThis as GlobalWithMap).__ndwtMap;
       layerRefs.current = {

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -13,9 +13,15 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { GetSite } from '../application/use-cases/get-site';
 import type { Site } from '../domain';
+import { useTileHealth } from '../store/tile-health';
 
-import LayerSwitcher, { type BaseMapId, type OverlayId } from './LayerSwitcher';
+import LayerSwitcher, {
+  BASE_MAPS,
+  type BaseMapId,
+  type OverlayId,
+} from './LayerSwitcher';
 import { makeHandleClick, makeHandlePointerMove } from './map-handlers';
+import TileHealthBanner from './TileHealthBanner';
 
 type GlobalWithMap = typeof globalThis & { __ndwtMap?: Map };
 
@@ -142,6 +148,26 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
       hiking: hikingLayer,
     };
 
+    // Wire OL tile-load events into the tile-health store so the
+    // banner can show when the active basemap is failing. Use the
+    // store's getState() — these listeners run outside React's
+    // render lifecycle, so we don't need (and can't safely use) a
+    // hook subscription here.
+    const recordSuccess = useTileHealth.getState().recordSuccess;
+    const recordError = useTileHealth.getState().recordError;
+    const trackTileEvents = (key: string, layer: TileLayer<OSM | XYZ>) => {
+      const source = layer.getSource();
+      if (source === null) return;
+      source.on('tileloadend', () => recordSuccess(key));
+      source.on('tileloaderror', () => recordError(key));
+    };
+    trackTileEvents('osm', osmLayer);
+    trackTileEvents('usgs', usgsLayer);
+    trackTileEvents('opentopomap', openTopoLayer);
+    trackTileEvents('aerial', aerialLayer);
+    trackTileEvents('openseamap', openSeaLayer);
+    trackTileEvents('hiking', hikingLayer);
+
     const map = new Map({
       target: container,
       layers: [
@@ -218,8 +244,15 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
     });
   };
 
+  const activeLayerLabel =
+    BASE_MAPS.find((b) => b.id === activeBaseMap)?.label ?? activeBaseMap;
+
   return (
     <div id="map" ref={containerRef}>
+      <TileHealthBanner
+        activeLayer={activeBaseMap}
+        activeLayerLabel={activeLayerLabel}
+      />
       <LayerSwitcher
         activeBaseMap={activeBaseMap}
         activeOverlays={activeOverlays}

--- a/src/components/tile-health-tracker.ts
+++ b/src/components/tile-health-tracker.ts
@@ -17,7 +17,10 @@ export interface LayerHealth {
 }
 
 export const EMPTY_HEALTH: LayerHealth = Object.freeze({
-  events: [],
+  // Object.freeze is shallow — also freeze the array so an
+  // accidental `EMPTY_HEALTH.events.push(...)` from a caller can't
+  // poison this shared singleton.
+  events: Object.freeze([] as TileLoadEvent[]),
   consecutiveErrors: 0,
   lastSuccessAt: null,
 });
@@ -32,9 +35,12 @@ export const WINDOW_SIZE = 20;
 export const DOWN_AFTER_CONSECUTIVE_ERRORS = 5;
 export const DOWN_NO_SUCCESS_FOR_MS = 10_000;
 
-// Degraded threshold — 30% errors in the recent window. High enough
-// that a single failed tile during a busy pan doesn't trip it.
+// Degraded threshold — 30% errors in the recent window AND at least
+// MIN_EVENTS_FOR_DEGRADED events recorded. The floor avoids a single
+// transient failure on initial load (1/1 = 100% > 30%) tripping the
+// banner before we have enough samples to call the layer degraded.
 export const DEGRADED_ERROR_RATIO = 0.3;
+export const MIN_EVENTS_FOR_DEGRADED = 5;
 
 export function recordEvent(
   state: LayerHealth,
@@ -63,9 +69,11 @@ export function classify(state: LayerHealth, now: number): HealthStatus {
     return 'down';
   }
 
-  const errorCount = state.events.filter((e) => e.kind === 'error').length;
-  if (errorCount / state.events.length > DEGRADED_ERROR_RATIO) {
-    return 'degraded';
+  if (state.events.length >= MIN_EVENTS_FOR_DEGRADED) {
+    const errorCount = state.events.filter((e) => e.kind === 'error').length;
+    if (errorCount / state.events.length > DEGRADED_ERROR_RATIO) {
+      return 'degraded';
+    }
   }
 
   return 'ok';

--- a/src/components/tile-health-tracker.ts
+++ b/src/components/tile-health-tracker.ts
@@ -1,0 +1,72 @@
+// Pure tile-health classification logic. Lives outside the Zustand
+// store so it can be unit-tested in jsdom without touching React or
+// OpenLayers — the store and the OL listeners just feed it events
+// and read its verdict.
+
+export type TileLoadEvent = {
+  readonly kind: 'success' | 'error';
+  readonly at: number;
+};
+
+export type HealthStatus = 'unknown' | 'ok' | 'degraded' | 'down';
+
+export interface LayerHealth {
+  readonly events: readonly TileLoadEvent[];
+  readonly consecutiveErrors: number;
+  readonly lastSuccessAt: number | null;
+}
+
+export const EMPTY_HEALTH: LayerHealth = Object.freeze({
+  events: [],
+  consecutiveErrors: 0,
+  lastSuccessAt: null,
+});
+
+// Rolling window — 20 events covers ~5–10 panned tile batches at
+// typical zooms. Bigger window = slower to react to recovery; smaller
+// = noisier classification.
+export const WINDOW_SIZE = 20;
+
+// Hard "down" trigger. Five consecutive errors with no successes in
+// the last 10 s is unambiguous — the layer is broken right now.
+export const DOWN_AFTER_CONSECUTIVE_ERRORS = 5;
+export const DOWN_NO_SUCCESS_FOR_MS = 10_000;
+
+// Degraded threshold — 30% errors in the recent window. High enough
+// that a single failed tile during a busy pan doesn't trip it.
+export const DEGRADED_ERROR_RATIO = 0.3;
+
+export function recordEvent(
+  state: LayerHealth,
+  kind: 'success' | 'error',
+  now: number
+): LayerHealth {
+  const events = [...state.events, { kind, at: now }].slice(-WINDOW_SIZE);
+  return {
+    events,
+    consecutiveErrors: kind === 'error' ? state.consecutiveErrors + 1 : 0,
+    lastSuccessAt: kind === 'success' ? now : state.lastSuccessAt,
+  };
+}
+
+export function classify(state: LayerHealth, now: number): HealthStatus {
+  if (state.events.length === 0) return 'unknown';
+
+  const noRecentSuccess =
+    state.lastSuccessAt === null ||
+    now - state.lastSuccessAt > DOWN_NO_SUCCESS_FOR_MS;
+
+  if (
+    state.consecutiveErrors >= DOWN_AFTER_CONSECUTIVE_ERRORS &&
+    noRecentSuccess
+  ) {
+    return 'down';
+  }
+
+  const errorCount = state.events.filter((e) => e.kind === 'error').length;
+  if (errorCount / state.events.length > DEGRADED_ERROR_RATIO) {
+    return 'degraded';
+  }
+
+  return 'ok';
+}

--- a/src/store/__tests__/tile-health.test.ts
+++ b/src/store/__tests__/tile-health.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { EMPTY_HEALTH } from '../../components/tile-health-tracker';
+import { useTileHealth } from '../tile-health';
+
+// Reset the (otherwise process-shared) Zustand state between tests
+// so each one starts from a known empty store.
+beforeEach(() => {
+  useTileHealth.setState({ health: {} });
+});
+
+describe('useTileHealth', () => {
+  it('starts with no per-layer health', () => {
+    expect(useTileHealth.getState().health).toEqual({});
+  });
+
+  it('recordSuccess seeds a new layer entry and stamps a success', () => {
+    expect(useTileHealth.getState().health['osm']).toBeUndefined();
+
+    useTileHealth.getState().recordSuccess('osm');
+    const entry = useTileHealth.getState().health['osm'];
+
+    expect(entry).toBeDefined();
+    expect(entry?.events).toHaveLength(1);
+    expect(entry?.events[0]?.kind).toBe('success');
+    expect(entry?.lastSuccessAt).not.toBeNull();
+    expect(entry?.consecutiveErrors).toBe(0);
+  });
+
+  it('recordError increments consecutiveErrors and leaves lastSuccessAt unchanged', () => {
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordError('osm');
+
+    const entry = useTileHealth.getState().health['osm'];
+    expect(entry?.consecutiveErrors).toBe(2);
+    expect(entry?.lastSuccessAt).toBeNull();
+  });
+
+  it('tracks each layer independently', () => {
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordSuccess('usgs');
+
+    expect(useTileHealth.getState().health['osm']?.consecutiveErrors).toBe(2);
+    expect(useTileHealth.getState().health['usgs']?.consecutiveErrors).toBe(0);
+    expect(useTileHealth.getState().health['usgs']?.events).toHaveLength(1);
+  });
+
+  it('reset clears a single layer back to EMPTY_HEALTH without touching others', () => {
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordSuccess('usgs');
+
+    useTileHealth.getState().reset('osm');
+
+    expect(useTileHealth.getState().health['osm']).toEqual(EMPTY_HEALTH);
+    // 'usgs' state unchanged.
+    expect(useTileHealth.getState().health['usgs']?.events).toHaveLength(1);
+  });
+
+  it('a recovery success after errors resets consecutiveErrors to 0', () => {
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordError('osm');
+    useTileHealth.getState().recordSuccess('osm');
+
+    expect(useTileHealth.getState().health['osm']?.consecutiveErrors).toBe(0);
+    expect(useTileHealth.getState().health['osm']?.events).toHaveLength(4);
+  });
+});

--- a/src/store/tile-health.ts
+++ b/src/store/tile-health.ts
@@ -1,12 +1,18 @@
 import { create } from 'zustand';
 
+import type { BaseMapId, OverlayId } from '../components/LayerSwitcher';
 import type { LayerHealth } from '../components/tile-health-tracker';
 import { EMPTY_HEALTH, recordEvent } from '../components/tile-health-tracker';
 
-export type LayerKey = string;
+// Restricting LayerKey to the actual layer ids prevents recording
+// health under a misspelled / unsupported key — call sites get a
+// type error instead of silently growing a dead entry in the store.
+export type LayerKey = BaseMapId | OverlayId;
 
+// Health entries are populated lazily as the first tile event for a
+// layer arrives, so the record is partial.
 interface TileHealthState {
-  health: Record<LayerKey, LayerHealth>;
+  health: Partial<Record<LayerKey, LayerHealth>>;
   recordSuccess: (layer: LayerKey) => void;
   recordError: (layer: LayerKey) => void;
   reset: (layer: LayerKey) => void;

--- a/src/store/tile-health.ts
+++ b/src/store/tile-health.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+import type { LayerHealth } from '../components/tile-health-tracker';
+import { EMPTY_HEALTH, recordEvent } from '../components/tile-health-tracker';
+
+export type LayerKey = string;
+
+interface TileHealthState {
+  health: Record<LayerKey, LayerHealth>;
+  recordSuccess: (layer: LayerKey) => void;
+  recordError: (layer: LayerKey) => void;
+  reset: (layer: LayerKey) => void;
+}
+
+export const useTileHealth = create<TileHealthState>((set) => ({
+  health: {},
+  recordSuccess: (layer) =>
+    set((s) => ({
+      health: {
+        ...s.health,
+        [layer]: recordEvent(
+          s.health[layer] ?? EMPTY_HEALTH,
+          'success',
+          Date.now()
+        ),
+      },
+    })),
+  recordError: (layer) =>
+    set((s) => ({
+      health: {
+        ...s.health,
+        [layer]: recordEvent(
+          s.health[layer] ?? EMPTY_HEALTH,
+          'error',
+          Date.now()
+        ),
+      },
+    })),
+  reset: (layer) =>
+    set((s) => ({ health: { ...s.health, [layer]: EMPTY_HEALTH } })),
+}));


### PR DESCRIPTION
## Summary

Implements **Tier 1** of the tile-resilience roadmap from #64: when the active basemap is failing to load tiles, the user gets a clear, non-blocking notification instead of staring at a blank canvas.

Today's behavior: a failed tile request leaves the cell blank with zero UI feedback. Confirmed via `grep` — there is no tile error handling anywhere in the codebase. For paddlers in cell-dead zones (very common on the Columbia/Snake), an upstream basemap outage means a mostly-empty map and no recovery path or even acknowledgment that anything is wrong.

This change:

- Wires OL's `tileloadend` and `tileloaderror` source events into a small Zustand store (`useTileHealth`)
- Classifies per-layer health on a rolling 20-event window: `ok` / `degraded` / `down`
- Renders a top-center banner over the map when the **active** basemap crosses the threshold; switching to a healthy alternative clears it immediately

## What you see in the banner

> ⚠ **Basemap unavailable**
> Street Map isn't loading right now. The tile service might be temporarily down — try a different basemap from the layers menu.

Auto-dismisses when tile loads recover. Different copy for `degraded` vs `down`.

## File map

| File | What |
|---|---|
| `src/components/tile-health-tracker.ts` (new) | Pure classification logic — fully unit-testable in jsdom |
| `src/components/__tests__/tile-health-tracker.test.ts` (new) | 16 unit tests covering record/classify edges (window overflow, recovery, no-success-since timeout, degraded vs down thresholds) |
| `src/store/tile-health.ts` (new) | Zustand slice mirroring `selected-site` store pattern |
| `src/components/TileHealthBanner.tsx` (new) | Reads active layer's health on a 2 s tick (so time-based "no success in 10 s" classifications age out); `data-testid` for stable e2e selection |
| `src/components/map.tsx` | Attaches success/error listeners on each `TileLayer` source via `useTileHealth.getState()`; renders the banner |
| `src/components/LayerSwitcher.tsx` | Exports `BASE_MAPS` so the banner can resolve the active layer's display label without duplication |
| `e2e/map.spec.ts` | Two new tests using `page.route()` to force OSM tiles to 503: (1) banner appears with "Basemap unavailable" + active layer name; (2) banner disappears after switching to a healthy basemap |

## Thresholds

In `tile-health-tracker.ts`:
- **down**: 5+ consecutive errors AND no successful tile in the last 10 s
- **degraded**: \>30% errors in the rolling 20-event window
- **ok**: otherwise

Tunable via the named exported constants. Tier 2 may want to make some of these per-layer.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 126 unit tests pass (16 new for the tracker)
- [x] `npm run build` — clean static export
- [x] `npx playwright test --workers=1` — 53 e2e pass (2 new banner tests, 4 existing aerial tests, 47 unchanged)
- [x] Manual: `npm run dev`, browser DevTools → block requests to `tile.openstreetmap.org`, banner appears within ~3s; switch to USGS Topo, banner clears
- [ ] Bot triage (DeepSource, SonarCloud, Gemini, Copilot) before merge

## Out of scope (tracked in #64)

- **Tier 2**: status dots in the LayerSwitcher (🟢🟡🔴) + auto-suggest a fallback layer with a one-click button in the banner
- **Tier 3**: service worker tile caching for offline use — the big win for paddlers in cell-dead zones

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)