### PR TITLE
docs(architecture): document tile resilience (ADR 0004 + diagrams)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ Architecture Decision Records explain the load-bearing choices:
   PandaCSS + Park UI preset over Chakra UI 2.
 - [`decisions/0003-hexagonal-architecture.md`](./decisions/0003-hexagonal-architecture.md) —
   Hexagonal architecture for site data.
+- [`decisions/0004-tile-resilience.md`](./decisions/0004-tile-resilience.md) —
+  Tile resilience via tracker + service worker + cache storage
+  (issue #64; PRs #65 / #67 / #68 / #70 / #71).
 
 ## Plans
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -39,9 +39,26 @@ graph TB
   subgraph Map_["src/components/ (map)"]
     MapApp["MapApp.tsx<br/>'use client'<br/>composition + dynamic map"]
     MapTSX["map.tsx<br/>OL Map instance<br/>5 tile layers + vectors"]
-    LayerSwitcher_["LayerSwitcher.tsx<br/>base-map + overlay toggles"]
+    LayerSwitcher_["LayerSwitcher.tsx<br/>base-map + overlay toggles<br/>+ per-layer health dots"]
     Handlers["map-handlers.ts<br/>pure click + pointermove"]
     Theme["ThemeToggleButton.tsx"]
+  end
+
+  subgraph Resilience_["src/components/ (tile resilience)"]
+    Tracker["tile-health-tracker.ts<br/>pure classifier<br/>ok / degraded / down"]
+    HealthBanner["TileHealthBanner.tsx<br/>top-center · auto-suggest"]
+    OfflinePill["OfflineIndicator.tsx<br/>bottom-center · navigator.onLine"]
+    SettingsBtn["MapSettingsButton.tsx<br/>top-right gear icon"]
+    SettingsDrawer["MapSettingsDrawer.tsx<br/>cache stats · clear · pre-warm"]
+  end
+
+  subgraph Lib_["src/lib/"]
+    SwReg["register-service-worker.ts<br/>production-only registration"]
+    TileCache["tile-cache.ts<br/>Cache Storage helpers<br/>+ tile-URL enumeration"]
+  end
+
+  subgraph Public_["public/"]
+    Sw["sw.js<br/>cache-first SW<br/>scoped to known tile hosts"]
   end
 
   subgraph Panels_["src/components/panels/"]
@@ -87,6 +104,7 @@ graph TB
 
   Comp["composition-root.ts<br/>createComposition factory"]
   Store["store/selected-site.ts<br/>Zustand"]
+  HealthStore["store/tile-health.ts<br/>Zustand · per-layer health"]
 
   Layout --> Providers
   Layout --> Header
@@ -112,10 +130,24 @@ graph TB
   MapApp --> Panel
   MapApp --> Theme
   MapApp --> Comp
+  MapApp --> SwReg
+  MapApp --> OfflinePill
+  MapApp --> SettingsBtn
+  MapApp --> SettingsDrawer
 
   MapTSX --> Handlers
   MapTSX --> LayerSwitcher_
+  MapTSX --> HealthBanner
+  MapTSX -->|tileloadend/error| HealthStore
+  HealthStore --> Tracker
+  HealthBanner --> HealthStore
+  LayerSwitcher_ --> HealthStore
   Handlers --> Store
+
+  SwReg -.registers.-> Sw
+  Sw -.intercepts.-> Tiles[("tile providers<br/>(SW boundary)")]
+  SettingsDrawer --> TileCache
+  TileCache -.reads/writes.-> Sw
 
   Panel --> Drawer
   Panel --> SiteDetails_
@@ -165,14 +197,16 @@ graph TB
   classDef adapter fill:#fef3c7,stroke:#d97706;
   classDef glue fill:#fee2e2,stroke:#dc2626;
   classDef content fill:#fae8ff,stroke:#a21caf;
+  classDef resilience fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e;
 
   class Layout,Providers,HomePage,SitesIndexRoute,SiteDetailRoute,AboutRoutes,EditorialRoutes,Globals route
   class Header,Hero,Footer,Box,Stack,Text,Heading,Badge,Link,Button,IconButton,Drawer,Panel,SiteDetails_,Facilities,MapApp,MapTSX,LayerSwitcher_,Theme,SiteIndex,Article,SectionIndex ui
   class Site,Coords,Fac,Slug,Idx domain
   class Port,ListUC,GetUC app
   class LoadSites,InMem,Geo,Parser,Gpx adapter
-  class Comp,Store,Handlers glue
+  class Comp,Store,Handlers,HealthStore glue
   class Mdx content
+  class Tracker,HealthBanner,OfflinePill,SettingsBtn,SettingsDrawer,SwReg,TileCache,Sw,Tiles resilience
 ```
 
 ## What lives where
@@ -241,19 +275,69 @@ list of articles inside one of the catch-all editorial routes.
 The OpenLayers integration:
 
 - `MapApp.tsx` is the `'use client'` boundary. It builds the
-  composition once per `sites` prop via `useMemo` and dynamic-
-  imports the OL component with `ssr: false`.
+  composition once per `sites` prop via `useMemo`, dynamic-
+  imports the OL component with `ssr: false`, registers the
+  service worker on first mount, and renders the offline pill
+  and settings button as siblings of the map.
 - `map.tsx` owns the `ol.Map` instance and its lifecycle (mount
   on `useEffect`, set the global test handle, clean up). It
   registers five tile layers (OSM / USGS / OpenTopoMap base
-  maps + OpenSeaMap / Waymarked Trails overlays) and syncs
-  their visibility from React state.
+  maps + OpenSeaMap / Waymarked Trails overlays), syncs their
+  visibility from React state, and wires `tileloadend` /
+  `tileloaderror` events from each source into the tile-health
+  store.
 - `LayerSwitcher.tsx` is the floating dropdown that drives the
-  base-map and overlay state. Pure presentation — `map.tsx`
-  passes the active selections and toggle callbacks in.
+  base-map and overlay state, plus the per-layer health dots
+  (🟢 ok / 🟡 degraded / 🔴 down) read off the tile-health
+  store.
 - `map-handlers.ts` exports curried pure functions
   (`makeHandleClick`, `makeHandlePointerMove`) that don't import
   any UI deps — straightforward to unit test against a fake Map.
+
+### Tile resilience (`tile-health-tracker.ts`, `TileHealthBanner.tsx`, `OfflineIndicator.tsx`, `MapSettingsButton.tsx`, `MapSettingsDrawer.tsx`)
+
+The graceful-degradation stack on top of the OL integration:
+
+- `tile-health-tracker.ts` is a pure classifier — no React, no OL.
+  Takes a rolling window of success / error events per layer and
+  emits `'unknown' | 'ok' | 'degraded' | 'down'`. Sticky-down
+  latching via `downSince` prevents banner flapping during a
+  flaky outage.
+- `TileHealthBanner.tsx` is the top-center status banner. Reads
+  the tile-health store; when the active basemap classifies as
+  'down', it surfaces a non-modal banner with a one-click
+  "Switch to USGS Topo?" auto-suggest.
+- `OfflineIndicator.tsx` is the bottom-center pill, driven by
+  `navigator.onLine` plus `online` / `offline` window events.
+  Pairs with the SW: when offline, the user gets clear feedback
+  that the map is running on cached tiles.
+- `MapSettingsButton.tsx` is the top-right gear icon.
+  `MapSettingsDrawer.tsx` is its drawer body — cache stats
+  (count + estimated bytes), Clear button, and "Save current
+  view for offline use" pre-warm action. Reuses the
+  `globalThis.__ndwtMap` handle to enumerate viewport tiles.
+
+### `src/lib/` (`register-service-worker.ts`, `tile-cache.ts`)
+
+Browser-edge helpers that the React tree consumes:
+
+- `register-service-worker.ts` — a one-liner the `MapApp` mount
+  calls. Gates on `NODE_ENV === 'production'` and swallows
+  registration failures.
+- `tile-cache.ts` — Cache Storage helpers (`getCacheStats`,
+  `clearTileCaches`, `formatBytes`), the bounded-concurrency
+  `prewarmTiles` worker pool, the pure `enumerateTileUrls`
+  helper, and the OL-aware `tileUrlsForMap` wrapper that
+  narrows OL layers/sources by `instanceof` before delegating.
+
+### `public/sw.js`
+
+The cache-first service worker. Scoped strictly to known tile
+hosts (`TILE_HOSTS`); everything else passes through to the
+browser's default handling. Cache versioned via `CACHE_NAME`;
+old caches are purged in the `activate` handler. See ADR
+[0004](../decisions/0004-tile-resilience.md) for the full
+rationale.
 
 ### `content/`
 
@@ -313,11 +397,21 @@ it to its own module would be a clean refactor.
 
 ### `src/store/`
 
-A single Zustand slice for the selected site. The split between
-"domain data" (in the composition) and "ephemeral UI state" (in
-Zustand) is intentional. The map's layer-switcher state lives
-in component-local `useState` inside `map.tsx`, not in Zustand,
-because no other component needs to read it.
+Two Zustand slices, each for one concern:
+
+- `selected-site.ts` — the currently-open site for the info
+  panel. Driven by the OL click handler (outside React's
+  context, so Zustand's `getState()` is the right fit).
+- `tile-health.ts` — per-layer rolling tile-load health. Fed by
+  the OL tile-event listeners in `map.tsx`, read by both the
+  `TileHealthBanner` and the per-layer dots in
+  `LayerSwitcher`. Wraps the pure classifier in
+  `tile-health-tracker.ts`.
+
+The split between "domain data" (in the composition) and
+"ephemeral UI state" (in Zustand) is intentional. The map's
+layer-switcher base/overlay state still lives in component-local
+`useState` inside `map.tsx` — no other component needs to read it.
 
 ## See also
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,8 +1,10 @@
 # Data flow
 
-There are two distinct flows worth understanding: the **build-time
-load** that bakes the trail data into the static export, and the
-**runtime click** that opens the info panel for a selected marker.
+There are three flows worth understanding: the **build-time load**
+that bakes the trail data into the static export, the **runtime
+click** that opens the info panel for a selected marker, and the
+**tile fetch with resilience** that the user actually exercises every
+time they pan the map.
 
 ## Build-time: GeoJSON → static HTML
 
@@ -78,7 +80,79 @@ sequenceDiagram
   Panel->>User: drawer opens with site info
 ```
 
-## Notable design decisions in this flow
+## Runtime: tile fetch with resilience
+
+Every pan, zoom, or basemap switch fires this loop. The service
+worker intercepts the network round-trip and the tile-health store
+tracks success/failure so the banner can suggest a healthy fallback
+when an upstream provider goes flaky.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Map as map.tsx<br/>(OL TileLayer source)
+  participant SW as public/sw.js<br/>(scoped to TILE_HOSTS)
+  participant Cache as Cache Storage<br/>(ndwt-tiles-v1)
+  participant Provider as Tile provider<br/>(OSM / USGS / …)
+  participant Store as Zustand<br/>tile-health
+  participant Tracker as tile-health-tracker
+  participant Banner as TileHealthBanner
+  participant Switcher as LayerSwitcher<br/>(per-layer dots)
+  participant Pill as OfflineIndicator
+
+  Note over Map: User pans → OL requests<br/>tile URL via img element
+
+  Map->>SW: GET tile URL
+  alt cache hit (warm region or pre-warmed)
+    SW->>Cache: match(request)
+    Cache-->>SW: cached Response
+    SW-->>Map: 200 OK (from cache)
+    Map->>Store: tileloadend(layerKey)
+  else cache miss
+    SW->>Provider: fetch(request)
+    alt network ok and response.ok
+      Provider-->>SW: 200 OK tile bytes
+      SW->>Cache: put(request, response.clone())
+      SW-->>Map: 200 OK
+      Map->>Store: tileloadend(layerKey)
+    else upstream error (4xx/5xx) or network failure
+      SW-->>Map: error response<br/>(or synthetic 504 on netfail)
+      Map->>Store: tileloaderror(layerKey)
+    end
+  end
+
+  Store->>Tracker: classify(events)
+  Tracker-->>Store: 'ok' / 'degraded' / 'down'
+
+  alt active basemap is 'down'
+    Store-->>Banner: re-render
+    Banner-->>Map: shows banner +<br/>auto-suggest fallback
+  end
+  Store-->>Switcher: re-render dots
+  Note over Pill: independent path —<br/>listens to navigator.onLine,<br/>shows pill when offline
+```
+
+**What this means in practice:**
+
+- **The SW lives outside React.** A route navigation or component
+  remount doesn't drop the cache; the SW keeps working while the page
+  reloads.
+- **The classifier is pure.** Sticky-down latching (`downSince`,
+  5-minute persistence) suppresses banner flapping when an outage is
+  partial — a few sporadic successes won't immediately revert the
+  classification to 'ok'.
+- **The SW only intercepts the seven known tile hosts.** App bundles,
+  GeoJSON, MDX content, and static assets all pass through to the
+  browser's default handling. See ADR
+  [0004](../decisions/0004-tile-resilience.md) for the full host
+  list and the rationale.
+- **The "Save current view for offline use" action in the settings
+  drawer** (top-right gear icon) walks the visible tile layers,
+  enumerates every (z, x, y) in the current viewport, and fetches
+  each through the same SW. After the action completes the tile
+  count in the drawer reflects the warmed cache.
+
+## Notable design decisions in these flows
 
 - **`MapApp` builds a fresh composition per render** via `useMemo`
   on `sites`. There is **no module-level mutable state** — every
@@ -108,3 +182,6 @@ sequenceDiagram
 - ADR [0001](../decisions/0001-nextjs-app-router.md) (static
   export) and [0003](../decisions/0003-hexagonal-architecture.md)
   (hex-arch) underpin the choice to bake data at build time
+- ADR [0004](../decisions/0004-tile-resilience.md) explains the
+  tile resilience choices — pure classifier, raw SW, cache-first
+  scoped to known hosts, sticky-down latching

--- a/docs/architecture/hexagonal.md
+++ b/docs/architecture/hexagonal.md
@@ -117,6 +117,27 @@ Concrete enforcement points:
   `@/adapters/*` from a UI module are a smell — the composition
   root is the choke point.
 
+### Browser-platform adapters
+
+`src/lib/tile-cache.ts` and `public/sw.js` are also platform-edge
+adapters in spirit: they wrap the Cache Storage API and the Service
+Worker runtime so the React tree can stay declarative. They live
+**outside** `src/adapters/` deliberately:
+
+- They don't implement the domain `SiteRepository` port — they
+  serve a different concern (browser-side tile cache management).
+- They don't carry domain types. `tile-cache.ts` deals in
+  `Request`, `Response`, and tile-URL strings; nothing crosses the
+  domain boundary.
+- `public/sw.js` is a static asset shipped by Next, not a TypeScript
+  module imported by anything in `src/`. Putting it under
+  `src/adapters/` would imply a code path that doesn't exist.
+
+The dependency rule still applies: nothing in `src/lib/tile-cache.ts`
+imports from `src/domain/`, and the UI components that consume it
+treat it as another adapter-shaped seam. See ADR
+[0004](../decisions/0004-tile-resilience.md) for the full rationale.
+
 ## Why hexagonal here
 
 The data path is small (one file, one in-memory map, one fs read

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,7 +45,9 @@ flowchart LR
 The container view zooms into the deployable units. Notice that
 **the only dynamic component is the user's browser** — Netlify
 serves pre-rendered HTML and the trail data + editorial articles
-are baked into each page at build time.
+are baked into each page at build time. A service worker running
+in the browser intercepts tile fetches cache-first so the map keeps
+working when the user is out of signal.
 
 ```mermaid
 flowchart TB
@@ -54,8 +56,10 @@ flowchart TB
   subgraph deploy["Static deploy on Netlify"]
     direction TB
     html["Pre-rendered HTML<br/>Next.js static export<br/>map · sites index · site detail<br/>+ water-safety · river-navigation<br/>+ leave-no-trace · natural-world<br/>+ past-and-present · trip-planning<br/>+ get-involved · about · about/*"]
-    js["Hydration bundle<br/>React 19 + OpenLayers 10<br/>map · layer switcher<br/>panel · GPX download"]
+    js["Hydration bundle<br/>React 19 + OpenLayers 10<br/>map · layer switcher · health banner<br/>panel · offline pill · settings drawer<br/>GPX download"]
     css["Atomic CSS<br/>PandaCSS<br/>generated at build time<br/>no runtime CSS-in-JS"]
+    sw["Service worker<br/>public/sw.js<br/>cache-first for tile hosts<br/>scoped to TILE_HOSTS allowlist"]
+    cache[("Cache Storage<br/>ndwt-tiles-v1<br/>tile blobs, LRU-evicted")]
     data[("/data/ndwt.geojson<br/>159 sites + facility flags<br/>still served for external GIS")]
     mdx[("content/*.mdx<br/>editorial articles<br/>safety · navigation · history…")]
   end
@@ -66,7 +70,10 @@ flowchart TB
 
   boater -->|HTTPS| html
   html -->|Hydrates| js
-  js -->|Tile requests| tiles
+  js -.->|Registers on mount<br/>production only| sw
+  js -->|Tile requests| sw
+  sw -->|cache-first<br/>then network| tiles
+  sw <-->|read / write| cache
   html -.->|Baked at build time| data
   html -.->|Baked at build time| mdx
   repo -->|Push triggers| ci
@@ -76,10 +83,12 @@ flowchart TB
   classDef store fill:#fef3c7,stroke:#d97706,color:#78350f;
   classDef ext fill:#fee2e2,stroke:#dc2626,color:#7f1d1d;
   classDef person fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+  classDef resilience fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e;
   class boater person
   class html,js,css container
   class data,mdx store
   class ci,tiles,repo ext
+  class sw,cache resilience
 ```
 
 ## Why this shape
@@ -99,6 +108,14 @@ flowchart TB
   OpenSeaMap sea marks or Waymarked Trails hiking. All tile
   fetches are direct from the browser to the provider; the
   static deploy never proxies them.
+- **Tile resilience handled in the browser** — a service worker
+  (`public/sw.js`) intercepts requests to the seven known tile
+  hosts cache-first. Combined with the in-page tile-health
+  tracker (banner + per-layer dots) and the offline indicator,
+  the map degrades gracefully from "fully online" through
+  "cached only" to "tiles unavailable." A settings drawer lets
+  the user pre-warm a planned route's tiles while on WiFi. See
+  ADR [0004](../decisions/0004-tile-resilience.md).
 - **OL is the only meaningful client-side dependency** — the
   hydration bundle stays small because we don't ship a UI
   runtime (Park UI components compile to plain elements +

--- a/docs/decisions/0004-tile-resilience.md
+++ b/docs/decisions/0004-tile-resilience.md
@@ -1,0 +1,230 @@
+# ADR 0004: Tile resilience via tracker + service worker + cache storage
+
+- **Status:** Accepted (issue [#64](https://github.com/ivanoats/ndwt-ol-chakra/issues/64), 2026-05)
+- **Deciders:** Ivan Storck
+
+## Context
+
+NDWT runs through some of the most cell-dead reaches of the Pacific
+Northwest: Hanford Reach, the Snake River canyons, the Wallula Gap.
+The realistic usage pattern is _plan from home (WiFi), open the map
+on the river (no signal)_. Before this work, four problems compounded
+that pattern badly:
+
+1. **Tile-host outages were invisible to users.** OpenLayers leaves a
+   failed tile cell blank with no UI feedback. A USGS outage looked
+   identical to "you panned past the cached area."
+2. **No retry, no fallback.** A flaky basemap stayed flaky until the
+   user manually picked a different one — and there was no signal
+   suggesting they should.
+3. **No offline behaviour.** First page load worked online or didn't
+   load at all; tiles fetched live from each provider with no caching
+   layer of our own.
+4. **No way to prepare for a trip.** A paddler couldn't "save the
+   route's tiles for offline use" on WiFi before going out.
+
+Issue [#64](https://github.com/ivanoats/ndwt-ol-chakra/issues/64)
+laid out a three-tier roadmap; this ADR captures the load-bearing
+choices made across PRs #65 / #67 / #68 / #70 / #71.
+
+## Decision
+
+### 1. Classifier as a pure module, separate from the Zustand slice
+
+`src/components/tile-health-tracker.ts` is a framework-free classifier
+that takes a rolling window of `{kind: 'success'|'error', at: number}`
+events and returns `'unknown' | 'ok' | 'degraded' | 'down'`. The
+Zustand store `src/store/tile-health.ts` is a thin wrapper that holds
+per-layer state and calls into the classifier on every tile event.
+
+The tracker is unit-tested directly in jsdom with no React, no OL,
+and no store. The store has its own small test suite focused on the
+React integration. Splitting the two means a misclassification bug
+is reproducible from a 30-line vitest test, not a render setup.
+
+### 2. Sticky-down latching via `downSince`
+
+When a layer crosses the 'down' threshold, the tracker stamps a
+`downSince: number` timestamp. The classifier then keeps reporting
+'down' for `DOWN_PERSIST_MS` (5 minutes) even if a few sporadic
+successes arrive — suppressing banner flapping during a flaky outage.
+
+The alternative (purely instantaneous classification) created a UX
+where the banner flickered open and closed during a partial outage,
+which is worse than just staying up until the connection is genuinely
+healthy again.
+
+### 3. Raw `public/sw.js` rather than Workbox / next-pwa
+
+The service worker is hand-written in `public/sw.js`, registered via
+`src/lib/register-service-worker.ts`, and called once from `MapApp`
+on first mount. Production-only (`NODE_ENV === 'production'` check).
+
+We deliberately did not adopt Workbox or `next-pwa`. The SW is small
+(~130 LOC), has a single concern (cache-first for known tile hosts),
+and changes rarely. A build-pipeline coupling (Workbox runs a
+manifest generator at build, next-pwa injects itself into Next's
+config) would buy nothing here and would conflict with the static-
+export setup (see ADR
+[0001](./0001-nextjs-app-router.md)).
+
+Version invalidation is by hand: bump the `CACHE_NAME` version suffix
+(`ndwt-tiles-v1` → `ndwt-tiles-v2`) and the SW's `activate` handler
+purges any cache whose name doesn't match. We do `skipWaiting()` +
+`clients.claim()` so the new SW takes over immediately — tile
+content's shape doesn't differ between SW versions, so there's no
+risk of incompatible cached data.
+
+### 4. Cache-first scoped strictly by tile hostnames
+
+The SW's `fetch` handler intercepts only `GET` requests to known tile
+hosts (`tile.openstreetmap.org`, `basemap.nationalmap.gov`, the
+OpenTopoMap subdomains, `tiles.openseamap.org`,
+`tile.waymarkedtrails.org`). Everything else passes through to the
+browser's default handling, untouched. App bundles, the GeoJSON,
+Next's static assets — all unaffected.
+
+Two practical consequences:
+
+- A future tile host needs adding to the `TILE_HOSTS` array in both
+  `public/sw.js` and the e2e test (`e2e/offline.spec.ts`); the scope
+  test fails loudly if they drift.
+- Only `response.ok` responses are cached. 4xx / 5xx come through to
+  the page (so OL fires its `tileloaderror` and the tracker counts
+  them) but aren't stored. Opaque responses (no-cors) are skipped
+  entirely because their `status === 0` makes "success vs upstream
+  failure" undetectable; OL's tile sources set
+  `crossOrigin: 'anonymous'` so this is a theoretical edge case
+  anyway.
+
+### 5. Tile-URL enumeration: pure helper + thin OL wrapper
+
+`src/lib/tile-cache.ts:enumerateTileUrls` is the pure loop that
+expands a tile range into URL strings. It takes duck-typed
+`VisibleTileSource<P>` and `TileEnumerationContext<P>` inputs (a
+generic `P` carries the projection type opaquely). It's 100% unit
+tested.
+
+`tileUrlsForMap` is the OL-aware glue: it walks `map.getLayers()`,
+narrows via `instanceof TileLayer` + `instanceof UrlTile`, then
+delegates to `enumerateTileUrls`. The function is marked
+`/* c8 ignore */` because an OL canvas can't render in jsdom; Playwright
+covers it end-to-end via the "pre-warm current viewport" e2e.
+
+### 6. `globalThis.__ndwtMap` reuse for the settings drawer
+
+The settings drawer reads the OL map handle off `globalThis.__ndwtMap`
+to enumerate viewport tiles for pre-warm. The handle was already
+exposed for Playwright deterministic interactions; it predates this
+work.
+
+The alternative (drilling a `Map` reference through the dynamic-
+imported `MapComponent` into a sibling drawer) would have added a
+layer of prop plumbing and a `useState<Map | null>` race during
+first render. Reusing the existing handle is the smaller surface
+area, and the handle is documented in CLAUDE.md as "the same Map a
+real user already has via the DOM."
+
+## Consequences
+
+**Wins:**
+
+- The five tiers compose into a graceful ladder: silent happy path →
+  banner suggests fallback → SW serves cached tiles → offline pill
+  appears → user can pre-warm the next trip's tiles. Each tier was a
+  small focused PR (~200–400 LOC), reviewable independently.
+- The pure tracker + pure enumeration helper give us 100% coverage on
+  the hard-to-reach branches (sticky-down latching, tile-range math)
+  without booting jsdom or OL.
+- No build-pipeline change. The SW ships under `public/` and Next
+  copies it through static export unmodified; the SW registration is a
+  one-line `useEffect` on first mount.
+- Bug surface is small: the SW intercepts only known hosts (strict
+  allowlist), only caches successful CORS responses, and version-
+  bumps are explicit.
+
+**Costs / hazards:**
+
+- **No explicit cache eviction.** We rely on the browser's LRU under
+  storage pressure. Fine for MVP — a single trip's worth of tiles
+  is ~5–30 MB, well below any modern storage budget — but worth
+  revisiting if the cache becomes a hot spot. A future PR could add
+  a size cap with oldest-first eviction.
+- **`globalThis.__ndwtMap` is a soft contract.** The settings drawer
+  silently no-ops if the handle is absent. Documented in CLAUDE.md
+  but not type-enforced. A future refactor that removed the handle
+  would break the drawer with no compile-time signal.
+- **The `TILE_HOSTS` list lives in three places** (the SW, the e2e
+  test, and implicitly in `map.tsx`'s layer definitions). Drift is
+  caught by the scope-correctness e2e but the duplication is real.
+  A future extraction to a shared constant would tighten this up.
+- **SW skipped in dev** (`NODE_ENV === 'production'` gate). Local
+  offline testing requires `npm run build && npm run preview`. Worth
+  it: Next's HMR layer doesn't compose cleanly with SW caching, and
+  the SW's scope is tiles-only so dev hot reload is unaffected.
+
+## Alternatives considered
+
+### Workbox / next-pwa
+
+- **Why considered:** Standard ecosystem answer; gives precaching,
+  routing DSL, automatic versioning.
+- **Why rejected:** Workbox precaching wants a build manifest of
+  every asset to cache, which is the wrong shape — we don't want to
+  cache the GeoJSON or the JS bundles, only the third-party tiles. Its
+  routing DSL is more general than a 7-host allowlist needs. next-pwa
+  would require modifying `next.config.mjs` and adding a build step.
+  Hand-written SW + no toolchain change was a net win for ~130 LOC.
+
+### Caching tiles via OpenLayers' own image-tile mechanism
+
+- **Why considered:** OL supports custom tile loaders that could read
+  from IndexedDB or Cache Storage directly.
+- **Why rejected:** Couples cache mechanics to the map component's
+  lifecycle. The SW model has the cache outside the React tree, so
+  a route navigation or component remount doesn't drop progress. The
+  SW also handles the "offline pill while panning" case for free — OL
+  fires `tileloaderror`, our tracker classifies, the banner can suggest
+  a fallback — without us needing to model "is the cache hot for this
+  region."
+
+### IndexedDB for the tile store
+
+- **Why considered:** More structured than Cache Storage; explicit
+  schema; transactional.
+- **Why rejected:** Cache Storage's `Cache.put` / `Cache.match` are
+  designed exactly for the Request → Response shape we need. We never
+  introspect tile bytes; storing them as opaque `Response` objects in
+  the cache is simpler than serializing into IndexedDB rows. The
+  estimated bytes readout in the settings drawer uses
+  `navigator.storage.estimate()`, which doesn't care which API holds
+  the bytes.
+
+### Banner per layer rather than one shared banner
+
+- **Why considered:** Cleaner per-layer status — "OSM is down, USGS
+  is fine, but you're looking at OSM."
+- **Why rejected:** The banner is about the _active_ layer; an
+  overlay being down (e.g. OpenSeaMap) is rarely user-actionable. The
+  health dots in the layer switcher (Tier 2) already give a per-layer
+  signal without crowding the map canvas. One banner, two reads (red
+  dot inline + banner if the active layer is the red one) is the
+  right split.
+
+## Notes
+
+- Tier 1 (banner): PR
+  [#65](https://github.com/ivanoats/ndwt-ol-chakra/pull/65)
+- Tier 2 (health dots + auto-suggest + sticky-down): PR
+  [#67](https://github.com/ivanoats/ndwt-ol-chakra/pull/67)
+- Tier 3a (service worker): PR
+  [#68](https://github.com/ivanoats/ndwt-ol-chakra/pull/68)
+- Tier 3b (offline indicator pill): PR
+  [#70](https://github.com/ivanoats/ndwt-ol-chakra/pull/70)
+- Tier 3c (settings drawer): PR
+  [#71](https://github.com/ivanoats/ndwt-ol-chakra/pull/71)
+- See
+  [`docs/architecture/overview.md`](../architecture/overview.md) for
+  the SW in the container view, and
+  [`docs/architecture/data-flow.md`](../architecture/data-flow.md)
+  for the resilience sequence diagram.


### PR DESCRIPTION
The five tiers of tile resilience (issue #64, merged in #65 / #67 / #68 / #70 / #71) introduced enough new architecture that the existing docs lagged the code. This PR catches them up.

## What changed

- **New ADR `0004-tile-resilience.md`** — captures the six load-bearing choices: pure classifier separate from the Zustand slice, sticky-down latching via `downSince`, raw `public/sw.js` rather than Workbox/next-pwa, cache-first scoped by tile hostnames, pure URL enumeration with thin OL wrapper, and `globalThis.__ndwtMap` reuse for pre-warm. Includes Alternatives Considered and Consequences sections.
- **`components.md`** — adds `Tile resilience`, `src/lib/`, and `public/` subgraphs to the Mermaid component diagram; new prose sections for each added module; the `src/store/` section now describes both Zustand slices.
- **`data-flow.md`** — third sequence diagram covering the tile fetch loop (SW cache-first → network → tracker → store → banner/dots) and the offline-pill side channel.
- **`overview.md`** — container view now shows the SW intercepting tile fetches and writing to Cache Storage; hydration bundle's component list calls out the resilience UI.
- **`hexagonal.md`** — new "Browser-platform adapters" section explaining why `public/sw.js` and `src/lib/tile-cache.ts` sit outside `src/adapters/` even though they're adapter-shaped.
- **`docs/README.md`** — link to ADR 0004.

## Verification

- All three Mermaid diagrams (overview container, components, resilience sequence) validated via the Mermaid renderer — `valid: true` for each.
- `npm run lint:md` clean (0 errors).
- No source changes; docs-only PR.

## Test plan

- [ ] Render the diagrams on GitHub (the PR diff view shows Mermaid inline)
- [ ] Confirm ADR 0004 reads correctly alongside the existing ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
