### PR TITLE
feat(map): tier 3c settings drawer with cache stats, clear, and pre-warm

### DIFF
--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -56,6 +56,105 @@ test.describe('Offline indicator', () => {
   });
 });
 
+test.describe('Map settings drawer', () => {
+  test('shows cache stats and clears the tile cache on demand', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Wait until the SW has cached at least one tile so the readout
+    // and the Clear button have something to operate on.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const names = await caches.keys();
+            let total = 0;
+            for (const name of names.filter((n) =>
+              n.startsWith('ndwt-tiles-')
+            )) {
+              const cache = await caches.open(name);
+              const keys = await cache.keys();
+              total += keys.length;
+            }
+            return total;
+          }),
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(0);
+
+    // Open the drawer.
+    await page.getByTestId('map-settings-button').click();
+    const drawer = page.getByTestId('map-settings-drawer');
+    await expect(drawer).toBeVisible();
+
+    // Tile count should be > 0 after the SW warmed it up.
+    const tileCount = page.getByTestId('cache-tile-count');
+    await expect(tileCount).not.toHaveText(/^0 tiles/);
+
+    // Clear the cache and verify the readout drops to zero.
+    await page.getByTestId('cache-clear').click();
+    await expect(page.getByTestId('cache-cleared-status')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(tileCount).toHaveText(/^0 tiles/);
+
+    // Cache Storage should now be empty of ndwt-tiles-* buckets.
+    const remaining = await page.evaluate(async () => {
+      const names = await caches.keys();
+      return names.filter((n) => n.startsWith('ndwt-tiles-')).length;
+    });
+    expect(remaining).toBe(0);
+  });
+
+  test('pre-warms the current viewport and bumps the tile count', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.evaluate(() => navigator.serviceWorker.ready);
+    await page.waitForFunction(
+      () =>
+        Boolean((globalThis as unknown as { __ndwtMap?: unknown }).__ndwtMap),
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    // Start from an empty cache so the assertion is unambiguous —
+    // any tile count after pre-warm is attributable to the action.
+    await page.evaluate(async () => {
+      const names = await caches.keys();
+      await Promise.all(
+        names
+          .filter((n) => n.startsWith('ndwt-tiles-'))
+          .map((n) => caches.delete(n))
+      );
+    });
+
+    await page.getByTestId('map-settings-button').click();
+    await expect(page.getByTestId('map-settings-drawer')).toBeVisible();
+
+    await page.getByTestId('cache-prewarm').click();
+
+    // The done-status appears once every queued tile has settled.
+    await expect(page.getByTestId('prewarm-done-status')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // And the tile count is no longer zero — the SW captured the
+    // prewarm fetches.
+    await expect(page.getByTestId('cache-tile-count')).not.toHaveText(
+      /^0 tiles/
+    );
+  });
+});
+
 test.describe('Tile cache service worker', () => {
   test('caches basemap tiles and serves them after tile hosts are blocked', async ({
     page,

--- a/src/components/MapApp.tsx
+++ b/src/components/MapApp.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { css } from 'styled-system/css';
 
 import { createComposition } from '../composition-root';
@@ -10,6 +10,8 @@ import { registerServiceWorker } from '../lib/register-service-worker';
 import { useSelectedSite } from '../store/selected-site';
 
 import SiteInfoPanel from './panels/SiteInfoPanel';
+import MapSettingsButton from './MapSettingsButton';
+import MapSettingsDrawer from './MapSettingsDrawer';
 import ThemeToggleButton from './ThemeToggleButton';
 
 // OpenLayers touches `window` at import time, so dynamic-import with
@@ -69,6 +71,11 @@ export default function MapApp({ sites }: MapAppProps) {
   const composition = useMemo(() => createComposition(sites), [sites]);
   useSiteUrlSync(sites);
 
+  // Settings-drawer open state. Lifted here so the gear button and
+  // the drawer are siblings of the map without prop-drilling through
+  // the dynamic-imported MapComponent.
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
   // Register the tile-cache service worker once on first mount. Skip
   // in dev (NODE_ENV check inside the helper), no-op without browser
   // SW support. The helper swallows its own failures so a rejected
@@ -93,6 +100,11 @@ export default function MapApp({ sites }: MapAppProps) {
       })}
     >
       <MapComponent sites={sites} getSite={composition.getSite} />
+      <MapSettingsButton onClick={() => setSettingsOpen(true)} />
+      <MapSettingsDrawer
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+      />
       <SiteInfoPanel />
       <ThemeToggleButton />
     </div>

--- a/src/components/MapSettingsButton.tsx
+++ b/src/components/MapSettingsButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Settings } from 'lucide-react';
+
+import { IconButton } from './ui/icon-button';
+
+// Gear icon — top-right corner of the map. Currently the only floating
+// control over there (LayerSwitcher is top-left, TileHealthBanner is
+// top-center, OfflineIndicator is bottom-center, OL attribution is
+// bottom-right inside the map). Clicking opens the cache + offline
+// settings drawer.
+
+interface MapSettingsButtonProps {
+  readonly onClick: () => void;
+}
+
+export default function MapSettingsButton({ onClick }: MapSettingsButtonProps) {
+  return (
+    <IconButton
+      data-testid="map-settings-button"
+      aria-label="Open map settings"
+      onClick={onClick}
+      icon={<Settings size={20} />}
+      css={{
+        position: 'absolute',
+        top: '4',
+        right: '4',
+        zIndex: 100,
+        backgroundColor: 'bg.default',
+      }}
+    />
+  );
+}

--- a/src/components/MapSettingsDrawer.tsx
+++ b/src/components/MapSettingsDrawer.tsx
@@ -86,6 +86,183 @@ const statusLineClass = css({
   marginTop: '1',
 });
 
+// Sub-components keep the JSX shallow so the deep-nesting linter
+// (DeepSource JS-0415) stays quiet at 4 levels max. Each section is
+// independently testable too.
+
+interface CacheSectionProps {
+  readonly stats: CacheStats;
+  readonly status: Status;
+  readonly onRefresh: () => void;
+  readonly onClear: () => void;
+}
+
+function CacheSection({
+  stats,
+  status,
+  onRefresh,
+  onClear,
+}: CacheSectionProps) {
+  const tilesLabel = `${stats.tileCount} tile${stats.tileCount === 1 ? '' : 's'}`;
+  return (
+    <section className={sectionClass} aria-labelledby="settings-cache-heading">
+      <h3 id="settings-cache-heading" className={sectionHeadingClass}>
+        Offline tile cache
+      </h3>
+      <p className={helpTextClass}>
+        Tiles you&apos;ve already viewed are stored in your browser so the map
+        keeps working when you lose signal.
+      </p>
+      <CacheReadout
+        tilesLabel={tilesLabel}
+        bytesLabel={`~${formatBytes(stats.byteEstimate)} of storage used`}
+      />
+      <CacheActions
+        onRefresh={onRefresh}
+        onClear={onClear}
+        clearDisabled={status.kind === 'clearing' || stats.tileCount === 0}
+      />
+      {status.kind === 'clearing' ? (
+        <p className={statusLineClass}>Clearing…</p>
+      ) : null}
+      {status.kind === 'cleared' ? (
+        <p className={statusLineClass} data-testid="cache-cleared-status">
+          Cleared.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+interface CacheReadoutProps {
+  readonly tilesLabel: string;
+  readonly bytesLabel: string;
+}
+
+function CacheReadout({ tilesLabel, bytesLabel }: CacheReadoutProps) {
+  return (
+    <div className={statRowClass}>
+      <span className={statValueClass} data-testid="cache-tile-count">
+        {tilesLabel}
+      </span>
+      <span className={helpTextClass} data-testid="cache-byte-estimate">
+        {bytesLabel}
+      </span>
+    </div>
+  );
+}
+
+interface CacheActionsProps {
+  readonly onRefresh: () => void;
+  readonly onClear: () => void;
+  readonly clearDisabled: boolean;
+}
+
+function CacheActions({
+  onRefresh,
+  onClear,
+  clearDisabled,
+}: CacheActionsProps) {
+  return (
+    <div className={actionsRowClass}>
+      <Button
+        data-testid="cache-refresh"
+        variant="outline"
+        size="sm"
+        onClick={onRefresh}
+      >
+        Refresh
+      </Button>
+      <Button
+        data-testid="cache-clear"
+        variant="outline"
+        size="sm"
+        colorScheme="gray"
+        onClick={onClear}
+        disabled={clearDisabled}
+      >
+        Clear cached tiles
+      </Button>
+    </div>
+  );
+}
+
+interface PrewarmSectionProps {
+  readonly status: Status;
+  readonly onPrewarm: () => void;
+}
+
+function PrewarmSection({ status, onPrewarm }: PrewarmSectionProps) {
+  return (
+    <section
+      className={sectionClass}
+      aria-labelledby="settings-prewarm-heading"
+    >
+      <h3 id="settings-prewarm-heading" className={sectionHeadingClass}>
+        Pre-load this view
+      </h3>
+      <p className={helpTextClass}>
+        Cache every tile in the current viewport for the basemap and overlays
+        you have on. Do this while you have WiFi so the map still works on the
+        river.
+      </p>
+      <PrewarmAction
+        onPrewarm={onPrewarm}
+        disabled={status.kind === 'prewarming'}
+      />
+      <PrewarmStatusLine status={status} />
+    </section>
+  );
+}
+
+interface PrewarmActionProps {
+  readonly onPrewarm: () => void;
+  readonly disabled: boolean;
+}
+
+function PrewarmAction({ onPrewarm, disabled }: PrewarmActionProps) {
+  return (
+    <div className={actionsRowClass}>
+      <Button
+        data-testid="cache-prewarm"
+        variant="solid"
+        size="sm"
+        onClick={onPrewarm}
+        disabled={disabled}
+      >
+        Save current view for offline use
+      </Button>
+    </div>
+  );
+}
+
+function PrewarmStatusLine({ status }: { readonly status: Status }) {
+  if (status.kind === 'prewarming') {
+    const failNote =
+      status.progress.failed > 0 ? ` (${status.progress.failed} failed)` : '';
+    return (
+      <p className={statusLineClass} data-testid="prewarm-progress">
+        Caching {status.progress.fetched} / {status.progress.total} tiles
+        {failNote}…
+      </p>
+    );
+  }
+  if (status.kind === 'prewarm-done') {
+    const { total, failed } = status.progress;
+    const tileWord = total === 1 ? 'tile' : 'tiles';
+    const message =
+      failed === 0
+        ? `Saved ${total} ${tileWord}.`
+        : `Saved ${total - failed} of ${total} ${tileWord} (${failed} failed).`;
+    return (
+      <p className={statusLineClass} data-testid="prewarm-done-status">
+        {message}
+      </p>
+    );
+  }
+  return null;
+}
+
 export default function MapSettingsDrawer({
   open,
   onClose,
@@ -103,7 +280,7 @@ export default function MapSettingsDrawer({
   // tiles loaded from the visible map).
   useEffect(() => {
     if (!open) return;
-    void refreshStats();
+    refreshStats();
   }, [open, refreshStats]);
 
   const handleClear = useCallback(async () => {
@@ -152,105 +329,22 @@ export default function MapSettingsDrawer({
         </h2>
       </DrawerHeader>
       <DrawerBody>
-        <section
-          className={sectionClass}
-          aria-labelledby="settings-cache-heading"
-        >
-          <h3 id="settings-cache-heading" className={sectionHeadingClass}>
-            Offline tile cache
-          </h3>
-          <p className={helpTextClass}>
-            Tiles you&apos;ve already viewed are stored in your browser so the
-            map keeps working when you lose signal.
-          </p>
-          <div className={statRowClass}>
-            <span className={statValueClass} data-testid="cache-tile-count">
-              {stats.tileCount} tile{stats.tileCount === 1 ? '' : 's'}
-            </span>
-            <span className={helpTextClass} data-testid="cache-byte-estimate">
-              ~{formatBytes(stats.byteEstimate)} of storage used
-            </span>
-          </div>
-          <div className={actionsRowClass}>
-            <Button
-              data-testid="cache-refresh"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                void refreshStats();
-              }}
-            >
-              Refresh
-            </Button>
-            <Button
-              data-testid="cache-clear"
-              variant="outline"
-              size="sm"
-              colorScheme="gray"
-              onClick={() => {
-                void handleClear();
-              }}
-              disabled={status.kind === 'clearing' || stats.tileCount === 0}
-            >
-              Clear cached tiles
-            </Button>
-          </div>
-          {status.kind === 'clearing' ? (
-            <p className={statusLineClass}>Clearing…</p>
-          ) : null}
-          {status.kind === 'cleared' ? (
-            <p className={statusLineClass} data-testid="cache-cleared-status">
-              Cleared.
-            </p>
-          ) : null}
-        </section>
-
-        <section
-          className={sectionClass}
-          aria-labelledby="settings-prewarm-heading"
-        >
-          <h3 id="settings-prewarm-heading" className={sectionHeadingClass}>
-            Pre-load this view
-          </h3>
-          <p className={helpTextClass}>
-            Cache every tile in the current viewport for the basemap and
-            overlays you have on. Do this while you have WiFi so the map still
-            works on the river.
-          </p>
-          <div className={actionsRowClass}>
-            <Button
-              data-testid="cache-prewarm"
-              variant="solid"
-              size="sm"
-              onClick={() => {
-                void handlePrewarm();
-              }}
-              disabled={status.kind === 'prewarming'}
-            >
-              Save current view for offline use
-            </Button>
-          </div>
-          {status.kind === 'prewarming' ? (
-            <p className={statusLineClass} data-testid="prewarm-progress">
-              Caching {status.progress.fetched} / {status.progress.total} tiles
-              {status.progress.failed > 0
-                ? ` (${status.progress.failed} failed)`
-                : ''}
-              …
-            </p>
-          ) : null}
-          {status.kind === 'prewarm-done' ? (
-            <p className={statusLineClass} data-testid="prewarm-done-status">
-              {status.progress.failed === 0
-                ? `Saved ${status.progress.total} tile${
-                    status.progress.total === 1 ? '' : 's'
-                  }.`
-                : `Saved ${status.progress.total - status.progress.failed} of ${
-                    status.progress.total
-                  } tiles (${status.progress.failed} failed).`}
-            </p>
-          ) : null}
-        </section>
+        <CacheSection
+          stats={stats}
+          status={status}
+          onRefresh={() => {
+            refreshStats();
+          }}
+          onClear={() => {
+            handleClear();
+          }}
+        />
+        <PrewarmSection
+          status={status}
+          onPrewarm={() => {
+            handlePrewarm();
+          }}
+        />
       </DrawerBody>
     </Drawer>
   );

--- a/src/components/MapSettingsDrawer.tsx
+++ b/src/components/MapSettingsDrawer.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import type { Map as OlMap } from 'ol';
+import { useCallback, useEffect, useState } from 'react';
+import { css } from 'styled-system/css';
+
+import {
+  type CacheStats,
+  clearTileCaches,
+  formatBytes,
+  getCacheStats,
+  type PrewarmProgress,
+  prewarmTiles,
+  tileUrlsForMap,
+} from '../lib/tile-cache';
+
+import { Button } from './ui/button';
+import { Drawer, DrawerBody, DrawerHeader } from './ui/drawer';
+
+// "Save current view" + "Clear cached tiles" sit behind the gear icon
+// from MapSettingsButton. Reads the OL map handle off `globalThis`
+// (the same one map.tsx exposes for Playwright) — keeps this drawer
+// fully decoupled from the dynamic-imported map module.
+
+type GlobalWithMap = typeof globalThis & { __ndwtMap?: OlMap };
+
+interface MapSettingsDrawerProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+type Status =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'prewarming'; readonly progress: PrewarmProgress }
+  | { readonly kind: 'prewarm-done'; readonly progress: PrewarmProgress }
+  | { readonly kind: 'clearing' }
+  | { readonly kind: 'cleared' };
+
+const initialStats: CacheStats = { tileCount: 0, byteEstimate: 0 };
+
+const sectionClass = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3',
+  paddingY: '4',
+  borderBottomWidth: '1px',
+  borderColor: 'gray.6',
+  _last: { borderBottomWidth: '0' },
+});
+
+const sectionHeadingClass = css({
+  fontSize: 'sm',
+  fontWeight: 'semibold',
+  color: 'fg.default',
+  textTransform: 'uppercase',
+  letterSpacing: 'wide',
+});
+
+const helpTextClass = css({
+  fontSize: 'sm',
+  color: 'fg.muted',
+  lineHeight: 'snug',
+});
+
+const statRowClass = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1',
+});
+
+const statValueClass = css({
+  fontSize: 'lg',
+  fontWeight: 'medium',
+  color: 'fg.default',
+});
+
+const actionsRowClass = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '2',
+});
+
+const statusLineClass = css({
+  fontSize: 'sm',
+  color: 'fg.muted',
+  marginTop: '1',
+});
+
+export default function MapSettingsDrawer({
+  open,
+  onClose,
+}: MapSettingsDrawerProps) {
+  const [stats, setStats] = useState<CacheStats>(initialStats);
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  const refreshStats = useCallback(async () => {
+    const next = await getCacheStats();
+    setStats(next);
+  }, []);
+
+  // Refresh the stats whenever the drawer opens so the readout
+  // matches reality (the cache may have grown since last open via
+  // tiles loaded from the visible map).
+  useEffect(() => {
+    if (!open) return;
+    void refreshStats();
+  }, [open, refreshStats]);
+
+  const handleClear = useCallback(async () => {
+    setStatus({ kind: 'clearing' });
+    await clearTileCaches();
+    await refreshStats();
+    setStatus({ kind: 'cleared' });
+  }, [refreshStats]);
+
+  const handlePrewarm = useCallback(async () => {
+    const map = (globalThis as GlobalWithMap).__ndwtMap;
+    if (map === undefined) {
+      // No map handle means the map hasn't mounted yet. Bail
+      // silently — the gear button won't render until MapApp is
+      // mounted, but a race is theoretically possible.
+      return;
+    }
+    const urls = tileUrlsForMap(map);
+    setStatus({
+      kind: 'prewarming',
+      progress: { total: urls.length, fetched: 0, failed: 0 },
+    });
+    const result = await prewarmTiles(urls, {
+      onProgress: (progress) => setStatus({ kind: 'prewarming', progress }),
+    });
+    setStatus({ kind: 'prewarm-done', progress: result });
+    await refreshStats();
+  }, [refreshStats]);
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      placement="right"
+      testId="map-settings-drawer"
+    >
+      <DrawerHeader>
+        <h2
+          className={css({
+            fontSize: 'lg',
+            fontWeight: 'semibold',
+            color: 'fg.default',
+          })}
+        >
+          Map settings
+        </h2>
+      </DrawerHeader>
+      <DrawerBody>
+        <section
+          className={sectionClass}
+          aria-labelledby="settings-cache-heading"
+        >
+          <h3 id="settings-cache-heading" className={sectionHeadingClass}>
+            Offline tile cache
+          </h3>
+          <p className={helpTextClass}>
+            Tiles you&apos;ve already viewed are stored in your browser so the
+            map keeps working when you lose signal.
+          </p>
+          <div className={statRowClass}>
+            <span className={statValueClass} data-testid="cache-tile-count">
+              {stats.tileCount} tile{stats.tileCount === 1 ? '' : 's'}
+            </span>
+            <span className={helpTextClass} data-testid="cache-byte-estimate">
+              ~{formatBytes(stats.byteEstimate)} of storage used
+            </span>
+          </div>
+          <div className={actionsRowClass}>
+            <Button
+              data-testid="cache-refresh"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void refreshStats();
+              }}
+            >
+              Refresh
+            </Button>
+            <Button
+              data-testid="cache-clear"
+              variant="outline"
+              size="sm"
+              colorScheme="gray"
+              onClick={() => {
+                void handleClear();
+              }}
+              disabled={status.kind === 'clearing' || stats.tileCount === 0}
+            >
+              Clear cached tiles
+            </Button>
+          </div>
+          {status.kind === 'clearing' ? (
+            <p className={statusLineClass}>Clearing…</p>
+          ) : null}
+          {status.kind === 'cleared' ? (
+            <p className={statusLineClass} data-testid="cache-cleared-status">
+              Cleared.
+            </p>
+          ) : null}
+        </section>
+
+        <section
+          className={sectionClass}
+          aria-labelledby="settings-prewarm-heading"
+        >
+          <h3 id="settings-prewarm-heading" className={sectionHeadingClass}>
+            Pre-load this view
+          </h3>
+          <p className={helpTextClass}>
+            Cache every tile in the current viewport for the basemap and
+            overlays you have on. Do this while you have WiFi so the map still
+            works on the river.
+          </p>
+          <div className={actionsRowClass}>
+            <Button
+              data-testid="cache-prewarm"
+              variant="solid"
+              size="sm"
+              onClick={() => {
+                void handlePrewarm();
+              }}
+              disabled={status.kind === 'prewarming'}
+            >
+              Save current view for offline use
+            </Button>
+          </div>
+          {status.kind === 'prewarming' ? (
+            <p className={statusLineClass} data-testid="prewarm-progress">
+              Caching {status.progress.fetched} / {status.progress.total} tiles
+              {status.progress.failed > 0
+                ? ` (${status.progress.failed} failed)`
+                : ''}
+              …
+            </p>
+          ) : null}
+          {status.kind === 'prewarm-done' ? (
+            <p className={statusLineClass} data-testid="prewarm-done-status">
+              {status.progress.failed === 0
+                ? `Saved ${status.progress.total} tile${
+                    status.progress.total === 1 ? '' : 's'
+                  }.`
+                : `Saved ${status.progress.total - status.progress.failed} of ${
+                    status.progress.total
+                  } tiles (${status.progress.failed} failed).`}
+            </p>
+          ) : null}
+        </section>
+      </DrawerBody>
+    </Drawer>
+  );
+}

--- a/src/components/__tests__/MapSettingsButton.test.tsx
+++ b/src/components/__tests__/MapSettingsButton.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import MapSettingsButton from '../MapSettingsButton';
+
+describe('<MapSettingsButton />', () => {
+  it('renders an accessible gear button and fires onClick', () => {
+    const onClick = vi.fn();
+
+    render(<MapSettingsButton onClick={onClick} />);
+
+    const button = screen.getByTestId('map-settings-button');
+    expect(button).toHaveAttribute('aria-label', 'Open map settings');
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/MapSettingsDrawer.test.tsx
+++ b/src/components/__tests__/MapSettingsDrawer.test.tsx
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+
+import MapSettingsDrawer from '../MapSettingsDrawer';
+
+// Mock the tile-cache module — these tests cover the drawer's wiring,
+// not the cache helpers themselves (those have their own suite).
+const getCacheStats = vi.fn();
+const clearTileCaches = vi.fn();
+const prewarmTiles = vi.fn();
+const tileUrlsForMap = vi.fn();
+
+vi.mock('../../lib/tile-cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/tile-cache')>();
+  return {
+    ...actual,
+    getCacheStats: (...args: unknown[]) =>
+      getCacheStats(...args) as ReturnType<typeof actual.getCacheStats>,
+    clearTileCaches: (...args: unknown[]) =>
+      clearTileCaches(...args) as ReturnType<typeof actual.clearTileCaches>,
+    prewarmTiles: (...args: unknown[]) =>
+      prewarmTiles(...args) as ReturnType<typeof actual.prewarmTiles>,
+    tileUrlsForMap: (...args: unknown[]) =>
+      tileUrlsForMap(...args) as ReturnType<typeof actual.tileUrlsForMap>,
+  };
+});
+
+beforeEach(() => {
+  getCacheStats.mockReset().mockResolvedValue({
+    tileCount: 12,
+    byteEstimate: 4_500_000,
+  });
+  clearTileCaches.mockReset().mockResolvedValue(1);
+  prewarmTiles
+    .mockReset()
+    .mockResolvedValue({ total: 3, fetched: 3, failed: 0, ok: true });
+  tileUrlsForMap.mockReset().mockReturnValue(['a', 'b', 'c']);
+});
+
+afterEach(() => {
+  delete (globalThis as { __ndwtMap?: unknown }).__ndwtMap;
+});
+
+describe('<MapSettingsDrawer />', () => {
+  it('loads cache stats when opened and renders the tile count + size', async () => {
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+
+    expect(getCacheStats).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByTestId('cache-tile-count')).toHaveTextContent(
+        '12 tiles'
+      );
+    });
+    expect(screen.getByTestId('cache-byte-estimate')).toHaveTextContent(
+      /4\.3 MB of storage used/
+    );
+  });
+
+  it('does not load stats while the drawer is closed', () => {
+    render(<MapSettingsDrawer open={false} onClose={() => {}} />);
+    expect(getCacheStats).not.toHaveBeenCalled();
+  });
+
+  it('refreshes stats when the user clicks Refresh', async () => {
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
+
+    // Bump the mocked value so we can confirm the readout updates.
+    getCacheStats.mockResolvedValueOnce({
+      tileCount: 99,
+      byteEstimate: 9 * 1024 * 1024,
+    });
+    fireEvent.click(screen.getByTestId('cache-refresh'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cache-tile-count')).toHaveTextContent(
+        '99 tiles'
+      );
+    });
+  });
+
+  it('clears caches when the user clicks Clear cached tiles', async () => {
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
+
+    // After clearing, the next stats read should reflect an empty cache.
+    getCacheStats.mockResolvedValueOnce({ tileCount: 0, byteEstimate: 0 });
+    fireEvent.click(screen.getByTestId('cache-clear'));
+
+    await waitFor(() => expect(clearTileCaches).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(screen.getByTestId('cache-cleared-status')).toHaveTextContent(
+        /Cleared/
+      );
+    });
+  });
+
+  it('disables Clear when the cache is already empty', async () => {
+    getCacheStats.mockResolvedValueOnce({ tileCount: 0, byteEstimate: 0 });
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('cache-tile-count')).toHaveTextContent(
+        '0 tiles'
+      );
+    });
+    expect(screen.getByTestId('cache-clear')).toBeDisabled();
+  });
+
+  it('pre-warms the current viewport when Save current view is clicked', async () => {
+    (globalThis as { __ndwtMap?: object }).__ndwtMap = {
+      // Sentinel — tileUrlsForMap is mocked, so the contents don't matter.
+    };
+
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('cache-prewarm'));
+
+    await waitFor(() => expect(prewarmTiles).toHaveBeenCalledTimes(1));
+    expect(tileUrlsForMap).toHaveBeenCalledTimes(1);
+    expect(prewarmTiles.mock.calls[0]?.[0]).toEqual(['a', 'b', 'c']);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prewarm-done-status')).toHaveTextContent(
+        /Saved 3 tiles/
+      );
+    });
+  });
+
+  it('reports failures inline when some tiles fail to pre-warm', async () => {
+    (globalThis as { __ndwtMap?: object }).__ndwtMap = {};
+    prewarmTiles.mockResolvedValueOnce({
+      total: 5,
+      fetched: 5,
+      failed: 2,
+      ok: false,
+    });
+
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('cache-prewarm'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prewarm-done-status')).toHaveTextContent(
+        /Saved 3 of 5 tiles \(2 failed\)/
+      );
+    });
+  });
+
+  it('skips pre-warm silently when no map handle is exposed', async () => {
+    delete (globalThis as { __ndwtMap?: unknown }).__ndwtMap;
+    render(<MapSettingsDrawer open onClose={() => {}} />);
+    await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('cache-prewarm'));
+    });
+
+    expect(tileUrlsForMap).not.toHaveBeenCalled();
+    expect(prewarmTiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/MapSettingsDrawer.test.tsx
+++ b/src/components/__tests__/MapSettingsDrawer.test.tsx
@@ -10,6 +10,10 @@ import {
 
 import MapSettingsDrawer from '../MapSettingsDrawer';
 
+// Shared no-op for tests that don't care about close events.
+// Extracted so we don't repeat `() => {}` (DeepSource JS-0321).
+const noop = (): void => undefined;
+
 // Mock the tile-cache module — these tests cover the drawer's wiring,
 // not the cache helpers themselves (those have their own suite).
 const getCacheStats = vi.fn();
@@ -50,7 +54,7 @@ afterEach(() => {
 
 describe('<MapSettingsDrawer />', () => {
   it('loads cache stats when opened and renders the tile count + size', async () => {
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
 
     expect(getCacheStats).toHaveBeenCalledTimes(1);
     await waitFor(() => {
@@ -64,12 +68,12 @@ describe('<MapSettingsDrawer />', () => {
   });
 
   it('does not load stats while the drawer is closed', () => {
-    render(<MapSettingsDrawer open={false} onClose={() => {}} />);
+    render(<MapSettingsDrawer open={false} onClose={noop} />);
     expect(getCacheStats).not.toHaveBeenCalled();
   });
 
   it('refreshes stats when the user clicks Refresh', async () => {
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
 
     // Bump the mocked value so we can confirm the readout updates.
@@ -87,7 +91,7 @@ describe('<MapSettingsDrawer />', () => {
   });
 
   it('clears caches when the user clicks Clear cached tiles', async () => {
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
 
     // After clearing, the next stats read should reflect an empty cache.
@@ -104,7 +108,7 @@ describe('<MapSettingsDrawer />', () => {
 
   it('disables Clear when the cache is already empty', async () => {
     getCacheStats.mockResolvedValueOnce({ tileCount: 0, byteEstimate: 0 });
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => {
       expect(screen.getByTestId('cache-tile-count')).toHaveTextContent(
         '0 tiles'
@@ -118,7 +122,7 @@ describe('<MapSettingsDrawer />', () => {
       // Sentinel — tileUrlsForMap is mocked, so the contents don't matter.
     };
 
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByTestId('cache-prewarm'));
@@ -143,7 +147,7 @@ describe('<MapSettingsDrawer />', () => {
       ok: false,
     });
 
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
     fireEvent.click(screen.getByTestId('cache-prewarm'));
 
@@ -156,10 +160,13 @@ describe('<MapSettingsDrawer />', () => {
 
   it('skips pre-warm silently when no map handle is exposed', async () => {
     delete (globalThis as { __ndwtMap?: unknown }).__ndwtMap;
-    render(<MapSettingsDrawer open onClose={() => {}} />);
+    render(<MapSettingsDrawer open onClose={noop} />);
     await waitFor(() => expect(getCacheStats).toHaveBeenCalledTimes(1));
 
-    await act(async () => {
+    // act() is synchronous here — fireEvent doesn't return a promise,
+    // and there's nothing to await inside. Wrapping prevents React
+    // from flushing the (no-op) state work outside an act() scope.
+    act(() => {
       fireEvent.click(screen.getByTestId('cache-prewarm'));
     });
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -30,6 +30,13 @@ interface DrawerProps {
   readonly onClose: () => void;
   readonly children: ReactNode;
   readonly placement?: 'right' | 'left';
+  /**
+   * Optional override for the panel's data-testid. Defaults to the
+   * historical 'site-info-panel' value so existing tests keep
+   * passing; supply a different id when mounting multiple drawers
+   * in the same tree to avoid `getByTestId` collisions.
+   */
+  readonly testId?: string;
 }
 
 export function Drawer({
@@ -37,6 +44,7 @@ export function Drawer({
   onClose,
   children,
   placement = 'right',
+  testId = 'site-info-panel',
 }: DrawerProps) {
   return (
     <Dialog.Root
@@ -63,7 +71,7 @@ export function Drawer({
           })}
         >
           <Dialog.Content
-            data-testid="site-info-panel"
+            data-testid={testId}
             className={css({
               ...content,
               ...(placement === 'right' ? rightPlacement : leftPlacement),

--- a/src/lib/__tests__/tile-cache.test.ts
+++ b/src/lib/__tests__/tile-cache.test.ts
@@ -226,7 +226,11 @@ describe('enumerateTileUrls', () => {
     grid = true,
   }: {
     readonly range: { minX: number; maxX: number; minY: number; maxY: number };
-    readonly template: (z: number, x: number, y: number) => string | undefined;
+    readonly template: (
+      tileZ: number,
+      tileX: number,
+      tileY: number
+    ) => string | undefined;
     readonly grid?: boolean;
   }): VisibleTileSource<unknown> {
     return {
@@ -238,19 +242,20 @@ describe('enumerateTileUrls', () => {
           : null,
       getTileUrlFunction:
         () =>
-        ([z, x, y]: [number, number, number]) =>
-          template(z, x, y),
+        ([tileZ, tileX, tileY]: [number, number, number]) =>
+          template(tileZ, tileX, tileY),
     };
   }
 
   it('expands every tile coord in the range into a URL', () => {
     const source = fakeSource({
       range: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
-      template: (z, x, y) => `https://example/${z}/${x}/${y}.png`,
+      template: (tileZ, tileX, tileY) =>
+        `https://example/${tileZ}/${tileX}/${tileY}.png`,
     });
     const urls = enumerateTileUrls([source], {
       extent: [0, 0, 1, 1],
-      z: 7,
+      tileZ: 7,
       projection: null,
     });
     expect([...urls].sort()).toEqual(
@@ -270,7 +275,11 @@ describe('enumerateTileUrls', () => {
       grid: false,
     });
     expect(
-      enumerateTileUrls([source], { extent: [0, 0, 1, 1], z: 5, projection: 0 })
+      enumerateTileUrls([source], {
+        extent: [0, 0, 1, 1],
+        tileZ: 5,
+        projection: 0,
+      })
     ).toEqual([]);
   });
 
@@ -280,11 +289,11 @@ describe('enumerateTileUrls', () => {
       // Returning undefined matches what OL's tileUrlFunction does
       // for coords outside a source's coverage area (eg. NOAA Charts
       // off-coast).
-      template: (_z, x) => (x === 0 ? 'a' : undefined),
+      template: (_tileZ, tileX) => (tileX === 0 ? 'a' : undefined),
     });
     const urls = enumerateTileUrls([source], {
       extent: [0, 0, 1, 1],
-      z: 3,
+      tileZ: 3,
       projection: null,
     });
     expect(urls).toEqual(['a']);
@@ -292,23 +301,29 @@ describe('enumerateTileUrls', () => {
 
   it('returns an empty array when given no sources', () => {
     expect(
-      enumerateTileUrls([], { extent: [0, 0, 1, 1], z: 1, projection: null })
+      enumerateTileUrls([], {
+        extent: [0, 0, 1, 1],
+        tileZ: 1,
+        projection: null,
+      })
     ).toEqual([]);
   });
 
   it('combines URLs from multiple sources (basemap + overlays)', () => {
     const base = fakeSource({
       range: { minX: 0, maxX: 0, minY: 0, maxY: 0 },
-      template: (z, x, y) => `https://base/${z}/${x}/${y}`,
+      template: (tileZ, tileX, tileY) =>
+        `https://base/${tileZ}/${tileX}/${tileY}`,
     });
     const overlay = fakeSource({
       range: { minX: 0, maxX: 0, minY: 0, maxY: 0 },
-      template: (z, x, y) => `https://overlay/${z}/${x}/${y}`,
+      template: (tileZ, tileX, tileY) =>
+        `https://overlay/${tileZ}/${tileX}/${tileY}`,
     });
     expect(
       enumerateTileUrls([base, overlay], {
         extent: [0, 0, 1, 1],
-        z: 4,
+        tileZ: 4,
         projection: null,
       })
     ).toEqual(['https://base/4/0/0', 'https://overlay/4/0/0']);

--- a/src/lib/__tests__/tile-cache.test.ts
+++ b/src/lib/__tests__/tile-cache.test.ts
@@ -1,0 +1,343 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from 'vitest';
+
+import {
+  clearTileCaches,
+  enumerateTileUrls,
+  formatBytes,
+  getCacheStats,
+  prewarmTiles,
+  TILE_CACHE_PREFIX,
+  type VisibleTileSource,
+} from '../tile-cache';
+
+// jsdom doesn't implement Cache Storage. We swap in a tiny mock that
+// mirrors the surface tile-cache.ts actually touches: `caches.keys`,
+// `caches.open`, `caches.delete`, plus a per-cache `keys` that
+// returns Request-ish objects.
+
+type CacheLike = { keys: () => Promise<readonly { url: string }[]> };
+
+type CachesMock = {
+  keys: () => Promise<readonly string[]>;
+  open: (name: string) => Promise<CacheLike>;
+  delete: (name: string) => Promise<boolean>;
+};
+
+function installCachesMock(buckets: Record<string, readonly string[]>): {
+  caches: CachesMock;
+  deleted: string[];
+} {
+  const deleted: string[] = [];
+  const mock: CachesMock = {
+    keys: () => Promise.resolve(Object.keys(buckets)),
+    open: (name) =>
+      Promise.resolve({
+        keys: () =>
+          Promise.resolve(
+            (buckets[name] ?? []).map((u) => ({ url: u }) as { url: string })
+          ),
+      }),
+    delete: (name) => {
+      deleted.push(name);
+      return Promise.resolve(true);
+    },
+  };
+  Object.defineProperty(globalThis, 'caches', {
+    value: mock,
+    configurable: true,
+    writable: true,
+  });
+  return { caches: mock, deleted };
+}
+
+function uninstallCachesMock(): void {
+  delete (globalThis as { caches?: unknown }).caches;
+}
+
+const originalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  navigator,
+  'storage'
+);
+
+function installStorageEstimate(usage: number | undefined): void {
+  Object.defineProperty(navigator, 'storage', {
+    value: { estimate: () => Promise.resolve({ usage }) },
+    configurable: true,
+  });
+}
+
+function restoreNavigatorStorage(): void {
+  if (originalStorageDescriptor === undefined) {
+    delete (navigator as { storage?: unknown }).storage;
+  } else {
+    Object.defineProperty(navigator, 'storage', originalStorageDescriptor);
+  }
+}
+
+afterEach(() => {
+  uninstallCachesMock();
+  restoreNavigatorStorage();
+});
+
+describe('formatBytes', () => {
+  it('renders 0 as 0 MB so an empty cache reads naturally', () => {
+    expect(formatBytes(0)).toBe('0 MB');
+  });
+
+  it('handles non-finite or negative input defensively', () => {
+    expect(formatBytes(Number.NaN)).toBe('0 MB');
+    expect(formatBytes(-1)).toBe('0 MB');
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('0 MB');
+  });
+
+  it('uses B / KB / MB / GB at the right thresholds', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2 * 1024)).toBe('2 KB');
+    expect(formatBytes(3.5 * 1024 * 1024)).toBe('3.5 MB');
+    expect(formatBytes(2.25 * 1024 * 1024 * 1024)).toBe('2.25 GB');
+  });
+});
+
+describe('getCacheStats', () => {
+  it('returns empty stats when the Cache Storage API is unavailable', async () => {
+    uninstallCachesMock();
+    const stats = await getCacheStats();
+    expect(stats).toEqual({ tileCount: 0, byteEstimate: 0 });
+  });
+
+  it('sums entries across ndwt-tiles-* caches and ignores other caches', async () => {
+    installCachesMock({
+      [`${TILE_CACHE_PREFIX}v1`]: ['https://a/tile/1', 'https://a/tile/2'],
+      [`${TILE_CACHE_PREFIX}v0`]: ['https://b/tile/3'],
+      // A foreign cache (e.g. another app's bucket) MUST NOT count.
+      'some-other-cache': ['https://x'],
+    });
+    installStorageEstimate(15 * 1024 * 1024);
+
+    const stats = await getCacheStats();
+    expect(stats.tileCount).toBe(3);
+    expect(stats.byteEstimate).toBe(15 * 1024 * 1024);
+  });
+
+  it('reports 0 bytes when navigator.storage is unavailable', async () => {
+    installCachesMock({ [`${TILE_CACHE_PREFIX}v1`]: ['https://a/1'] });
+    delete (navigator as { storage?: unknown }).storage;
+
+    const stats = await getCacheStats();
+    expect(stats.tileCount).toBe(1);
+    expect(stats.byteEstimate).toBe(0);
+  });
+
+  it('falls back to empty stats on a cache-API failure', async () => {
+    Object.defineProperty(globalThis, 'caches', {
+      value: {
+        keys: () => Promise.reject(new Error('boom')),
+      },
+      configurable: true,
+    });
+    const stats = await getCacheStats();
+    expect(stats).toEqual({ tileCount: 0, byteEstimate: 0 });
+  });
+});
+
+describe('clearTileCaches', () => {
+  it('is a no-op when the Cache Storage API is unavailable', async () => {
+    uninstallCachesMock();
+    await expect(clearTileCaches()).resolves.toBe(0);
+  });
+
+  it('deletes every ndwt-tiles-* bucket and leaves foreign caches alone', async () => {
+    const { deleted } = installCachesMock({
+      [`${TILE_CACHE_PREFIX}v1`]: [],
+      [`${TILE_CACHE_PREFIX}v0`]: [],
+      'unrelated-cache': [],
+    });
+    const cleared = await clearTileCaches();
+    expect(cleared).toBe(2);
+    expect(deleted.sort()).toEqual(
+      [`${TILE_CACHE_PREFIX}v0`, `${TILE_CACHE_PREFIX}v1`].sort()
+    );
+  });
+});
+
+describe('prewarmTiles', () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  it('returns 0/0 immediately when there are no URLs to fetch', async () => {
+    const result = await prewarmTiles([]);
+    expect(result).toEqual({ total: 0, fetched: 0, failed: 0, ok: true });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fires onProgress after every URL settles and resolves with totals', async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 200 }));
+    const progressCalls: { fetched: number; failed: number }[] = [];
+
+    const result = await prewarmTiles(
+      ['https://a/1', 'https://a/2', 'https://a/3'],
+      {
+        concurrency: 2,
+        onProgress: ({ fetched, failed }) =>
+          progressCalls.push({ fetched, failed }),
+      }
+    );
+
+    expect(result).toEqual({ total: 3, fetched: 3, failed: 0, ok: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    // Final progress matches the result.
+    expect(progressCalls.at(-1)).toEqual({ fetched: 3, failed: 0 });
+  });
+
+  it('counts non-2xx responses as failures but keeps going', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 504 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const result = await prewarmTiles(['a', 'b', 'c'], { concurrency: 1 });
+    expect(result).toEqual({ total: 3, fetched: 3, failed: 1, ok: false });
+  });
+
+  it('counts thrown fetches as failures', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+    const result = await prewarmTiles(['a', 'b'], { concurrency: 1 });
+    expect(result).toEqual({ total: 2, fetched: 2, failed: 2, ok: false });
+  });
+});
+
+describe('enumerateTileUrls', () => {
+  // Build a fake VisibleTileSource that returns a configurable tile
+  // range and a URL template. No OL classes involved.
+  function fakeSource({
+    range,
+    template,
+    grid = true,
+  }: {
+    readonly range: { minX: number; maxX: number; minY: number; maxY: number };
+    readonly template: (z: number, x: number, y: number) => string | undefined;
+    readonly grid?: boolean;
+  }): VisibleTileSource<unknown> {
+    return {
+      getTileGrid: () =>
+        grid
+          ? {
+              getTileRangeForExtentAndZ: () => range,
+            }
+          : null,
+      getTileUrlFunction:
+        () =>
+        ([z, x, y]: [number, number, number]) =>
+          template(z, x, y),
+    };
+  }
+
+  it('expands every tile coord in the range into a URL', () => {
+    const source = fakeSource({
+      range: { minX: 0, maxX: 1, minY: 0, maxY: 1 },
+      template: (z, x, y) => `https://example/${z}/${x}/${y}.png`,
+    });
+    const urls = enumerateTileUrls([source], {
+      extent: [0, 0, 1, 1],
+      z: 7,
+      projection: null,
+    });
+    expect([...urls].sort()).toEqual(
+      [
+        'https://example/7/0/0.png',
+        'https://example/7/0/1.png',
+        'https://example/7/1/0.png',
+        'https://example/7/1/1.png',
+      ].sort()
+    );
+  });
+
+  it('skips sources that have no tile grid yet', () => {
+    const source = fakeSource({
+      range: { minX: 0, maxX: 0, minY: 0, maxY: 0 },
+      template: () => 'should-not-appear',
+      grid: false,
+    });
+    expect(
+      enumerateTileUrls([source], { extent: [0, 0, 1, 1], z: 5, projection: 0 })
+    ).toEqual([]);
+  });
+
+  it('drops any tile coord whose URL function returns undefined', () => {
+    const source = fakeSource({
+      range: { minX: 0, maxX: 1, minY: 0, maxY: 0 },
+      // Returning undefined matches what OL's tileUrlFunction does
+      // for coords outside a source's coverage area (eg. NOAA Charts
+      // off-coast).
+      template: (_z, x) => (x === 0 ? 'a' : undefined),
+    });
+    const urls = enumerateTileUrls([source], {
+      extent: [0, 0, 1, 1],
+      z: 3,
+      projection: null,
+    });
+    expect(urls).toEqual(['a']);
+  });
+
+  it('returns an empty array when given no sources', () => {
+    expect(
+      enumerateTileUrls([], { extent: [0, 0, 1, 1], z: 1, projection: null })
+    ).toEqual([]);
+  });
+
+  it('combines URLs from multiple sources (basemap + overlays)', () => {
+    const base = fakeSource({
+      range: { minX: 0, maxX: 0, minY: 0, maxY: 0 },
+      template: (z, x, y) => `https://base/${z}/${x}/${y}`,
+    });
+    const overlay = fakeSource({
+      range: { minX: 0, maxX: 0, minY: 0, maxY: 0 },
+      template: (z, x, y) => `https://overlay/${z}/${x}/${y}`,
+    });
+    expect(
+      enumerateTileUrls([base, overlay], {
+        extent: [0, 0, 1, 1],
+        z: 4,
+        projection: null,
+      })
+    ).toEqual(['https://base/4/0/0', 'https://overlay/4/0/0']);
+  });
+});
+
+describe('prewarmTiles abort signal', () => {
+  let fetchSpy: MockInstance<typeof fetch>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  it('stops dispatching new fetches once the signal is aborted', async () => {
+    const controller = new AbortController();
+    // Resolve the first fetch then abort before the second runs. The
+    // worker loop checks `signal.aborted` between URLs, so the
+    // second/third pulls return early.
+    fetchSpy.mockImplementation(() => {
+      controller.abort();
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+
+    const result = await prewarmTiles(['a', 'b', 'c'], {
+      concurrency: 1,
+      signal: controller.signal,
+    });
+    // The first URL completed before abort took effect; subsequent
+    // pulls hit the early-return guard.
+    expect(result.fetched).toBe(1);
+  });
+});

--- a/src/lib/tile-cache.ts
+++ b/src/lib/tile-cache.ts
@@ -196,7 +196,7 @@ export interface VisibleTileSource<P> {
   readonly getTileGrid: () => {
     readonly getTileRangeForExtentAndZ: (
       extent: number[],
-      z: number
+      zoom: number
     ) => TileRangeLike;
   } | null;
   readonly getTileUrlFunction: () => (
@@ -208,33 +208,33 @@ export interface VisibleTileSource<P> {
 
 export interface TileEnumerationContext<P> {
   readonly extent: number[];
-  readonly z: number;
+  readonly tileZ: number;
   readonly projection: P;
   readonly pixelRatio?: number;
 }
 
 /**
  * Pure helper — given the visible tile sources and the viewport
- * geometry, expand every (z, x, y) into a URL string. No OL classes
- * involved, so vitest can exercise this directly. The `P` generic
- * carries the projection type through opaquely (OL's `Projection`
- * in production, anything in tests) so we don't have to import OL
- * types into the pure helper.
+ * geometry, expand every (tileZ, tileX, tileY) into a URL string.
+ * No OL classes involved, so vitest can exercise this directly. The
+ * `P` generic carries the projection type through opaquely (OL's
+ * `Projection` in production, anything in tests) so we don't have
+ * to import OL types into the pure helper.
  */
 export function enumerateTileUrls<P>(
   sources: readonly VisibleTileSource<P>[],
   context: TileEnumerationContext<P>
 ): readonly string[] {
-  const { extent, z, projection, pixelRatio = 1 } = context;
+  const { extent, tileZ, projection, pixelRatio = 1 } = context;
   const urls: string[] = [];
   for (const source of sources) {
     const grid = source.getTileGrid();
     if (grid === null) continue;
-    const range = grid.getTileRangeForExtentAndZ(extent, z);
+    const range = grid.getTileRangeForExtentAndZ(extent, tileZ);
     const tileUrlFn = source.getTileUrlFunction();
     for (let tileX = range.minX; tileX <= range.maxX; tileX += 1) {
       for (let tileY = range.minY; tileY <= range.maxY; tileY += 1) {
-        const url = tileUrlFn([z, tileX, tileY], pixelRatio, projection);
+        const url = tileUrlFn([tileZ, tileX, tileY], pixelRatio, projection);
         if (typeof url === 'string') urls.push(url);
       }
     }
@@ -270,7 +270,7 @@ export function tileUrlsForMap(map: OlMap): readonly string[] {
   const extent = view.calculateExtent(size);
   const zoom = view.getZoom();
   if (zoom === undefined) return [];
-  const z = Math.round(zoom);
+  const tileZ = Math.round(zoom);
 
   const sources: VisibleTileSource<typeof projection>[] = [];
   for (const layer of map.getLayers().getArray()) {
@@ -284,6 +284,6 @@ export function tileUrlsForMap(map: OlMap): readonly string[] {
     if (!(source instanceof UrlTile)) continue;
     sources.push(source);
   }
-  return enumerateTileUrls(sources, { extent, z, projection });
+  return enumerateTileUrls(sources, { extent, tileZ, projection });
 }
 /* c8 ignore stop */

--- a/src/lib/tile-cache.ts
+++ b/src/lib/tile-cache.ts
@@ -1,0 +1,289 @@
+// Browser-side helpers for the offline tile cache UI.
+//
+// All Cache Storage interaction is centralised here so the React
+// components stay declarative and the unit tests can hit pure logic
+// with a mocked `caches` global. The prefix matches the SW's
+// CACHE_NAME shape — bumping the SW's version creates a new bucket
+// (`ndwt-tiles-v2`, etc.) that the activate handler purges. We also
+// clear anything in the prefix so a stale-version cache left around
+// by a partially-completed upgrade gets nuked from the UI too.
+
+import type { Map as OlMap } from 'ol';
+import TileLayer from 'ol/layer/Tile';
+import UrlTile from 'ol/source/UrlTile';
+
+export const TILE_CACHE_PREFIX = 'ndwt-tiles-';
+
+export interface CacheStats {
+  /** Number of tile entries summed across every `ndwt-tiles-*` cache. */
+  readonly tileCount: number;
+  /**
+   * Estimated bytes used by tile caches. Derived from
+   * `navigator.storage.estimate().usage` when available — that
+   * counts the whole origin's storage, which on this site is
+   * dominated by the tile cache because the static export has no
+   * IndexedDB or localStorage of meaningful size. Falls back to 0
+   * when the StorageManager API is unavailable (older browsers,
+   * private mode in some engines).
+   */
+  readonly byteEstimate: number;
+}
+
+const EMPTY_STATS: CacheStats = Object.freeze({
+  tileCount: 0,
+  byteEstimate: 0,
+});
+
+function hasCachesApi(): boolean {
+  return typeof globalThis !== 'undefined' && 'caches' in globalThis;
+}
+
+async function listTileCacheNames(): Promise<readonly string[]> {
+  const keys = await caches.keys();
+  return keys.filter((k) => k.startsWith(TILE_CACHE_PREFIX));
+}
+
+export async function getCacheStats(): Promise<CacheStats> {
+  if (!hasCachesApi()) return EMPTY_STATS;
+  try {
+    const names = await listTileCacheNames();
+    let tileCount = 0;
+    for (const name of names) {
+      const cache = await caches.open(name);
+      const reqs = await cache.keys();
+      tileCount += reqs.length;
+    }
+    let byteEstimate = 0;
+    if (typeof navigator !== 'undefined' && 'storage' in navigator) {
+      // `estimate()` returns a wider type than the spec — `usage` is
+      // optional and can be undefined in some environments. Coerce to
+      // number with `?? 0` so the UI doesn't have to special-case it.
+      const estimate = await navigator.storage.estimate();
+      byteEstimate = estimate.usage ?? 0;
+    }
+    return { tileCount, byteEstimate };
+  } catch {
+    // A cache read failure shouldn't block the drawer rendering.
+    // Returning empty stats lets the UI show "0 tiles" rather than
+    // throwing inside a useEffect.
+    return EMPTY_STATS;
+  }
+}
+
+export async function clearTileCaches(): Promise<number> {
+  if (!hasCachesApi()) return 0;
+  const names = await listTileCacheNames();
+  await Promise.all(names.map((name) => caches.delete(name)));
+  return names.length;
+}
+
+const BYTES_IN_KIB = 1024;
+const BYTES_IN_MIB = BYTES_IN_KIB * 1024;
+const BYTES_IN_GIB = BYTES_IN_MIB * 1024;
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB';
+  if (bytes >= BYTES_IN_GIB) {
+    return `${(bytes / BYTES_IN_GIB).toFixed(2)} GB`;
+  }
+  if (bytes >= BYTES_IN_MIB) {
+    return `${(bytes / BYTES_IN_MIB).toFixed(1)} MB`;
+  }
+  if (bytes >= BYTES_IN_KIB) {
+    return `${(bytes / BYTES_IN_KIB).toFixed(0)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+export interface PrewarmProgress {
+  readonly total: number;
+  readonly fetched: number;
+  readonly failed: number;
+}
+
+export interface PrewarmResult extends PrewarmProgress {
+  /** True if every URL came back with a non-error response. */
+  readonly ok: boolean;
+}
+
+/**
+ * Fetch every URL serially with a small concurrency cap so we don't
+ * overwhelm tile-host rate limits or the device's network stack.
+ *
+ * Each fetch is "fire-and-forget" from the caller's perspective —
+ * the response is read enough for the SW to write to cache (the SW's
+ * `fetch` handler clones into the cache before the response reaches
+ * us) and then dropped on the floor. We never decode tile bytes
+ * here; the only goal is to populate the cache.
+ *
+ * `onProgress` fires after every URL settles (success OR failure)
+ * so the UI can render a counter without each callback re-rendering
+ * mid-fetch.
+ */
+export async function prewarmTiles(
+  urls: readonly string[],
+  options: {
+    readonly signal?: AbortSignal;
+    readonly concurrency?: number;
+    readonly onProgress?: (p: PrewarmProgress) => void;
+  } = {}
+): Promise<PrewarmResult> {
+  const { signal, concurrency = 4, onProgress } = options;
+  const total = urls.length;
+  let fetched = 0;
+  let failed = 0;
+
+  if (total === 0) {
+    return { total: 0, fetched: 0, failed: 0, ok: true };
+  }
+
+  // Simple bounded-parallel worker pool. Each worker pulls the next
+  // URL off a shared index and fetches it; when the index runs out
+  // the worker resolves. This avoids the all-at-once `Promise.all`
+  // pattern that would fire `total` concurrent requests at zoom-13
+  // viewports (could easily be 64+ tiles per layer).
+  let cursor = 0;
+  const next = (): string | null => {
+    if (cursor >= total) return null;
+    const url = urls[cursor];
+    cursor += 1;
+    return url ?? null;
+  };
+
+  const worker = async (): Promise<void> => {
+    let url = next();
+    while (url !== null) {
+      if (signal?.aborted === true) return;
+      try {
+        const res = await fetch(url, { signal });
+        // Treat non-2xx as a failure for the counter; the SW already
+        // declined to cache it. We don't surface which tiles failed —
+        // the e2e network-blocked scenario covers full-fail visually.
+        if (!res.ok) failed += 1;
+      } catch {
+        failed += 1;
+      }
+      fetched += 1;
+      onProgress?.({ total, fetched, failed });
+      url = next();
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, total) }, () =>
+    worker()
+  );
+  await Promise.all(workers);
+
+  return { total, fetched, failed, ok: failed === 0 };
+}
+
+/**
+ * Duck-typed shape of a visible tile-source-with-grid. Lifted out of
+ * the OL-specific wrapper so the per-layer URL math is testable in
+ * jsdom without constructing real OL Map / Source instances. Extent
+ * and projection are typed loose-ly because OL's types are mutable
+ * and a tight interface here would clash with OL's variance at the
+ * `tileUrlsForMap` call site — the helper doesn't mutate either.
+ */
+export interface TileRangeLike {
+  readonly minX: number;
+  readonly maxX: number;
+  readonly minY: number;
+  readonly maxY: number;
+}
+
+export interface VisibleTileSource<P> {
+  readonly getTileGrid: () => {
+    readonly getTileRangeForExtentAndZ: (
+      extent: number[],
+      z: number
+    ) => TileRangeLike;
+  } | null;
+  readonly getTileUrlFunction: () => (
+    coord: [number, number, number],
+    pixelRatio: number,
+    projection: P
+  ) => string | undefined;
+}
+
+export interface TileEnumerationContext<P> {
+  readonly extent: number[];
+  readonly z: number;
+  readonly projection: P;
+  readonly pixelRatio?: number;
+}
+
+/**
+ * Pure helper — given the visible tile sources and the viewport
+ * geometry, expand every (z, x, y) into a URL string. No OL classes
+ * involved, so vitest can exercise this directly. The `P` generic
+ * carries the projection type through opaquely (OL's `Projection`
+ * in production, anything in tests) so we don't have to import OL
+ * types into the pure helper.
+ */
+export function enumerateTileUrls<P>(
+  sources: readonly VisibleTileSource<P>[],
+  context: TileEnumerationContext<P>
+): readonly string[] {
+  const { extent, z, projection, pixelRatio = 1 } = context;
+  const urls: string[] = [];
+  for (const source of sources) {
+    const grid = source.getTileGrid();
+    if (grid === null) continue;
+    const range = grid.getTileRangeForExtentAndZ(extent, z);
+    const tileUrlFn = source.getTileUrlFunction();
+    for (let x = range.minX; x <= range.maxX; x += 1) {
+      for (let y = range.minY; y <= range.maxY; y += 1) {
+        const url = tileUrlFn([z, x, y], pixelRatio, projection);
+        if (typeof url === 'string') urls.push(url);
+      }
+    }
+  }
+  return urls;
+}
+
+/**
+ * Enumerate the tile URLs that cover the map's current viewport for
+ * every visible tile layer. Used by the "Save current view" action
+ * to pre-warm the SW cache.
+ *
+ * Notes on OL internals:
+ *  - `getTileGrid()` can return `null` for sources that haven't been
+ *    fully initialised; we skip those.
+ *  - `getTileUrlFunction()` is the source of truth for the URL
+ *    template even when the source was constructed with `url:` —
+ *    OSM, XYZ, and the WMTS sources all expose it identically.
+ *  - `pixelRatio` is fixed at 1; OL would request `@2x` URLs on
+ *    HiDPI screens for some sources, but the project's sources don't
+ *    define `tilePixelRatio`, so 1 matches what OL itself fetches.
+ *
+ * This function exists as the OL-aware glue around `enumerateTileUrls`
+ * — `instanceof` narrowing happens here so the loop math stays pure.
+ * Covered by the Playwright e2e (an OL canvas can't render in jsdom).
+ */
+/* c8 ignore start */
+export function tileUrlsForMap(map: OlMap): readonly string[] {
+  const view = map.getView();
+  const projection = view.getProjection();
+  const size = map.getSize();
+  if (size === undefined) return [];
+  const extent = view.calculateExtent(size);
+  const zoom = view.getZoom();
+  if (zoom === undefined) return [];
+  const z = Math.round(zoom);
+
+  const sources: VisibleTileSource<typeof projection>[] = [];
+  for (const layer of map.getLayers().getArray()) {
+    if (!(layer instanceof TileLayer) || !layer.getVisible()) continue;
+    const source = layer.getSource();
+    // Narrow to UrlTile — the parent of OSM, XYZ, TileImage, etc.
+    // and the class that owns `getTileUrlFunction`. The project
+    // doesn't use non-UrlTile sources (e.g. ImageWMS), so anything
+    // that fails the instanceof check is something we don't know
+    // how to enumerate URLs for and can safely skip.
+    if (!(source instanceof UrlTile)) continue;
+    sources.push(source);
+  }
+  return enumerateTileUrls(sources, { extent, z, projection });
+}
+/* c8 ignore stop */

--- a/src/lib/tile-cache.ts
+++ b/src/lib/tile-cache.ts
@@ -232,9 +232,9 @@ export function enumerateTileUrls<P>(
     if (grid === null) continue;
     const range = grid.getTileRangeForExtentAndZ(extent, z);
     const tileUrlFn = source.getTileUrlFunction();
-    for (let x = range.minX; x <= range.maxX; x += 1) {
-      for (let y = range.minY; y <= range.maxY; y += 1) {
-        const url = tileUrlFn([z, x, y], pixelRatio, projection);
+    for (let tileX = range.minX; tileX <= range.maxX; tileX += 1) {
+      for (let tileY = range.minY; tileY <= range.maxY; tileY += 1) {
+        const url = tileUrlFn([z, tileX, tileY], pixelRatio, projection);
         if (typeof url === 'string') urls.push(url);
       }
     }


### PR DESCRIPTION
Closes the loop on issue #64 by giving users explicit control over the offline tile cache the SW maintains. A gear icon in the top-right of the map opens a non-modal drawer with three actions:

- **Cache stats** — count of cached tiles + estimated bytes (via `navigator.storage.estimate`)
- **Clear cached tiles** — drops every `ndwt-tiles-*` bucket from Cache Storage
- **Save current view for offline use** — enumerates every (z, x, y) tile for the visible basemap + overlays at the current viewport/zoom, fetches each through the SW so the cache is warm before a trip

## Why this matters

NDWT runs through cell-dead reaches of the Columbia/Snake. The Tier 3a SW already opportunistically caches tiles you've panned over; this drawer turns that into a deliberate workflow: pan to your planned route while on WiFi, hit *Save current view*, then close the laptop with confidence the map will work on the river.

## Architecture notes

The OL-aware URL enumeration in `src/lib/tile-cache.ts` splits into:

- `enumerateTileUrls(sources, context)` — pure helper, fully unit-tested in jsdom
- `tileUrlsForMap(map)` — thin OL wrapper that narrows via `instanceof TileLayer` / `instanceof UrlTile`, then delegates. Covered by Playwright; marked `/* c8 ignore */` so the coverage number reflects the testable surface.

This keeps the math reachable from vitest (canvas-free) without dropping the file from Sonar's coverage measurement.

Small fix in `src/components/ui/drawer.tsx`: the `Drawer` primitive had a hardcoded `data-testid="site-info-panel"`. Now overridable via a `testId` prop (default unchanged) so the new map-settings drawer doesn't collide with the existing site-info drawer in `screen.getByTestId`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors)
- [x] `npm run test` — 193 tests pass, 100% line / 95% branch coverage on `tile-cache.ts`
- [x] `npm run build` — clean static export
- [ ] Playwright e2e — runs in CI
- [ ] Manual: open map, click gear, save current view, refresh + verify tile count, clear cache, verify count goes to zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)
