### PR TITLE
feat(map): tier 2 of tile resilience — health dots, auto-suggest, sticky down

### DIFF
--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -257,11 +257,89 @@ test.describe('Northwest Discovery Water Trail map', () => {
 
     // Switch to USGS Topo (different host, no route override). The
     // banner reads health for the new active layer, which has no
-    // events yet → 'unknown' → banner hides.
+    // events yet → 'unknown' → banner hides. Scope the click to the
+    // LayerSwitcher panel — the Tier 2 banner now also renders a
+    // "Switch to USGS Topo" fallback button which would otherwise
+    // collide on the role/name selector.
     await page.getByRole('button', { name: 'Toggle layer switcher' }).click();
-    await page.getByRole('button', { name: /USGS Topo/ }).click();
+    await page
+      .getByRole('group', { name: 'Map layers' })
+      .getByRole('button', { name: /USGS Topo/ })
+      .click();
 
     await expect(banner).toBeHidden({ timeout: 5_000 });
+  });
+
+  test('one-click fallback switches to a healthy basemap and clears the banner', async ({
+    page,
+  }) => {
+    // OSM is the failing default; force every OSM tile to 503 so
+    // the banner reaches the 'down' state. USGS, OpenTopoMap, and
+    // USGS Imagery are untouched so suggestFallback has healthy
+    // candidates to surface in the switch button.
+    await page.route(/tile\.openstreetmap\.org\//, (route) =>
+      route.fulfill({ status: 503, body: 'simulated outage' })
+    );
+
+    await page.goto('/');
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const banner = page.getByTestId('tile-health-banner');
+    await expect(banner).toBeVisible({ timeout: 20_000 });
+    await expect(banner).toHaveAttribute('data-status', 'down');
+
+    // The fallback button should appear inside the banner once the
+    // layer is fully down. Its label names whichever basemap
+    // suggestFallback picked — verify the click handler switches to
+    // that layer.
+    const fallbackButton = page.getByTestId('tile-health-fallback-button');
+    await expect(fallbackButton).toBeVisible({ timeout: 5_000 });
+    await expect(fallbackButton).toContainText(/Switch to/);
+
+    await fallbackButton.click();
+
+    // Banner clears because the new active basemap has no recorded
+    // events yet (or is healthy).
+    await expect(banner).toBeHidden({ timeout: 5_000 });
+
+    // And the active basemap actually changed away from OSM.
+    await page.getByRole('button', { name: 'Toggle layer switcher' }).click();
+    await expect(
+      page.getByRole('button', { name: /Street Map/ })
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('LayerSwitcher health dot turns red when the active basemap is down', async ({
+    page,
+  }) => {
+    await page.route(/tile\.openstreetmap\.org\//, (route) =>
+      route.fulfill({ status: 503, body: 'simulated outage' })
+    );
+
+    await page.goto('/');
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Wait for the banner so we know OSM has reached 'down'.
+    await expect(page.getByTestId('tile-health-banner')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Open the switcher and assert the dot for OSM is red.
+    await page.getByRole('button', { name: 'Toggle layer switcher' }).click();
+    await expect(page.getByTestId('health-dot-osm')).toHaveAttribute(
+      'data-status',
+      'down'
+    );
   });
 });
 

--- a/src/components/LayerSwitcher.tsx
+++ b/src/components/LayerSwitcher.tsx
@@ -126,6 +126,13 @@ const dividerClass = css({
 // Color reflects the layer's current tile-health classification.
 // Hidden from screen readers — the `title` provides hover-tooltip
 // context and the surrounding banner already announces failures.
+const HEALTH_DOT_COLORS: Record<HealthStatus, string> = {
+  ok: 'green.9',
+  degraded: 'amber.9',
+  down: 'red.9',
+  unknown: 'gray.6',
+};
+
 const healthDotClass = (status: HealthStatus) =>
   css({
     marginLeft: 'auto',
@@ -133,14 +140,7 @@ const healthDotClass = (status: HealthStatus) =>
     height: '2',
     borderRadius: 'full',
     flexShrink: 0,
-    backgroundColor:
-      status === 'down'
-        ? 'red.9'
-        : status === 'degraded'
-          ? 'amber.9'
-          : status === 'ok'
-            ? 'green.9'
-            : 'gray.6',
+    backgroundColor: HEALTH_DOT_COLORS[status],
     opacity: status === 'unknown' ? 0.35 : 1,
   });
 

--- a/src/components/LayerSwitcher.tsx
+++ b/src/components/LayerSwitcher.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { Layers } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { css } from 'styled-system/css';
+
+import { useTileHealth } from '../store/tile-health';
+
+import { classify, type HealthStatus } from './tile-health-tracker';
 
 export type BaseMapId = 'osm' | 'usgs' | 'opentopomap' | 'aerial';
 export type OverlayId = 'openseamap' | 'hiking';
@@ -118,6 +122,40 @@ const dividerClass = css({
   margin: '0',
 });
 
+// Health dot: pushed to the right of the button via marginLeft auto.
+// Color reflects the layer's current tile-health classification.
+// Hidden from screen readers — the `title` provides hover-tooltip
+// context and the surrounding banner already announces failures.
+const healthDotClass = (status: HealthStatus) =>
+  css({
+    marginLeft: 'auto',
+    width: '2',
+    height: '2',
+    borderRadius: 'full',
+    flexShrink: 0,
+    backgroundColor:
+      status === 'down'
+        ? 'red.9'
+        : status === 'degraded'
+          ? 'amber.9'
+          : status === 'ok'
+            ? 'green.9'
+            : 'gray.6',
+    opacity: status === 'unknown' ? 0.35 : 1,
+  });
+
+const HEALTH_TITLES: Record<HealthStatus, string> = {
+  ok: 'Tiles loading',
+  degraded: 'Slow / partial tile loads',
+  down: 'Tile service unavailable',
+  unknown: 'No tile loads yet',
+};
+
+// Re-tick at the same cadence as the banner so time-based
+// classifications (e.g. "no successful tile in 10s") age the dots
+// even when no new events arrive.
+const TICK_MS = 2000;
+
 export default function LayerSwitcher({
   activeBaseMap,
   activeOverlays,
@@ -125,6 +163,18 @@ export default function LayerSwitcher({
   onOverlayToggle,
 }: LayerSwitcherProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const allHealth = useTileHealth((s) => s.health);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const id = globalThis.setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => globalThis.clearInterval(id);
+  }, []);
+
+  const statusFor = (id: BaseMapId | OverlayId): HealthStatus => {
+    const entry = allHealth[id];
+    return entry === undefined ? 'unknown' : classify(entry, now);
+  };
 
   return (
     <div className={panelClass}>
@@ -141,38 +191,58 @@ export default function LayerSwitcher({
       {isOpen && (
         <div className={dropdownClass} role="group" aria-label="Map layers">
           <p className={sectionLabelClass}>Base Map</p>
-          {BASE_MAPS.map(({ id, label }) => (
-            <button
-              key={id}
-              type="button"
-              aria-pressed={activeBaseMap === id}
-              onClick={() => onBaseMapChange(id)}
-              className={layerBtnClass(activeBaseMap === id)}
-            >
-              <span aria-hidden="true">
-                {activeBaseMap === id ? '● ' : '○ '}
-              </span>
-              {label}
-            </button>
-          ))}
+          {BASE_MAPS.map(({ id, label }) => {
+            const status = statusFor(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={activeBaseMap === id}
+                onClick={() => onBaseMapChange(id)}
+                className={layerBtnClass(activeBaseMap === id)}
+              >
+                <span aria-hidden="true">
+                  {activeBaseMap === id ? '● ' : '○ '}
+                </span>
+                {label}
+                <span
+                  aria-hidden="true"
+                  title={HEALTH_TITLES[status]}
+                  data-testid={`health-dot-${id}`}
+                  data-status={status}
+                  className={healthDotClass(status)}
+                />
+              </button>
+            );
+          })}
 
           <hr className={dividerClass} />
 
           <p className={sectionLabelClass}>Overlays</p>
-          {OVERLAYS.map(({ id, label }) => (
-            <button
-              key={id}
-              type="button"
-              aria-pressed={activeOverlays.has(id)}
-              onClick={() => onOverlayToggle(id)}
-              className={layerBtnClass(activeOverlays.has(id))}
-            >
-              <span aria-hidden="true">
-                {activeOverlays.has(id) ? '☑ ' : '☐ '}
-              </span>
-              {label}
-            </button>
-          ))}
+          {OVERLAYS.map(({ id, label }) => {
+            const status = statusFor(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={activeOverlays.has(id)}
+                onClick={() => onOverlayToggle(id)}
+                className={layerBtnClass(activeOverlays.has(id))}
+              >
+                <span aria-hidden="true">
+                  {activeOverlays.has(id) ? '☑ ' : '☐ '}
+                </span>
+                {label}
+                <span
+                  aria-hidden="true"
+                  title={HEALTH_TITLES[status]}
+                  data-testid={`health-dot-${id}`}
+                  data-status={status}
+                  className={healthDotClass(status)}
+                />
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/LayerSwitcher.tsx
+++ b/src/components/LayerSwitcher.tsx
@@ -151,6 +151,22 @@ const HEALTH_TITLES: Record<HealthStatus, string> = {
   unknown: 'No tile loads yet',
 };
 
+// Screen-reader-only span that announces the layer's status as part
+// of the surrounding button's accessible name. The dot itself stays
+// purely decorative — title tooltips aren't reliably exposed to
+// assistive tech.
+const srOnlyClass = css({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  borderWidth: 0,
+  clipPath: 'inset(50%)',
+});
+
 // Re-tick at the same cadence as the banner so time-based
 // classifications (e.g. "no successful tile in 10s") age the dots
 // even when no new events arrive.
@@ -166,10 +182,15 @@ export default function LayerSwitcher({
   const allHealth = useTileHealth((s) => s.health);
   const [now, setNow] = useState<number>(() => Date.now());
 
+  // Only tick while the dropdown is open — the dots are hidden when
+  // it's closed, so a background interval would just burn wakeups
+  // on mobile / low-power devices. The first render after opening
+  // already reads a fresh Date.now() via the lazy useState init.
   useEffect(() => {
+    if (!isOpen) return undefined;
     const id = globalThis.setInterval(() => setNow(Date.now()), TICK_MS);
     return () => globalThis.clearInterval(id);
-  }, []);
+  }, [isOpen]);
 
   const statusFor = (id: BaseMapId | OverlayId): HealthStatus => {
     const entry = allHealth[id];
@@ -205,6 +226,12 @@ export default function LayerSwitcher({
                   {activeBaseMap === id ? '● ' : '○ '}
                 </span>
                 {label}
+                {status !== 'ok' && status !== 'unknown' && (
+                  <span className={srOnlyClass}>
+                    {' '}
+                    ({HEALTH_TITLES[status]})
+                  </span>
+                )}
                 <span
                   aria-hidden="true"
                   title={HEALTH_TITLES[status]}
@@ -233,6 +260,12 @@ export default function LayerSwitcher({
                   {activeOverlays.has(id) ? '☑ ' : '☐ '}
                 </span>
                 {label}
+                {status !== 'ok' && status !== 'unknown' && (
+                  <span className={srOnlyClass}>
+                    {' '}
+                    ({HEALTH_TITLES[status]})
+                  </span>
+                )}
                 <span
                   aria-hidden="true"
                   title={HEALTH_TITLES[status]}

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -88,8 +88,11 @@ export default function TileHealthBanner({
   activeLayerLabel,
   onSwitchTo,
 }: TileHealthBannerProps) {
-  const health = useTileHealth((s) => s.health[activeLayer]);
+  // Single store subscription — the active layer's slice is derived
+  // from the full record. Avoids two `useTileHealth` calls when one
+  // subscription already gives us everything we need.
   const allHealth = useTileHealth((s) => s.health);
+  const health = allHealth[activeLayer];
   const [now, setNow] = useState<number>(() => Date.now());
 
   useEffect(() => {

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -6,12 +6,13 @@ import { css } from 'styled-system/css';
 
 import { useTileHealth } from '../store/tile-health';
 
-import type { BaseMapId } from './LayerSwitcher';
-import { classify } from './tile-health-tracker';
+import { BASE_MAPS, type BaseMapId } from './LayerSwitcher';
+import { classify, suggestFallback } from './tile-health-tracker';
 
 interface TileHealthBannerProps {
   readonly activeLayer: BaseMapId;
   readonly activeLayerLabel: string;
+  readonly onSwitchTo: (id: BaseMapId) => void;
 }
 
 // Top-center banner over the map. Sits high enough to clear the
@@ -49,17 +50,46 @@ const labelClass = css({
   fontWeight: 'semibold',
 });
 
+const switchBtnClass = css({
+  marginTop: '2',
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '1.5',
+  paddingInline: '3',
+  borderRadius: 'sm',
+  cursor: 'pointer',
+  fontSize: 'sm',
+  fontWeight: 'semibold',
+  backgroundColor: 'colorPalette.9',
+  color: 'colorPalette.contrast',
+  borderWidth: '1px',
+  borderColor: 'colorPalette.9',
+  _hover: { backgroundColor: 'colorPalette.10' },
+  _focusVisible: {
+    outline: '2px solid',
+    outlineColor: 'colorPalette.9',
+    outlineOffset: '2px',
+  },
+});
+
 // Time-based classification (e.g. "no successful tile in 10s") needs
 // the component to re-render even when no new events arrive. Tick at
 // a coarse interval — 2 s is fine for human-perceived latency and
 // keeps wakeups cheap.
 const TICK_MS = 2000;
 
+const BASE_MAP_IDS: readonly BaseMapId[] = BASE_MAPS.map((b) => b.id);
+
+const labelFor = (id: BaseMapId): string =>
+  BASE_MAPS.find((b) => b.id === id)?.label ?? id;
+
 export default function TileHealthBanner({
   activeLayer,
   activeLayerLabel,
+  onSwitchTo,
 }: TileHealthBannerProps) {
   const health = useTileHealth((s) => s.health[activeLayer]);
+  const allHealth = useTileHealth((s) => s.health);
   const [now, setNow] = useState<number>(() => Date.now());
 
   useEffect(() => {
@@ -74,6 +104,21 @@ export default function TileHealthBanner({
     status === 'down'
       ? `${activeLayerLabel} isn't loading right now. The tile service might be temporarily down — try a different basemap from the layers menu.`
       : `${activeLayerLabel} is having trouble loading some tiles.`;
+
+  // Only offer the one-click switch when the active layer is fully
+  // down — a 'degraded' layer is still usable and a forced swap
+  // would be more disruptive than helpful. `suggestFallback` returns
+  // null if every other basemap is also down, in which case there's
+  // nowhere good to send the user.
+  const fallbackId =
+    status === 'down'
+      ? (suggestFallback(
+          activeLayer,
+          allHealth,
+          BASE_MAP_IDS,
+          now
+        ) as BaseMapId | null)
+      : null;
 
   return (
     // <output> has an implicit `role="status"` (and the matching
@@ -92,6 +137,16 @@ export default function TileHealthBanner({
           {status === 'down' ? 'Basemap unavailable' : 'Slow connection'}
         </div>
         <div>{message}</div>
+        {fallbackId !== null && (
+          <button
+            type="button"
+            className={switchBtnClass}
+            data-testid="tile-health-fallback-button"
+            onClick={() => onSwitchTo(fallbackId)}
+          >
+            Switch to {labelFor(fallbackId)}
+          </button>
+        )}
       </div>
     </output>
   );

--- a/src/components/TileHealthBanner.tsx
+++ b/src/components/TileHealthBanner.tsx
@@ -109,34 +109,34 @@ export default function TileHealthBanner({
   // down — a 'degraded' layer is still usable and a forced swap
   // would be more disruptive than helpful. `suggestFallback` returns
   // null if every other basemap is also down, in which case there's
-  // nowhere good to send the user.
+  // nowhere good to send the user. The helper is generic over the id
+  // type so no cast is needed.
   const fallbackId =
     status === 'down'
-      ? (suggestFallback(
-          activeLayer,
-          allHealth,
-          BASE_MAP_IDS,
-          now
-        ) as BaseMapId | null)
+      ? suggestFallback(activeLayer, allHealth, BASE_MAP_IDS, now)
       : null;
 
   return (
-    // <output> has an implicit `role="status"` (and the matching
-    // `aria-live="polite"`), which is better-supported by screen
-    // readers than `<div role="status">`. The non-interruptive
-    // semantics fit "your basemap is slow" — `role="alert"` would
-    // force assertive announcement which is too loud for this.
-    <output
+    // Outer wrapper carries the test/data attributes for selectors
+    // and the visual styling, but no live-region role. The textual
+    // status lives in an inner <output> (implicit role="status" +
+    // aria-live="polite"); the fallback button sits as a sibling
+    // outside that live region so screen readers don't repeatedly
+    // announce the button when state ticks. Pattern recommended by
+    // WAI-ARIA: keep interactive controls outside aria-live regions.
+    <div
       data-testid="tile-health-banner"
       data-status={status}
       className={bannerClass}
     >
       <AlertTriangle size={20} className={iconClass} aria-hidden="true" />
       <div>
-        <div className={labelClass}>
-          {status === 'down' ? 'Basemap unavailable' : 'Slow connection'}
-        </div>
-        <div>{message}</div>
+        <output>
+          <div className={labelClass}>
+            {status === 'down' ? 'Basemap unavailable' : 'Slow connection'}
+          </div>
+          <div>{message}</div>
+        </output>
         {fallbackId !== null && (
           <button
             type="button"
@@ -148,6 +148,6 @@ export default function TileHealthBanner({
           </button>
         )}
       </div>
-    </output>
+    </div>
   );
 }

--- a/src/components/__tests__/LayerSwitcher.test.tsx
+++ b/src/components/__tests__/LayerSwitcher.test.tsx
@@ -1,15 +1,21 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 
+import { useTileHealth } from '../../store/tile-health';
 import LayerSwitcher, {
   type BaseMapId,
   type OverlayId,
 } from '../LayerSwitcher';
+import { DOWN_AFTER_CONSECUTIVE_ERRORS } from '../tile-health-tracker';
 
 const DEFAULT_OVERLAYS: ReadonlySet<OverlayId> = new Set<OverlayId>([
   'openseamap',
 ]);
+
+beforeEach(() => {
+  useTileHealth.setState({ health: {} });
+});
 
 describe('<LayerSwitcher />', () => {
   it('renders the toggle button', () => {
@@ -185,5 +191,72 @@ describe('<LayerSwitcher />', () => {
     expect(
       screen.queryByRole('group', { name: 'Map layers' })
     ).not.toBeInTheDocument();
+  });
+
+  describe('health dots', () => {
+    const openPanel = (): void => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Toggle layer switcher' })
+      );
+    };
+
+    it('renders an unknown-status dot for every layer before any tile events', () => {
+      render(
+        <LayerSwitcher
+          activeBaseMap="osm"
+          activeOverlays={new Set<OverlayId>()}
+          onBaseMapChange={vi.fn()}
+          onOverlayToggle={vi.fn()}
+        />
+      );
+      openPanel();
+
+      for (const id of ['osm', 'usgs', 'opentopomap', 'aerial'] as const) {
+        const dot = screen.getByTestId(`health-dot-${id}`);
+        expect(dot).toHaveAttribute('data-status', 'unknown');
+      }
+    });
+
+    it('reflects per-layer health: ok for layers with successes, down for failing layers', () => {
+      // OSM: 5 errors → down. USGS: 1 success → ok.
+      Array.from({ length: DOWN_AFTER_CONSECUTIVE_ERRORS }).forEach(() =>
+        useTileHealth.getState().recordError('osm')
+      );
+      useTileHealth.getState().recordSuccess('usgs');
+
+      render(
+        <LayerSwitcher
+          activeBaseMap="osm"
+          activeOverlays={new Set<OverlayId>()}
+          onBaseMapChange={vi.fn()}
+          onOverlayToggle={vi.fn()}
+        />
+      );
+      openPanel();
+
+      expect(screen.getByTestId('health-dot-osm')).toHaveAttribute(
+        'data-status',
+        'down'
+      );
+      expect(screen.getByTestId('health-dot-usgs')).toHaveAttribute(
+        'data-status',
+        'ok'
+      );
+    });
+
+    it('renders health dots for overlays as well as basemaps', () => {
+      render(
+        <LayerSwitcher
+          activeBaseMap="osm"
+          activeOverlays={new Set<OverlayId>()}
+          onBaseMapChange={vi.fn()}
+          onOverlayToggle={vi.fn()}
+        />
+      );
+      openPanel();
+
+      expect(screen.getByTestId('health-dot-openseamap')).toBeInTheDocument();
+      expect(screen.getByTestId('health-dot-hiking')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/TileHealthBanner.test.tsx
+++ b/src/components/__tests__/TileHealthBanner.test.tsx
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import type { LayerKey } from '../../store/tile-health';
 import { useTileHealth } from '../../store/tile-health';
@@ -23,10 +23,18 @@ const repeatRecord = (
   Array.from({ length: count }).forEach(() => action(layer));
 };
 
+const NOOP = (): void => {
+  /* unused in tests that don't exercise the switch button */
+};
+
 describe('<TileHealthBanner />', () => {
   it('renders nothing when no tile events have been recorded for the layer', () => {
     render(
-      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+      <TileHealthBanner
+        activeLayer="osm"
+        activeLayerLabel="Street Map"
+        onSwitchTo={NOOP}
+      />
     );
     expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
   });
@@ -34,7 +42,11 @@ describe('<TileHealthBanner />', () => {
   it('renders nothing while the active layer is healthy', () => {
     useTileHealth.getState().recordSuccess('osm');
     render(
-      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+      <TileHealthBanner
+        activeLayer="osm"
+        activeLayerLabel="Street Map"
+        onSwitchTo={NOOP}
+      />
     );
     expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
   });
@@ -42,7 +54,11 @@ describe('<TileHealthBanner />', () => {
   it('shows the "down" banner when the active layer crosses the threshold', () => {
     repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
     render(
-      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+      <TileHealthBanner
+        activeLayer="osm"
+        activeLayerLabel="Street Map"
+        onSwitchTo={NOOP}
+      />
     );
 
     const banner = screen.getByTestId('tile-health-banner');
@@ -58,6 +74,7 @@ describe('<TileHealthBanner />', () => {
       <TileHealthBanner
         activeLayer="aerial"
         activeLayerLabel="Aerial Imagery"
+        onSwitchTo={NOOP}
       />
     );
 
@@ -72,24 +89,107 @@ describe('<TileHealthBanner />', () => {
     useTileHealth.getState().recordSuccess('usgs');
 
     render(
-      <TileHealthBanner activeLayer="usgs" activeLayerLabel="USGS Topo" />
+      <TileHealthBanner
+        activeLayer="usgs"
+        activeLayerLabel="USGS Topo"
+        onSwitchTo={NOOP}
+      />
     );
     expect(screen.queryByTestId('tile-health-banner')).not.toBeInTheDocument();
   });
 
   it('shows the degraded banner copy when status is "degraded"', () => {
-    // 4 errors + 6 successes = 40% errors, above the 30% degraded
-    // threshold but consecutiveErrors=4 stays under the 5-error
-    // "down" threshold; 10 events ≥ MIN_EVENTS_FOR_DEGRADED.
     repeatRecord('osm', 'success', 6);
     repeatRecord('osm', 'error', 4);
 
     render(
-      <TileHealthBanner activeLayer="osm" activeLayerLabel="Street Map" />
+      <TileHealthBanner
+        activeLayer="osm"
+        activeLayerLabel="Street Map"
+        onSwitchTo={NOOP}
+      />
     );
 
     const banner = screen.getByTestId('tile-health-banner');
     expect(banner).toHaveAttribute('data-status', 'degraded');
     expect(banner).toHaveTextContent(/Slow connection/);
+  });
+
+  describe('switch-to-fallback button', () => {
+    it('renders a switch button when down and a healthy alternative exists', () => {
+      // Active layer (OSM) is down; USGS has at least one successful
+      // load so it qualifies as the fallback.
+      repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+      useTileHealth.getState().recordSuccess('usgs');
+
+      render(
+        <TileHealthBanner
+          activeLayer="osm"
+          activeLayerLabel="Street Map"
+          onSwitchTo={NOOP}
+        />
+      );
+
+      const button = screen.getByTestId('tile-health-fallback-button');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent(/Switch to USGS Topo/);
+    });
+
+    it('calls onSwitchTo with the suggested layer id when clicked', () => {
+      repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+      useTileHealth.getState().recordSuccess('usgs');
+      const onSwitchTo = vi.fn();
+
+      render(
+        <TileHealthBanner
+          activeLayer="osm"
+          activeLayerLabel="Street Map"
+          onSwitchTo={onSwitchTo}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('tile-health-fallback-button'));
+      expect(onSwitchTo).toHaveBeenCalledWith('usgs');
+    });
+
+    it('does not render the switch button when status is only degraded', () => {
+      // Degraded layers are still usable; a forced switch would be
+      // more disruptive than helpful.
+      repeatRecord('osm', 'success', 6);
+      repeatRecord('osm', 'error', 4);
+
+      render(
+        <TileHealthBanner
+          activeLayer="osm"
+          activeLayerLabel="Street Map"
+          onSwitchTo={NOOP}
+        />
+      );
+
+      expect(
+        screen.queryByTestId('tile-health-fallback-button')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render the switch button when every other basemap is also down', () => {
+      // No healthy fallback exists — suggestFallback returns null.
+      repeatRecord('osm', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+      repeatRecord('usgs', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+      repeatRecord('opentopomap', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+      repeatRecord('aerial', 'error', DOWN_AFTER_CONSECUTIVE_ERRORS);
+
+      render(
+        <TileHealthBanner
+          activeLayer="osm"
+          activeLayerLabel="Street Map"
+          onSwitchTo={NOOP}
+        />
+      );
+
+      expect(screen.getByTestId('tile-health-banner')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('tile-health-fallback-button')
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/tile-health-tracker.test.ts
+++ b/src/components/__tests__/tile-health-tracker.test.ts
@@ -5,10 +5,12 @@ import {
   DEGRADED_ERROR_RATIO,
   DOWN_AFTER_CONSECUTIVE_ERRORS,
   DOWN_NO_SUCCESS_FOR_MS,
+  DOWN_PERSIST_MS,
   EMPTY_HEALTH,
   type LayerHealth,
   MIN_EVENTS_FOR_DEGRADED,
   recordEvent,
+  suggestFallback,
   WINDOW_SIZE,
 } from '../tile-health-tracker';
 
@@ -33,6 +35,7 @@ describe('recordEvent', () => {
     expect(EMPTY_HEALTH.events).toHaveLength(0);
     expect(EMPTY_HEALTH.consecutiveErrors).toBe(0);
     expect(EMPTY_HEALTH.lastSuccessAt).toBeNull();
+    expect(EMPTY_HEALTH.downSince).toBeNull();
   });
 
   it('appends a success event and updates lastSuccessAt', () => {
@@ -41,6 +44,7 @@ describe('recordEvent', () => {
     expect(next.events[0]).toEqual({ kind: 'success', at: T0 });
     expect(next.lastSuccessAt).toBe(T0);
     expect(next.consecutiveErrors).toBe(0);
+    expect(next.downSince).toBeNull();
   });
 
   it('increments consecutiveErrors on errors, resets on success', () => {
@@ -76,6 +80,39 @@ describe('recordEvent', () => {
     const beforeSnapshot = JSON.stringify(before);
     recordEvent(before, 'error', T0 + 100);
     expect(JSON.stringify(before)).toBe(beforeSnapshot);
+  });
+
+  it('latches downSince when consecutiveErrors crosses the threshold', () => {
+    const allErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    expect(allErrors.downSince).toBe(T0);
+  });
+
+  it('refreshes downSince on each error past the threshold', () => {
+    const allErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    const moreErrors = recordEvent(allErrors, 'error', T0 + 500);
+    expect(moreErrors.downSince).toBe(T0 + 500);
+  });
+
+  it('leaves downSince untouched on success below threshold', () => {
+    const allErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    const oneSuccess = recordEvent(allErrors, 'success', T0 + 500);
+    expect(oneSuccess.consecutiveErrors).toBe(0);
+    expect(oneSuccess.downSince).toBe(T0);
   });
 });
 
@@ -127,9 +164,10 @@ describe('classify', () => {
     expect(classify(allErrors, T0)).toBe('down');
   });
 
-  it('does not report down if a success arrived within the recovery window', () => {
-    // 5 errors but a success was just recorded — recovery resets the
-    // consecutiveErrors counter to 0, so it cannot be 'down'.
+  it('stays down for the persistence window even when a single success arrives', () => {
+    // Tier 2 anti-flapping: 5 errors latch downSince; a single
+    // success resets consecutiveErrors but the sticky timestamp
+    // keeps classify reporting 'down' through the 5-min window.
     const allErrors = feedEvents(
       EMPTY_HEALTH,
       'error',
@@ -137,7 +175,22 @@ describe('classify', () => {
       T0
     );
     const recovered = recordEvent(allErrors, 'success', T0 + 100);
-    expect(classify(recovered, T0 + 200)).not.toBe('down');
+    expect(recovered.consecutiveErrors).toBe(0);
+    expect(classify(recovered, T0 + 200)).toBe('down');
+  });
+
+  it('exits the sticky down state once the persistence window elapses', () => {
+    // After DOWN_PERSIST_MS passes since the last down trigger
+    // *and* no new errors have hit the threshold, classify drops
+    // back to its fresh evaluation (ok / degraded as appropriate).
+    const allErrors = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    const recovered = feedEvents(allErrors, 'success', WINDOW_SIZE, T0 + 100);
+    expect(classify(recovered, T0 + DOWN_PERSIST_MS + 1)).toBe('ok');
   });
 
   it('does not report down if consecutive errors are below the threshold', () => {
@@ -167,7 +220,7 @@ describe('classify', () => {
     expect(classify(sustainedErrors, T0 + 100)).toBe('down');
   });
 
-  it('recovers to ok once the rolling window fills with successes', () => {
+  it('recovers to ok once the rolling window fills with successes and the sticky window expires', () => {
     const downState = feedEvents(
       EMPTY_HEALTH,
       'error',
@@ -177,6 +230,76 @@ describe('classify', () => {
     expect(classify(downState, T0)).toBe('down');
 
     const recovered = feedEvents(downState, 'success', WINDOW_SIZE, T0);
-    expect(classify(recovered, T0 + 1)).toBe('ok');
+    // Inside the persistence window — still down.
+    expect(classify(recovered, T0 + 1)).toBe('down');
+    // After the persistence window — fresh classification kicks in.
+    expect(classify(recovered, T0 + DOWN_PERSIST_MS + 1)).toBe('ok');
+  });
+});
+
+describe('suggestFallback', () => {
+  const ALL: readonly string[] = ['osm', 'usgs', 'opentopomap', 'aerial'];
+
+  it('returns null when there are no other candidates', () => {
+    expect(suggestFallback('osm', {}, ['osm'], T0)).toBeNull();
+  });
+
+  it('skips the currently active layer', () => {
+    const healths = {
+      osm: feedEvents(EMPTY_HEALTH, 'success', 1, T0),
+      usgs: feedEvents(EMPTY_HEALTH, 'success', 1, T0),
+    };
+    expect(suggestFallback('osm', healths, ['osm', 'usgs'], T0)).toBe('usgs');
+  });
+
+  it('returns null when every other candidate is down', () => {
+    const downHealth = feedEvents(
+      EMPTY_HEALTH,
+      'error',
+      DOWN_AFTER_CONSECUTIVE_ERRORS,
+      T0
+    );
+    const healths = {
+      osm: downHealth,
+      usgs: downHealth,
+      opentopomap: downHealth,
+      aerial: downHealth,
+    };
+    expect(suggestFallback('osm', healths, ALL, T0 + 1)).toBeNull();
+  });
+
+  it('prefers an ok layer over an unknown one', () => {
+    const healths = {
+      usgs: feedEvents(EMPTY_HEALTH, 'success', 1, T0),
+      // 'opentopomap' has no entry → unknown
+    };
+    expect(suggestFallback('osm', healths, ALL, T0)).toBe('usgs');
+  });
+
+  it('prefers unknown over degraded', () => {
+    const degraded = feedEvents(
+      feedEvents(EMPTY_HEALTH, 'success', 6, T0),
+      'error',
+      4,
+      T0 + 6
+    );
+    const healths = { usgs: degraded };
+    // opentopomap and aerial have no entry → unknown, preferred
+    expect(suggestFallback('osm', healths, ALL, T0 + 100)).not.toBe('usgs');
+  });
+
+  it('skips the active layer even if it is the healthiest', () => {
+    const ok = feedEvents(EMPTY_HEALTH, 'success', 5, T0);
+    const degraded = feedEvents(
+      feedEvents(EMPTY_HEALTH, 'success', 6, T0),
+      'error',
+      4,
+      T0 + 6
+    );
+    const healths = { osm: ok, usgs: degraded };
+    // OSM is the healthiest but it's the one we're switching away from
+    expect(suggestFallback('osm', healths, ['osm', 'usgs'], T0 + 100)).toBe(
+      'usgs'
+    );
   });
 });

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -266,6 +266,7 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
       <TileHealthBanner
         activeLayer={activeBaseMap}
         activeLayerLabel={activeLayerLabel}
+        onSwitchTo={setActiveBaseMap}
       />
       <LayerSwitcher
         activeBaseMap={activeBaseMap}

--- a/src/components/tile-health-tracker.ts
+++ b/src/components/tile-health-tracker.ts
@@ -14,6 +14,12 @@ export interface LayerHealth {
   readonly events: readonly TileLoadEvent[];
   readonly consecutiveErrors: number;
   readonly lastSuccessAt: number | null;
+  // Wall-clock timestamp of the most recent "down" trigger. Once
+  // set, classify keeps reporting 'down' for DOWN_PERSIST_MS even
+  // if a few sporadic successes arrive — this suppresses banner
+  // flapping during a flaky outage. Cleared implicitly when the
+  // persistence window elapses (classify just stops honouring it).
+  readonly downSince: number | null;
 }
 
 export const EMPTY_HEALTH: LayerHealth = Object.freeze({
@@ -23,6 +29,7 @@ export const EMPTY_HEALTH: LayerHealth = Object.freeze({
   events: Object.freeze([] as TileLoadEvent[]),
   consecutiveErrors: 0,
   lastSuccessAt: null,
+  downSince: null,
 });
 
 // Rolling window — 20 events covers ~5–10 panned tile batches at
@@ -42,22 +49,45 @@ export const DOWN_NO_SUCCESS_FOR_MS = 10_000;
 export const DEGRADED_ERROR_RATIO = 0.3;
 export const MIN_EVENTS_FOR_DEGRADED = 5;
 
+// Once a layer is classified 'down', stay 'down' for at least this
+// long even if intermittent successes arrive. Stops the banner from
+// flapping during a flaky outage. Tuned to 5 minutes — long enough
+// for users to notice and switch basemap, short enough that a true
+// recovery surfaces quickly.
+export const DOWN_PERSIST_MS = 5 * 60_000;
+
 export function recordEvent(
   state: LayerHealth,
   kind: 'success' | 'error',
   now: number
 ): LayerHealth {
   const events = [...state.events, { kind, at: now }].slice(-WINDOW_SIZE);
-  return {
-    events,
-    consecutiveErrors: kind === 'error' ? state.consecutiveErrors + 1 : 0,
-    lastSuccessAt: kind === 'success' ? now : state.lastSuccessAt,
-  };
+  const consecutiveErrors = kind === 'error' ? state.consecutiveErrors + 1 : 0;
+  const lastSuccessAt = kind === 'success' ? now : state.lastSuccessAt;
+
+  // Latch / refresh the sticky-down timestamp whenever we're sitting
+  // at or above the consecutive-error threshold. Overwriting `now`
+  // every time errors come in extends the persistence window for
+  // sustained outages but leaves it untouched (and eventually
+  // expiring) once errors stop.
+  const downSince =
+    consecutiveErrors >= DOWN_AFTER_CONSECUTIVE_ERRORS ? now : state.downSince;
+
+  return { events, consecutiveErrors, lastSuccessAt, downSince };
 }
 
 export function classify(state: LayerHealth, now: number): HealthStatus {
   if (state.events.length === 0) return 'unknown';
 
+  // Sticky down: keep reporting 'down' for the persistence window
+  // after the most recent down trigger, even if a few successes
+  // have arrived since.
+  if (state.downSince !== null && now - state.downSince < DOWN_PERSIST_MS) {
+    return 'down';
+  }
+
+  // Fresh down check — catches the case where the persistence
+  // window has elapsed but the layer is still actively failing.
   const noRecentSuccess =
     state.lastSuccessAt === null ||
     now - state.lastSuccessAt > DOWN_NO_SUCCESS_FOR_MS;
@@ -77,4 +107,37 @@ export function classify(state: LayerHealth, now: number): HealthStatus {
   }
 
   return 'ok';
+}
+
+// Pick the best alternative basemap to suggest when the active
+// layer is down. Returns null if every other candidate is also
+// down. Prefers 'ok' over 'unknown' over 'degraded'; never
+// suggests a layer that's currently 'down' itself.
+const FALLBACK_PREFERENCE: Record<HealthStatus, number> = {
+  ok: 0,
+  unknown: 1,
+  degraded: 2,
+  down: 3,
+};
+
+export function suggestFallback(
+  active: string,
+  healths: Readonly<Partial<Record<string, LayerHealth>>>,
+  candidates: readonly string[],
+  now: number
+): string | null {
+  const ranked = candidates
+    .filter((id) => id !== active)
+    .map((id) => {
+      const entry = healths[id];
+      const status: HealthStatus =
+        entry === undefined ? 'unknown' : classify(entry, now);
+      return { id, status };
+    })
+    .filter((c) => c.status !== 'down')
+    .sort(
+      (a, b) => FALLBACK_PREFERENCE[a.status] - FALLBACK_PREFERENCE[b.status]
+    );
+
+  return ranked[0]?.id ?? null;
 }

--- a/src/components/tile-health-tracker.ts
+++ b/src/components/tile-health-tracker.ts
@@ -120,12 +120,12 @@ const FALLBACK_PREFERENCE: Record<HealthStatus, number> = {
   down: 3,
 };
 
-export function suggestFallback(
-  active: string,
-  healths: Readonly<Partial<Record<string, LayerHealth>>>,
-  candidates: readonly string[],
+export function suggestFallback<TId extends string>(
+  active: TId,
+  healths: Readonly<Partial<Record<TId, LayerHealth>>>,
+  candidates: readonly TId[],
   now: number
-): string | null {
+): TId | null {
   const ranked = candidates
     .filter((id) => id !== active)
     .map((id) => {


### PR DESCRIPTION
Tier 2 of the resilience roadmap from #64, **stacked on top of [#65](https://github.com/ivanoats/ndwt-ol-chakra/pull/65)** (Tier 1). Will rebase onto `main` once #65 merges.

## What changes for users

| | Before | This PR |
|---|---|---|
| LayerSwitcher dropdown | flat list of layer names | each layer has a 🟢🟡🔴⚪ health dot reflecting current tile health |
| Banner when basemap goes down | "try a different basemap" — user has to figure out which | _Switch to **USGS Topo**?_ — one-click button, label resolves to the best healthy alternative |
| Flaky outage | banner can flicker on/off as tiles intermittently succeed | banner stays for 5 min from the most recent down trigger |

## Components

- **`tile-health-tracker.ts`** — extended `LayerHealth` with `downSince: number | null`, added `DOWN_PERSIST_MS = 5 min` constant. `recordEvent` latches `downSince` whenever `consecutiveErrors >= threshold`; `classify` honours `downSince` before falling back to fresh evaluation. New pure `suggestFallback(active, healths, candidates, now)` picks the best alternative basemap (prefers `ok` over `unknown` over `degraded`, skips `down`).

- **`TileHealthBanner.tsx`** — new `onSwitchTo: (id: BaseMapId) => void` prop. When status is `down` and `suggestFallback` returns a candidate, renders a `Switch to <Label>` button next to the message. Doesn't render the button for `degraded` (those layers are still usable).

- **`LayerSwitcher.tsx`** — subscribes to the tile-health store, renders a small colored dot at the end of each layer button. Reuses the same 2-second tick the banner uses so time-based statuses age out without needing new events. Both basemaps and overlays get dots.

- **`map.tsx`** — passes `setActiveBaseMap` to the banner as `onSwitchTo`. No new state container needed.

## Threading + design choices

- Active basemap state stays in `map.tsx` (no lifting to MapApp or new Zustand slice). Banner doesn't own activeBaseMap, just receives the setter as a callback — keeps the component contract simple.
- Switch button only shows for `down`, not `degraded`. Reasoning in the PR description on #64: degraded layers are still usable; a forced swap would be more disruptive than helpful.
- `downSince` ticks on every error past the threshold (extending the window for sustained outages) and is never explicitly cleared — `classify` just stops honouring it once the window has elapsed. Avoids needing extra state for the "currently in a flapping outage" condition.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — **156** unit tests pass (Tier 2 adds 6 tracker + 4 banner + 3 switcher = 13 new cases; 2 existing tracker tests updated to reflect the new sticky semantics)
- [x] `npm run build` — clean static export
- [x] `npx playwright test --workers=1` — **55** e2e pass (Tier 2 adds 2: one-click fallback flow + dot turns red when active basemap is down; 1 existing selector tightened to disambiguate the new switch button from the LayerSwitcher's USGS Topo button)
- [x] Manual: in dev, block requests to `tile.openstreetmap.org`, watch the banner appear, click *Switch to USGS Topo*, banner clears and USGS becomes active. Open the LayerSwitcher dropdown — OSM dot is red, USGS dot is green.
- [ ] Bot triage (DeepSource, SonarCloud, Gemini, Copilot)

## What's still queued for Tier 3 (in #64)

Service worker tile caching for offline use. Architectural, separate effort.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)