### PR TITLE
feat(map): tier 3a tile-cache service worker for offline use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,16 @@ section in `docs/plans/modernization.md`.
   `--workers=1` (CI does this by default).
 - **Netlify build env defaults to a stale Node** — `netlify.toml`
   pins `NODE_VERSION = "24"`. Don't drop the file.
+- **Tile-cache service worker (`public/sw.js`)** intercepts requests
+  to known basemap / overlay hosts cache-first. Scope is the whole
+  origin (SW served at `/sw.js`) but it ONLY touches the hostnames
+  in `TILE_HOSTS` — app assets pass through untouched. Bump the
+  `CACHE_NAME` version suffix on any change to the SW's caching
+  shape; the `activate` handler purges old `ndwt-tiles-*` caches
+  automatically. Registration is gated on `NODE_ENV === 'production'`
+  in `src/lib/register-service-worker.ts`, so `next dev` is
+  unaffected. For local offline testing use `npm run build && npm
+  run preview` (SW works on localhost over HTTP).
 - **Sonar's CI Action and Sonar's automatic analysis collide**.
   Automatic analysis must be off in the SonarCloud project
   settings (Administration → Analysis Method) for the Action's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ section in `docs/plans/modernization.md`.
   automatically. Registration is gated on `NODE_ENV === 'production'`
   in `src/lib/register-service-worker.ts`, so `next dev` is
   unaffected. For local offline testing use `npm run build && npm
-  run preview` (SW works on localhost over HTTP).
+run preview` (SW works on localhost over HTTP).
 - **Sonar's CI Action and Sonar's automatic analysis collide**.
   Automatic analysis must be off in the SonarCloud project
   settings (Administration → Analysis Method) for the Action's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,9 @@ section in `docs/plans/modernization.md`.
   shape; the `activate` handler purges old `ndwt-tiles-*` caches
   automatically. Registration is gated on `NODE_ENV === 'production'`
   in `src/lib/register-service-worker.ts`, so `next dev` is
-  unaffected. For local offline testing use `npm run build && npm
-run preview` (SW works on localhost over HTTP).
+  unaffected. For local offline testing run
+  `npm run build && npm run preview` (SW works on localhost over
+  HTTP).
 - **Sonar's CI Action and Sonar's automatic analysis collide**.
   Automatic analysis must be off in the SonarCloud project
   settings (Administration → Analysis Method) for the Action's

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -1,6 +1,16 @@
 import { expect, type Page, test } from '@playwright/test';
 
 test.describe('Northwest Discovery Water Trail map', () => {
+  // Block the tile-cache service worker for this entire describe
+  // block. Several tests below use `page.route()` to mock specific
+  // tile-host responses (503, etc.) — but `page.route()` doesn't
+  // intercept fetches initiated *inside* a service worker, so once
+  // the SW is registered it would shadow the page-level mock and
+  // hand OL real cached / network responses. The offline.spec.ts
+  // suite is the one that actually exercises the SW; here we just
+  // want the pre-SW network behaviour.
+  test.use({ serviceWorkers: 'block' });
+
   test('renders the OpenLayers canvas at non-zero size', async ({ page }) => {
     await page.goto('/');
 

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test';
+
+// Matches every basemap / overlay tile host the SW knows about.
+// Used to selectively block tile traffic at the Playwright layer
+// without taking the localhost preview server offline — the
+// realistic scenario is "online enough to load the app, tile hosts
+// unreachable", which `context.setOffline(true)` can't model
+// because it kills localhost too.
+const TILE_HOST_REGEX =
+  /(?:tile\.openstreetmap\.org|basemap\.nationalmap\.gov|\b[abc]\.tile\.opentopomap\.org|tiles\.openseamap\.org|tile\.waymarkedtrails\.org)\//;
+
+test.describe('Tile cache service worker', () => {
+  test('caches basemap tiles and serves them after tile hosts are blocked', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Wait for the SW to be active and controlling the page. The
+    // registration runs from MapApp's first mount; `navigator.
+    // serviceWorker.ready` resolves once the SW is in the active
+    // state. Our activate handler calls `clients.claim()`, so the
+    // current page becomes controlled without needing a reload.
+    await page.evaluate(() => navigator.serviceWorker.ready);
+
+    // OL is dynamic-imported with ssr:false, so wait for the map to
+    // mount before we count tile cache entries.
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Give OL a moment to request the initial viewport's tiles and
+    // for the SW to write them into the cache. Tile load order is
+    // non-deterministic; poll until at least one tile is cached
+    // rather than relying on a fixed sleep.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () => {
+            const names = await caches.keys();
+            let total = 0;
+            for (const name of names.filter((n) =>
+              n.startsWith('ndwt-tiles-')
+            )) {
+              const cache = await caches.open(name);
+              const keys = await cache.keys();
+              total += keys.length;
+            }
+            return total;
+          }),
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(0);
+
+    // Block every tile host AT THE NETWORK LAYER (below the SW).
+    // The page itself still loads from localhost; only the tile
+    // CDNs are unreachable, which is the realistic "weak signal in
+    // a canyon" scenario the SW exists to handle.
+    await page.route(TILE_HOST_REGEX, (route) =>
+      route.abort('internetdisconnected')
+    );
+
+    await page.reload();
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Canvas still renders at a real size.
+    const canvas = page.locator('#map').locator('canvas').first();
+    await expect(canvas).toBeVisible();
+    const box = await canvas.boundingBox();
+    if (box === null) throw new Error('OL canvas should have a bounding box');
+    expect(box.width).toBeGreaterThan(0);
+    expect(box.height).toBeGreaterThan(0);
+
+    // And we never crossed into the "basemap unavailable" banner —
+    // the cached tiles satisfied OL's tileload events.
+    await expect(page.getByTestId('tile-health-banner')).toBeHidden();
+  });
+
+  test('SW intercepts cross-origin tile requests but lets app assets through', async ({
+    page,
+  }) => {
+    // Verify the SW's scope: tile hosts are intercepted (cached on
+    // success), but app-bundle / GeoJSON / static-asset requests
+    // pass through to the browser's default handling. We assert
+    // this via the cache contents — after a page load, the tile
+    // cache contains entries with hostnames matching the
+    // TILE_HOSTS list and nothing else (e.g. no localhost entries).
+    await page.goto('/');
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async () => {
+            const names = await caches.keys();
+            const hosts = new Set<string>();
+            for (const name of names.filter((n) =>
+              n.startsWith('ndwt-tiles-')
+            )) {
+              const cache = await caches.open(name);
+              for (const req of await cache.keys()) {
+                hosts.add(new URL(req.url).hostname);
+              }
+            }
+            return Array.from(hosts).sort();
+          }),
+        { timeout: 15_000 }
+      )
+      .not.toEqual([]);
+
+    // Cached hostnames are exclusively the known tile hosts. (We
+    // can't enumerate the exact list because OL only fetches the
+    // active basemap's tiles, not every host; but every cached
+    // entry MUST be a known tile host.)
+    const allowedHosts = new Set([
+      'tile.openstreetmap.org',
+      'basemap.nationalmap.gov',
+      'a.tile.opentopomap.org',
+      'b.tile.opentopomap.org',
+      'c.tile.opentopomap.org',
+      'tiles.openseamap.org',
+      'tile.waymarkedtrails.org',
+    ]);
+    // `expect.poll` returns void; re-query the value for the assert.
+    const finalHosts = await page.evaluate(async () => {
+      const names = await caches.keys();
+      const hosts = new Set<string>();
+      for (const name of names.filter((n) => n.startsWith('ndwt-tiles-'))) {
+        const cache = await caches.open(name);
+        for (const req of await cache.keys()) {
+          hosts.add(new URL(req.url).hostname);
+        }
+      }
+      return Array.from(hosts);
+    });
+    for (const host of finalHosts) {
+      expect(allowedHosts.has(host)).toBe(true);
+    }
+  });
+});

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -1,13 +1,29 @@
 import { expect, test } from '@playwright/test';
 
