### PR TITLE
ci(wsg-check): ratchet fail-threshold from 0 to 50

### DIFF
--- a/.github/workflows/sustainability.yml
+++ b/.github/workflows/sustainability.yml
@@ -11,9 +11,9 @@ jobs:
   wsg-check:
     name: WSG sustainability check
     runs-on: ubuntu-latest
-    # Advisory only on day 1: --fail-threshold 0 means the job
-    # never fails on the score. Promote to a real threshold once
-    # we've seen a few baseline reports against the deploy preview.
+    # Ratchet 1: threshold raised to 50 (clamp minimum) after confirming
+    # 5 successful WSG runs on PRs #71–#75. Score data was not retrievable
+    # in this environment; tighten further once scores are observable.
     env:
       PREVIEW_URL: https://deploy-preview-${{ github.event.pull_request.number }}--ndwt-ol-chakra.netlify.app
     steps:
@@ -42,7 +42,7 @@ jobs:
             "$PREVIEW_URL" \
             --format json \
             --output wsg-report.json \
-            --fail-threshold 0
+            --fail-threshold 50
 
       - name: Run wsg-check (Markdown report)
         run: |
@@ -50,7 +50,7 @@ jobs:
             "$PREVIEW_URL" \
             --format markdown \
             --output wsg-report.md \
-            --fail-threshold 0
+            --fail-threshold 50
 
       - name: Print Markdown report to job summary
         if: always()


### PR DESCRIPTION
## Summary

Promotes the WSG sustainability check from advisory-only (`--fail-threshold 0`)
to an enforced minimum of **50**, the prescribed clamp minimum for a first ratchet
when fewer than 3 score reports are available.

## Baseline data

| Run confirmed on | WSG run ID (job) | Score |
|---|---|---|
| PR #75 (2026-05-14) | job `75931344524` / run `25842480606` | not retrieved |
| PR #74 (2026-05-14) | job `75928247110` / run `25841713529` | not retrieved |
| PR #73 (2026-05-13) | job `75846825482` / run `25816627505` | not retrieved |
| PR #72 (2026-05-13) | job `75713964406` / run `25777805165` | not retrieved |
| PR #71 (2026-05-13) | job `75692066085` / run `25770399066` | not retrieved |

**5 successful WSG runs confirmed** (via `pull_request_read.get_check_runs` for each PR).
Score data could **not** be retrieved: this cloud execution environment has no `gh` CLI, no
GitHub token for the REST API, and its IP is blocked from all `*.netlify.app` URLs
(`403 host_not_allowed`), so the `wsg-report.json` artifacts are inaccessible.

## Threshold computation

Fewer than 3 score reports were available, so the more-conservative formula applies
(subtract 10 instead of 5, then floor to the nearest multiple of 5):

```
new_threshold = floor((min_score - 10) / 5) * 5   [clamp to 50–90]
```

With 0 observed scores, `min_score` is undefined → the formula produces no value.
Per the spec the threshold is therefore set to **50** (the clamp's lower bound), the
most conservative legal value.

## Notes

- **This is the first ratchet.** Future ratchets should tighten the threshold once
  scores are actually observable (e.g. from a machine with Netlify access or once a
  `GITHUB_TOKEN` with `actions: read` is available in the environment).
- Setting `--fail-threshold 50` means the job will fail if the site scores below 50%
  on the Web Sustainability Guidelines — meaningfully stricter than 0, but very
  conservative.
- The Netlify Lighthouse plugin separately reports per-deploy performance scores
  (PR #75 preview: 71, PR #74: 71, PR #73: 64) — WSG scores are independent of
  Lighthouse and measure different criteria.

## Bot triage checklist
- [ ] Gemini Code Assist inline comments reviewed
- [ ] GitHub Copilot inline comments reviewed

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQLYf1nPs6jciE8Yx9mLQ6)_