### PR TITLE
docs(claude.md): correct DeepSource report-access note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ human review:
    detail (file paths, line numbers, code excerpts) is also in
    the same HTML — parse it directly rather than asking a human
    to paste it.
+
 4. Tick the "bot triage" checkbox in the PR template before
    requesting human review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,12 @@ human review:
    commits with the SHA in your reply; mark threads resolved.
 3. For DeepSource, the report URL is in the commit status — the
    page is publicly accessible for public repos, so a quick
-   curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE '[A-Z]{2,}-[A-Z0-9]+' | sort -u
+
+   ```sh
+   curl -s 'https://app.deepsource.com/gh/<org>/<repo>/run/<id>/javascript/' \
+     | grep -oE '[A-Z]{2,}-[A-Z0-9]+' | sort -u
+   ```
+
    surfaces the rule IDs without auth. The full per-issue
    detail (file paths, line numbers, code excerpts) is also in
    the same HTML — parse it directly rather than asking a human

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ human review:
    commits with the SHA in your reply; mark threads resolved.
 3. For DeepSource, the report URL is in the commit status — the
    page is publicly accessible for public repos, so a quick
-curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE '[A-Z]{2,}-[A-Z0-9]+' | sort -u
+   curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE '[A-Z]{2,}-[A-Z0-9]+' | sort -u
    surfaces the rule IDs without auth. The full per-issue
    detail (file paths, line numbers, code excerpts) is also in
    the same HTML — parse it directly rather than asking a human

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,8 +150,13 @@ human review:
    inline thread.
 2. Bucket each comment as **fix / defer / dismiss**. Push fixup
    commits with the SHA in your reply; mark threads resolved.
-3. For DeepSource, the report URL is in the commit status —
-   the user has to paste it because the dashboard requires auth.
+3. For DeepSource, the report URL is in the commit status — the
+   page is publicly accessible for public repos, so a quick
+   `curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE 'JS-[A-Z][0-9]+' | sort -u`
+   surfaces the rule IDs without auth. The full per-issue
+   detail (file paths, line numbers, code excerpts) is also in
+   the same HTML — parse it directly rather than asking a human
+   to paste it.
 4. Tick the "bot triage" checkbox in the PR template before
    requesting human review.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ human review:
    commits with the SHA in your reply; mark threads resolved.
 3. For DeepSource, the report URL is in the commit status — the
    page is publicly accessible for public repos, so a quick
-   `curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE 'JS-[A-Z][0-9]+' | sort -u`
+curl https://app.deepsource.com/.../run/<id>/javascript/ | grep -oE '[A-Z]{2,}-[A-Z0-9]+' | sort -u
    surfaces the rule IDs without auth. The full per-issue
    detail (file paths, line numbers, code excerpts) is also in
    the same HTML — parse it directly rather than asking a human


### PR DESCRIPTION
## Summary

The bot-triage section in CLAUDE.md said the DeepSource report URL "requires auth and the user has to paste it." Empirically, that's not true for public repos: `curl` returns HTTP 200 with the issue HTML, including rule IDs, file paths, line numbers, and code excerpts.

Discovered while addressing the `JS-C1002` finding on [#65](https://github.com/ivanoats/ndwt-ol-chakra/pull/65) — extracted the rule + per-file occurrences directly via curl + grep, no auth needed:

```sh
curl -s 'https://app.deepsource.com/gh/<org>/<repo>/run/<id>/javascript/' \
  | grep -oE 'JS-[A-Z][0-9]+' | sort -u
```

Updates the note so future agents (and humans) know to fetch and parse the report directly instead of waiting on a copy-paste.

## Test plan

- [x] `npm run lint:md` — markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)