+// Single source of truth for the host list the SW intercepts. Keep
+// in sync with TILE_HOSTS in public/sw.js — if drift happens the
+// scope-correctness test below will fail loudly. The regex and the
+// allowed-host check used in the scope test are both derived from
+// this list so we only have one place to update.
+const TILE_HOSTS = [
+  'tile.openstreetmap.org',
+  'basemap.nationalmap.gov',
+  'a.tile.opentopomap.org',
+  'b.tile.opentopomap.org',
+  'c.tile.opentopomap.org',
+  'tiles.openseamap.org',
+  'tile.waymarkedtrails.org',
+] as const;
+
 // Matches every basemap / overlay tile host the SW knows about.
 // Used to selectively block tile traffic at the Playwright layer
 // without taking the localhost preview server offline — the
 // realistic scenario is "online enough to load the app, tile hosts
 // unreachable", which `context.setOffline(true)` can't model
 // because it kills localhost too.
-const TILE_HOST_REGEX =
-  /(?:tile\.openstreetmap\.org|basemap\.nationalmap\.gov|\b[abc]\.tile\.opentopomap\.org|tiles\.openseamap\.org|tile\.waymarkedtrails\.org)\//;
+const TILE_HOST_REGEX = new RegExp(
+  `(?:${TILE_HOSTS.map((h) => h.replace(/\./g, '\\.')).join('|')})/`
+);
 
 test.describe('Tile cache service worker', () => {
   test('caches basemap tiles and serves them after tile hosts are blocked', async ({
@@ -125,15 +141,7 @@ test.describe('Tile cache service worker', () => {
     // can't enumerate the exact list because OL only fetches the
     // active basemap's tiles, not every host; but every cached
     // entry MUST be a known tile host.)
-    const allowedHosts = new Set([
-      'tile.openstreetmap.org',
-      'basemap.nationalmap.gov',
-      'a.tile.opentopomap.org',
-      'b.tile.opentopomap.org',
-      'c.tile.opentopomap.org',
-      'tiles.openseamap.org',
-      'tile.waymarkedtrails.org',
-    ]);
+    const allowedHosts = new Set<string>(TILE_HOSTS);
     // `expect.poll` returns void; re-query the value for the assert.
     const finalHosts = await page.evaluate(async () => {
       const names = await caches.keys();

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -37,7 +37,7 @@ test.describe('Tile cache service worker', () => {
     // rather than relying on a fixed sleep.
     await expect
       .poll(
-        async () =>
+        () =>
           page.evaluate(async () => {
             const names = await caches.keys();
             let total = 0;
@@ -103,7 +103,7 @@ test.describe('Tile cache service worker', () => {
 
     await expect
       .poll(
-        async () =>
+        () =>
           page.evaluate(async () => {
             const names = await caches.keys();
             const hosts = new Set<string>();

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,8 +36,12 @@ const TILE_HOSTS = [
 ];
 
 function isTileRequest(url) {
-  // URL constructor handles both absolute URLs and relative ones.
-  // We only intercept absolute cross-origin tile hosts.
+  // The URL constructor here only handles absolute URLs — we don't
+  // pass a base. That's fine because every request that reaches the
+  // SW's `fetch` event has an absolute `request.url`, and we only
+  // care about cross-origin tile hosts. A relative URL would throw
+  // and fall through to `false`, which is the right answer (don't
+  // intercept).
   try {
     const parsed = new URL(url);
     return TILE_HOSTS.includes(parsed.hostname);
@@ -91,9 +95,14 @@ self.addEventListener('fetch', (event) => {
 
       try {
         const response = await fetch(request);
-        // Only cache successful responses. 4xx / 5xx errors get
-        // returned to the page but not stored.
-        if (response.ok || response.type === 'opaque') {
+        // Only cache successful CORS responses. 4xx / 5xx errors get
+        // returned to the page but not stored. Opaque responses
+        // (no-cors fetches) are deliberately skipped — they expose
+        // status=0 so we can't tell success from upstream failure,
+        // and OL's tile sources set `crossOrigin: 'anonymous'`
+        // anyway, so genuine tile fetches always come back as CORS
+        // responses with a real status.
+        if (response.ok) {
           // `response.clone()` is required because a Response body
           // can only be consumed once and we need to both return it
           // and put it in the cache.
@@ -106,8 +115,11 @@ self.addEventListener('fetch', (event) => {
       } catch {
         // Network failure with no cached fallback — return a
         // synthetic 504 so OL fires its tileloaderror handler and
-        // the tile-health banner can show the user.
-        return new Response('Tile unavailable offline', {
+        // the tile-health banner can show the user. Empty body
+        // because the response stands in for image bytes;
+        // returning text would surface "corrupt image" warnings in
+        // the browser console when OL tries to decode it.
+        return new Response(null, {
           status: 504,
           statusText: 'Gateway Timeout',
         });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,117 @@
+// Service worker — caches basemap and overlay tiles cache-first so
+// the map keeps working offline (and so subsequent visits skip the
+// network round-trip for previously-loaded tiles). The big win is
+// for paddlers using NDWT in cell-dead reaches of the Columbia /
+// Snake: pre-load a planned route's tiles on WiFi at home, then run
+// the map without a signal on the river.
+//
+// Scope: ONLY cross-origin tile requests to the known basemap /
+// overlay hosts are intercepted. Everything else (Next assets, the
+// GeoJSON, app bundles) is left to the browser's default handling,
+// which Next + Netlify already cache-control correctly.
+//
+// Strategy: cache-first with network fallback. On a cache miss, the
+// SW fetches from the network, returns the response to the page,
+// and writes a clone into the cache. Subsequent requests for the
+// same tile are served from the cache without a network round-trip.
+//
+// No explicit eviction in this version — the browser will LRU-evict
+// caches under storage pressure. A future PR can add a hard size
+// cap + UI to manually clear (tracked in #64 Tier 3b).
+//
+// Version invalidation: bump CACHE_NAME's version suffix to force
+// a clean install. The `activate` handler deletes any cache whose
+// name doesn't match the current version.
+
+const CACHE_NAME = 'ndwt-tiles-v1';
+
+const TILE_HOSTS = [
+  'tile.openstreetmap.org',
+  'basemap.nationalmap.gov',
+  'a.tile.opentopomap.org',
+  'b.tile.opentopomap.org',
+  'c.tile.opentopomap.org',
+  'tiles.openseamap.org',
+  'tile.waymarkedtrails.org',
+];
+
+function isTileRequest(url) {
+  // URL constructor handles both absolute URLs and relative ones.
+  // We only intercept absolute cross-origin tile hosts.
+  try {
+    const parsed = new URL(url);
+    return TILE_HOSTS.includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+self.addEventListener('install', (event) => {
+  // Activate the new SW immediately on install instead of waiting
+  // for the old one to release control. Tile content doesn't change
+  // shape between SW versions, so there's no risk of the new SW
+  // serving incompatible cached data.
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      // Clean up old cache versions left over from previous SW
+      // installs. Anything that isn't CACHE_NAME gets dropped.
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith('ndwt-tiles-') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      );
+      // Take control of pages that loaded before this SW activated.
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  // Only intercept GETs to known tile hosts; everything else
+  // passes through to the browser's default handling.
+  if (request.method !== 'GET' || !isTileRequest(request.url)) {
+    return;
+  }
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(request);
+      if (cached) {
+        // Cache hit — serve immediately. (Future PR: refresh in the
+        // background via stale-while-revalidate.)
+        return cached;
+      }
+
+      try {
+        const response = await fetch(request);
+        // Only cache successful responses. 4xx / 5xx errors get
+        // returned to the page but not stored.
+        if (response.ok || response.type === 'opaque') {
+          // `response.clone()` is required because a Response body
+          // can only be consumed once and we need to both return it
+          // and put it in the cache.
+          cache.put(request, response.clone()).catch(() => {
+            // Cache.put can throw on quota-exceeded or other storage
+            // errors. Swallow so a full disk doesn't break the map.
+          });
+        }
+        return response;
+      } catch {
+        // Network failure with no cached fallback — return a
+        // synthetic 504 so OL fires its tileloaderror handler and
+        // the tile-health banner can show the user.
+        return new Response('Tile unavailable offline', {
+          status: 504,
+          statusText: 'Gateway Timeout',
+        });
+      }
+    })()
+  );
+});

--- a/src/components/MapApp.tsx
+++ b/src/components/MapApp.tsx
@@ -6,6 +6,7 @@ import { css } from 'styled-system/css';
 
 import { createComposition } from '../composition-root';
 import type { Site } from '../domain';
+import { registerServiceWorker } from '../lib/register-service-worker';
 import { useSelectedSite } from '../store/selected-site';
 
 import SiteInfoPanel from './panels/SiteInfoPanel';
@@ -67,6 +68,14 @@ const useSiteUrlSync = (sites: readonly Site[]) => {
 export default function MapApp({ sites }: MapAppProps) {
   const composition = useMemo(() => createComposition(sites), [sites]);
   useSiteUrlSync(sites);
+
+  // Register the tile-cache service worker once on first mount. Skip
+  // in dev (NODE_ENV check inside the helper), no-op without browser
+  // SW support. Production users get cache-first offline tiles after
+  // the first online visit.
+  useEffect(() => {
+    void registerServiceWorker();
+  }, []);
 
   return (
     // The root layout's <main> is a flex column; this container

--- a/src/components/MapApp.tsx
+++ b/src/components/MapApp.tsx
@@ -71,10 +71,11 @@ export default function MapApp({ sites }: MapAppProps) {
 
   // Register the tile-cache service worker once on first mount. Skip
   // in dev (NODE_ENV check inside the helper), no-op without browser
-  // SW support. Production users get cache-first offline tiles after
-  // the first online visit.
+  // SW support. The helper swallows its own failures so a rejected
+  // promise can't propagate here — no `.catch` needed at the call
+  // site.
   useEffect(() => {
-    void registerServiceWorker();
+    registerServiceWorker();
   }, []);
 
   return (

--- a/src/lib/__tests__/register-service-worker.test.ts
+++ b/src/lib/__tests__/register-service-worker.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { registerServiceWorker } from '../register-service-worker';
+
+// Save and restore the navigator.serviceWorker patch we apply per
+// test so order-of-execution doesn't matter. `vi.stubEnv` handles
+// NODE_ENV restoration automatically via `vi.unstubAllEnvs()`.
+let originalServiceWorker: ServiceWorkerContainer | undefined;
+
+beforeEach(() => {
+  originalServiceWorker = navigator.serviceWorker;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  if (originalServiceWorker === undefined) {
+    delete (navigator as { serviceWorker?: ServiceWorkerContainer })
+      .serviceWorker;
+  } else {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: originalServiceWorker,
+      configurable: true,
+    });
+  }
+});
+
+function mockServiceWorker(
+  register: (path: string) => Promise<ServiceWorkerRegistration>
+): void {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: { register },
+    configurable: true,
+  });
+}
+
+describe('registerServiceWorker', () => {
+  it('is a no-op in development', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const register = vi.fn();
+    mockServiceWorker(register);
+
+    await registerServiceWorker();
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when navigator.serviceWorker is absent (older browsers / SSR)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    delete (navigator as { serviceWorker?: ServiceWorkerContainer })
+      .serviceWorker;
+
+    // Should not throw despite no SW support.
+    await expect(registerServiceWorker()).resolves.toBeUndefined();
+  });
+
+  it('registers /sw.js in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const register = vi
+      .fn<(path: string) => Promise<ServiceWorkerRegistration>>()
+      .mockResolvedValue({} as ServiceWorkerRegistration);
+    mockServiceWorker(register);
+
+    await registerServiceWorker();
+    expect(register).toHaveBeenCalledExactlyOnceWith('/sw.js');
+  });
+
+  it('swallows registration failures so the page keeps loading', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const register = vi
+      .fn<(path: string) => Promise<ServiceWorkerRegistration>>()
+      .mockRejectedValue(new Error('insecure context'));
+    mockServiceWorker(register);
+
+    // The map works without the SW, just without offline caching —
+    // a registration failure must not bubble up.
+    await expect(registerServiceWorker()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/register-service-worker.ts
+++ b/src/lib/register-service-worker.ts
@@ -1,0 +1,30 @@
+// Service-worker registration entry point. Called once from MapApp
+// when the component first mounts in the browser. Hides the dance of
+// feature detection, dev-mode skip, and registration error handling
+// so the caller is a one-liner.
+
+const SW_PATH = '/sw.js';
+
+export async function registerServiceWorker(): Promise<void> {
+  // Bail in non-browser environments (SSR, tests without DOM).
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  // SWs only work on HTTPS and localhost. In dev mode (next dev),
+  // Next's HMR layer doesn't play well with SW caching of app
+  // assets either, so we skip registration entirely. The SW is
+  // scoped to tiles, not app assets, so this is conservative —
+  // re-enable for dev later if needed for testing.
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  try {
+    await navigator.serviceWorker.register(SW_PATH);
+  } catch {
+    // Registration failures shouldn't surface to users — the map
+    // still works without the SW, just without offline caching.
+    // (Future: route this to a structured telemetry endpoint.)
+  }
+}


### PR DESCRIPTION
Tier 3 (foundation) of the resilience roadmap from #64. Sits on top of Tier 1+2 — banner + dots + auto-suggest from #65 / #67 already shipped.

## The big win

Paddlers using NDWT in cell-dead reaches of the Columbia / Snake can now:
- Load a planned route's tiles online at home
- Open the map on the river with no signal
- Cached tiles serve transparently from the SW; the map keeps working

## How it works

`public/sw.js` is a vanilla service worker (no Workbox, no build step — just a static file served at the site root). On every fetch:

1. If it's not a known tile host (OSM, USGS Topo/Imagery, OpenTopoMap, OpenSeaMap, Waymarked Trails), the SW does nothing — request passes straight through to the browser's default handling. Next assets, the GeoJSON, etc. are untouched.
2. If it's a tile, try cache first. Hit → serve immediately.
3. Miss → `fetch()` from network. Success → cache for next time + return. Failure → return a synthetic 504 so OL's `tileloaderror` fires and the existing tile-health banner can surface the failure.

Cache name is versioned (`ndwt-tiles-v1`); the `activate` handler purges any older `ndwt-tiles-*` caches. Bump the version suffix on any change to caching shape.

## Files

| File | What |
|---|---|
| `public/sw.js` (new) | The service worker |
| `src/lib/register-service-worker.ts` (new) | Typed registration, gated on `NODE_ENV === 'production'` |
| `src/lib/__tests__/register-service-worker.test.ts` (new) | 4 unit tests covering dev-skip / no-support skip / register / swallow-failure |
| `src/components/MapApp.tsx` | Calls the registration helper once on mount |
| `e2e/offline.spec.ts` (new) | Two e2e tests: cached-tile fallback + scope-correctness |
| `e2e/map.spec.ts` | One-line `test.use({ serviceWorkers: 'block' })` so existing Tier 1/2 tests keep working — `page.route()` doesn't intercept SW fetches, so the SW would otherwise shadow tile mocks |
| `CLAUDE.md` | Added to "Useful gotchas": version bumping, dev-mode skip, local offline testing |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — **160** unit tests pass (4 new for register-service-worker)
- [x] `npm run build` — clean static export; `out/sw.js` present (4.4 KB)
- [x] `npx playwright test --workers=1` — **57** e2e pass (2 new for SW caching + scope; all 55 existing tier-1/2/aerial tests still green via the `serviceWorkers: 'block'` fixture)
- [x] Manual: `npm run build && npm run preview`, open localhost:4173, DevTools → Application → Service Workers shows `sw.js` active. Reload → tile requests show "(ServiceWorker)" source. Go offline → tiles still load from cache.
- [ ] Bot triage (DeepSource / SonarCloud / Copilot / Gemini)

## Out of scope (Tier 3b — separate PRs)

- **Cache size cap + manual clear UI.** Right now browsers handle LRU eviction under storage pressure. A follow-up should expose a "47 MB cached, clear?" control plus an explicit cap.
- **Pre-warm controls.** A "save this area for offline use" button that iterates tiles in the current viewport's bbox at the next few zooms. Needs new UI surface (settings drawer).
- **Offline status indicator.** A small UI cue when `navigator.onLine === false`.

These are tracked in #64 Tier 3. Worth landing this foundation first since it's the load-bearing piece.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)