### PR TITLE
feat(map): offline status indicator pill

### DIFF
--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -25,6 +25,37 @@ const TILE_HOST_REGEX = new RegExp(
   `(?:${TILE_HOSTS.map((h) => h.replace(/\./g, '\\.')).join('|')})/`
 );
 
+test.describe('Offline indicator', () => {
+  test('shows the offline pill when the browser goes offline and hides on reconnect', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+    // Wait for OL to mount so we know the map component (and the
+    // sibling OfflineIndicator) is in the DOM.
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const indicator = page.getByTestId('offline-indicator');
+    await expect(indicator).toBeHidden();
+
+    // Drop connectivity. Chrome fires the `offline` event on
+    // window, the indicator's listener flips state, the pill
+    // renders.
+    await context.setOffline(true);
+    await expect(indicator).toBeVisible({ timeout: 5_000 });
+    await expect(indicator).toContainText(/Offline/);
+
+    // Reconnect — pill hides again.
+    await context.setOffline(false);
+    await expect(indicator).toBeHidden({ timeout: 5_000 });
+  });
+});
+
 test.describe('Tile cache service worker', () => {
   test('caches basemap tiles and serves them after tile hosts are blocked', async ({
     page,

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { WifiOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { css } from 'styled-system/css';
+
+// Small persistent pill at the bottom-center of the map. Appears
+// whenever the browser reports it's offline; auto-hides on
+// reconnect. Pairs with the tile-cache service worker — combined,
+// the map keeps working from cached tiles and the user has clear
+// feedback that they're operating from cache.
+//
+// Position: bottom-center, away from the LayerSwitcher (top-left),
+// the tile-health banner (top-center), and OL's attribution
+// control (bottom-right). Uses the same `<output>` + implicit
+// role="status" / aria-live="polite" pattern as the health banner
+// — non-interruptive announcement on transition.
+
+const pillClass = css({
+  position: 'absolute',
+  bottom: '4',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  zIndex: 110,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2',
+  padding: '2',
+  paddingInline: '3',
+  borderRadius: 'full',
+  boxShadow: 'sm',
+  backgroundColor: 'bg.default',
+  color: 'fg.default',
+  borderWidth: '1px',
+  borderColor: 'colorPalette.7',
+  fontSize: 'sm',
+  fontWeight: 'medium',
+  colorPalette: 'amber',
+});
+
+const iconClass = css({
+  flexShrink: 0,
+  color: 'colorPalette.9',
+});
+
+export default function OfflineIndicator() {
+  // Lazy-init from `navigator.onLine` so a page that mounts while
+  // already offline shows the pill immediately. Default to `true`
+  // (online) for SSR / non-browser test environments where
+  // `navigator` is undefined or `onLine` is unreliable.
+  const [isOnline, setIsOnline] = useState<boolean>(() =>
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  );
+
+  useEffect(() => {
+    const update = (): void => setIsOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  if (isOnline) return null;
+
+  return (
+    <output data-testid="offline-indicator" className={pillClass}>
+      <WifiOff size={16} className={iconClass} aria-hidden="true" />
+      Offline — showing cached tiles
+    </output>
+  );
+}

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -58,16 +58,16 @@ export default function OfflineIndicator() {
     // guarantees that), but guarding against missing globals keeps
     // the component safe to instantiate from any future caller —
     // an isolated SSR snapshot, a node-side test that doesn't load
-    // jsdom, etc.
-    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
-      return undefined;
-    }
+    // jsdom, etc. `globalThis` is the modern preferred reference
+    // (Sonar typescript:S7764) and works identically to `window`
+    // in browsers.
+    if (typeof navigator === 'undefined') return undefined;
     const update = (): void => setIsOnline(navigator.onLine);
-    window.addEventListener('online', update);
-    window.addEventListener('offline', update);
+    globalThis.addEventListener('online', update);
+    globalThis.addEventListener('offline', update);
     return () => {
-      window.removeEventListener('online', update);
-      window.removeEventListener('offline', update);
+      globalThis.removeEventListener('online', update);
+      globalThis.removeEventListener('offline', update);
     };
   }, []);
 

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -53,6 +53,15 @@ export default function OfflineIndicator() {
   );
 
   useEffect(() => {
+    // Belt-and-suspenders. In practice this effect only runs after
+    // a successful client-side mount (React's useEffect contract
+    // guarantees that), but guarding against missing globals keeps
+    // the component safe to instantiate from any future caller —
+    // an isolated SSR snapshot, a node-side test that doesn't load
+    // jsdom, etc.
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return undefined;
+    }
     const update = (): void => setIsOnline(navigator.onLine);
     window.addEventListener('online', update);
     window.addEventListener('offline', update);

--- a/src/components/__tests__/OfflineIndicator.test.tsx
+++ b/src/components/__tests__/OfflineIndicator.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { act, render, screen } from '@testing-library/react';
+
+import OfflineIndicator from '../OfflineIndicator';
+
+// Save the original navigator.onLine descriptor so each test starts
+// from a known "online" baseline regardless of the host machine's
+// real connectivity.
+const originalOnLineDescriptor = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(navigator),
+  'onLine'
+);
+
+function setOnLine(value: boolean): void {
+  Object.defineProperty(navigator, 'onLine', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function fireConnectivityEvent(name: 'online' | 'offline'): void {
+  act(() => {
+    window.dispatchEvent(new Event(name));
+  });
+}
+
+beforeEach(() => {
+  setOnLine(true);
+});
+
+afterEach(() => {
+  // Restore the prototype descriptor so we don't leak the per-test
+  // mock into other suites that read navigator.onLine.
+  if (originalOnLineDescriptor !== undefined) {
+    Object.defineProperty(
+      Object.getPrototypeOf(navigator),
+      'onLine',
+      originalOnLineDescriptor
+    );
+  }
+  // Also strip any own-property override we set.
+  delete (navigator as { onLine?: boolean }).onLine;
+});
+
+describe('<OfflineIndicator />', () => {
+  it('renders nothing while the browser is online', () => {
+    setOnLine(true);
+    render(<OfflineIndicator />);
+    expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+  });
+
+  it('renders the offline pill when the browser starts offline', () => {
+    setOnLine(false);
+    render(<OfflineIndicator />);
+    const pill = screen.getByTestId('offline-indicator');
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveTextContent(/Offline/);
+    expect(pill).toHaveTextContent(/cached tiles/);
+  });
+
+  it('appears when the browser fires the offline event after mount', () => {
+    setOnLine(true);
+    render(<OfflineIndicator />);
+    expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+
+    setOnLine(false);
+    fireConnectivityEvent('offline');
+    expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+  });
+
+  it('disappears when the browser fires the online event after going back online', () => {
+    setOnLine(false);
+    render(<OfflineIndicator />);
+    expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+
+    setOnLine(true);
+    fireConnectivityEvent('online');
+    expect(screen.queryByTestId('offline-indicator')).not.toBeInTheDocument();
+  });
+
+  it('removes its event listeners on unmount', () => {
+    setOnLine(false);
+    const { unmount } = render(<OfflineIndicator />);
+    unmount();
+
+    // Fire an offline event after unmount — would throw if the
+    // component still had a listener attached and tried to setState
+    // on an unmounted component (React warns / Vitest catches).
+    expect(() => fireConnectivityEvent('offline')).not.toThrow();
+  });
+});

--- a/src/components/__tests__/OfflineIndicator.test.tsx
+++ b/src/components/__tests__/OfflineIndicator.test.tsx
@@ -22,7 +22,7 @@ function setOnLine(value: boolean): void {
 
 function fireConnectivityEvent(name: 'online' | 'offline'): void {
   act(() => {
-    window.dispatchEvent(new Event(name));
+    globalThis.dispatchEvent(new Event(name));
   });
 }
 
@@ -86,8 +86,8 @@ describe('<OfflineIndicator />', () => {
     // references it registered. Dispatching events post-unmount
     // doesn't throw in React 19, so a "did the listener still run"
     // assertion would silently pass even if cleanup were broken.
-    const addSpy = vi.spyOn(window, 'addEventListener');
-    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const addSpy = vi.spyOn(globalThis, 'addEventListener');
+    const removeSpy = vi.spyOn(globalThis, 'removeEventListener');
 
     const { unmount } = render(<OfflineIndicator />);
 

--- a/src/components/__tests__/OfflineIndicator.test.tsx
+++ b/src/components/__tests__/OfflineIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { act, render, screen } from '@testing-library/react';
 
@@ -81,13 +81,26 @@ describe('<OfflineIndicator />', () => {
   });
 
   it('removes its event listeners on unmount', () => {
-    setOnLine(false);
+    // Spy on add / removeEventListener so we can assert the
+    // component's cleanup actually unregisters the same handler
+    // references it registered. Dispatching events post-unmount
+    // doesn't throw in React 19, so a "did the listener still run"
+    // assertion would silently pass even if cleanup were broken.
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
     const { unmount } = render(<OfflineIndicator />);
+
+    const onlineCall = addSpy.mock.calls.find(([type]) => type === 'online');
+    const offlineCall = addSpy.mock.calls.find(([type]) => type === 'offline');
+    expect(onlineCall).toBeDefined();
+    expect(offlineCall).toBeDefined();
+    const onlineHandler = onlineCall?.[1];
+    const offlineHandler = offlineCall?.[1];
+
     unmount();
 
-    // Fire an offline event after unmount — would throw if the
-    // component still had a listener attached and tried to setState
-    // on an unmounted component (React warns / Vitest catches).
-    expect(() => fireConnectivityEvent('offline')).not.toThrow();
+    expect(removeSpy).toHaveBeenCalledWith('online', onlineHandler);
+    expect(removeSpy).toHaveBeenCalledWith('offline', offlineHandler);
   });
 });

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -24,6 +24,7 @@ import LayerSwitcher, {
   type OverlayId,
 } from './LayerSwitcher';
 import { makeHandleClick, makeHandlePointerMove } from './map-handlers';
+import OfflineIndicator from './OfflineIndicator';
 import TileHealthBanner from './TileHealthBanner';
 
 type GlobalWithMap = typeof globalThis & { __ndwtMap?: Map };
@@ -274,6 +275,7 @@ export default function MapComponent({ sites, getSite }: MapComponentProps) {
         onBaseMapChange={setActiveBaseMap}
         onOverlayToggle={handleOverlayToggle}
       />
+      <OfflineIndicator />
     </div>
   );
 }


### PR DESCRIPTION
Tier 3b deliverable #1 from #64. Stacks on top of #68 (now merged).

## What this PR adds

A small pill at the bottom-center of the map that appears when the browser reports it's offline. Pairs with the tile-cache service worker from #68 — combined, the user gets clear feedback that they're offline while the map keeps working from cached tiles.

> ⚪ **Offline — showing cached tiles**

Auto-hides on reconnect.

## Why this is small on purpose

This is the smallest of the three remaining Tier 3 items because it doesn't need any new UI surface (no settings drawer required). Just a `navigator.onLine` listener + a styled pill. The other two — cache size / clear controls and pre-warm — share a settings-drawer dependency and will land together in a follow-up.

## Implementation

- **`src/components/OfflineIndicator.tsx`** (new) — single file, ~70 LOC. Lazy-init from `navigator.onLine` so a page that mounts while already offline shows the pill immediately. `useEffect` adds + cleans up `online` / `offline` listeners. Renders nothing while online.
- **`src/components/map.tsx`** — adds `<OfflineIndicator />` as a sibling of the existing `<TileHealthBanner />` inside the `#map` container.
- Same `<output>` + implicit `role="status"` pattern as the tile-health banner for non-interruptive announcement on transition.

## Position

Bottom-center of the `#map` container — away from the LayerSwitcher (top-left), the tile-health banner (top-center), and OL's attribution control (bottom-right).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — **165** unit tests pass (5 new for OfflineIndicator: rendered / hidden, initial offline state, online and offline transitions, listener cleanup on unmount)
- [x] `npm run build` — clean static export
- [x] `npx playwright test --workers=1` — **58** e2e pass (1 new for offline-indicator: drives real connectivity changes via `context.setOffline()` and asserts the pill toggles)
- [x] Manual: dev server, DevTools → Network → Offline, pill appears; toggle Online, pill hides
- [ ] Bot triage

## What's still queued in #64 for Tier 3c

- Cache size cap + manual clear UI
- Pre-warm controls ("save this area for offline use")

Both share a settings-drawer dependency, so they'll ship together in a follow-up PR.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)